### PR TITLE
Add queue audit entrypoints and workspace typecheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Agent Loop 用自己的 Issues 管理自己的开发任务：
 4. Daemon 自动认领、规划、执行、提交 PR
 5. Review PR → Merge → Issue 自动标记 `agent:done`
 
+当 daemon 以 continuous mode 跑着，但看起来“没有继续消费”时，先做只读 queue audit：
+
+```bash
+cd apps/agent-daemon
+bun run issues:audit -- --repo JamesWuHK/agent-loop
+```
+
+这条命令会复用 daemon 的同一套认证配置，所以也需要你已经配置好 `~/.agent-loop/config.json`，或者先提供 `GH_TOKEN` / `GITHUB_TOKEN`。它只读取当前 open managed issues，输出 `state`、`claimable`、`blockedBy`、`errors` 等信息，帮助你判断是依赖未满足、contract 不完整，还是 ready 池本身为空。它不会自动修改 issue label、assignee 或 comment。
+
 ```
 JamesWuHK/agent-loop
   Issues (agent:ready) ← daemon polling

--- a/apps/agent-daemon/package.json
+++ b/apps/agent-daemon/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun --watch run src/index.ts",
+    "issues:audit": "bun run src/audit-issue-contracts.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test"
   },

--- a/apps/agent-daemon/src/audit-issue-contracts.test.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+import { formatAuditLine, formatInvalidReadySection } from './audit-issue-contracts'
+
+describe('audit-issue-contracts', () => {
+  test('formats claimability, blockers, and contract errors on one line', () => {
+    expect(
+      formatAuditLine({
+        number: 51,
+        title: '[CI-A1] 固定登录相关 smoke tests',
+        state: 'ready',
+        isClaimable: false,
+        hasExecutableContract: false,
+        claimBlockedBy: [49, 50],
+        contractValidationErrors: ['missing ## RED 测试 / RED Tests'],
+      }),
+    ).toBe(
+      '#51 state=ready claimable=false contract=false blockedBy=49,50 errors=missing ## RED 测试 / RED Tests',
+    )
+  })
+
+  test('renders a dedicated section for invalid ready issues', () => {
+    const section = formatInvalidReadySection([
+      {
+        number: 52,
+        title: '[CI-A2] Sprint A 发布前最小检查清单',
+        state: 'ready',
+        isClaimable: false,
+        hasExecutableContract: false,
+        claimBlockedBy: [],
+        contractValidationErrors: [
+          'missing ### Dependencies JSON block',
+          'missing executable scope contract (AllowedFiles/ForbiddenFiles/MustPreserve/OutOfScope/RequiredSemantics)',
+        ],
+      },
+    ])
+
+    expect(section).toContain('invalid ready issues:')
+    expect(section).toContain('#52 [CI-A2] Sprint A 发布前最小检查清单')
+    expect(section).toContain('- missing ### Dependencies JSON block')
+  })
+})

--- a/apps/agent-daemon/src/audit-issue-contracts.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.ts
@@ -1,37 +1,71 @@
 import { listOpenAgentIssues } from '@agent/shared'
-import { loadConfig } from './config'
+import { loadConfig, type CliArgs } from './config'
+
+interface AuditedIssue {
+  number: number
+  title: string
+  state: string
+  isClaimable: boolean
+  hasExecutableContract: boolean
+  claimBlockedBy: number[]
+  contractValidationErrors: string[]
+}
+
+export function formatAuditLine(issue: AuditedIssue): string {
+  return `#${issue.number} state=${issue.state} claimable=${issue.isClaimable} `
+    + `contract=${issue.hasExecutableContract} blockedBy=${issue.claimBlockedBy.join(',') || '-'} `
+    + `errors=${issue.contractValidationErrors.join(' | ') || '-'}`
+}
+
+export function formatInvalidReadySection(issues: AuditedIssue[]): string {
+  if (issues.length === 0) {
+    return ''
+  }
+
+  return [
+    'invalid ready issues:',
+    ...issues.flatMap((issue) => [
+      `#${issue.number} ${issue.title}`,
+      ...issue.contractValidationErrors.map((error) => `- ${error}`),
+    ]),
+  ].join('\n')
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  let repo: string | undefined
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]
+    if (arg === '--repo') {
+      repo = argv[index + 1]
+      index++
+    }
+  }
+
+  return { repo }
+}
 
 async function main(): Promise<void> {
-  const config = loadConfig()
+  const config = loadConfig(parseArgs(process.argv.slice(2)))
   const issues = await listOpenAgentIssues(config)
   const managedIssues = issues.filter(issue => issue.labels.some(label => label.startsWith('agent:')))
 
   console.log(`managed issues: ${managedIssues.length}`)
 
   for (const issue of managedIssues) {
-    const blockers = issue.contractValidationErrors.length > 0
-      ? issue.contractValidationErrors.join(' | ')
-      : '-'
-    console.log(
-      `#${issue.number} state=${issue.state} claimable=${issue.isClaimable} `
-      + `contract=${issue.hasExecutableContract} blockedBy=${issue.claimBlockedBy.join(',') || '-'} `
-      + `errors=${blockers}`,
-    )
+    console.log(formatAuditLine(issue))
   }
 
   const invalidReady = managedIssues.filter(issue => issue.state === 'ready' && !issue.hasExecutableContract)
-  if (invalidReady.length > 0) {
-    console.log('\ninvalid ready issues:')
-    for (const issue of invalidReady) {
-      console.log(`#${issue.number} ${issue.title}`)
-      for (const error of issue.contractValidationErrors) {
-        console.log(`- ${error}`)
-      }
-    }
+  const invalidReadySection = formatInvalidReadySection(invalidReady)
+  if (invalidReadySection) {
+    console.log(`\n${invalidReadySection}`)
   }
 }
 
-main().catch((error) => {
-  console.error('[audit-issue-contracts] failed:', error)
-  process.exit(1)
-})
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error('[audit-issue-contracts] failed:', error)
+    process.exit(1)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "agent:issues:enforce-ready": "bun apps/agent-daemon/src/ready-gate.ts",
     "start": "bun run apps/agent-daemon/src/index.ts",
     "dev": "bun --watch run apps/agent-daemon/src/index.ts",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "bun run --cwd packages/agent-shared typecheck && bun run --cwd apps/agent-daemon typecheck",
     "test": "bun test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add a tested queue-audit formatter and CLI with --repo override support
- expose the audit entrypoint via apps/agent-daemon and document continuous-mode troubleshooting in the README
- fix the root typecheck script so it actually runs both workspace checks

## Validation
- bun test apps/agent-daemon/src/audit-issue-contracts.test.ts
- bun run typecheck
- GH_TOKEN="$(gh auth token)" bash -lc 'cd apps/agent-daemon && bun run issues:audit -- --repo JamesWuHK/digital-employee >/tmp/agent-loop-audit.out && rg "managed issues:|claimable=|errors=" /tmp/agent-loop-audit.out'
- bun test
