### PR TITLE
Requeue failed issues without local recovery state

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ agent:claimed  → working (daemon starts)
 agent:working  → done (PR created)
                 → failed (agent error)
                 → stale (daemon shutdown / 30min timeout)
+agent:failed   → working (resume existing local worktree)
+                → ready (auto requeue after cooldown when no local worktree / open PR remains)
 agent:stale    → ready (re-enqueue)
 ```
 

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from 'bun:test'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { buildPrMergeRetryComment, isMergeabilityFailure, rebaseManagedBranchOntoDefault, shouldResumeManagedIssue } from './daemon'
+import {
+  buildPrMergeRetryComment,
+  isMergeabilityFailure,
+  rebaseManagedBranchOntoDefault,
+  shouldRequeueFailedIssue,
+  shouldResumeManagedIssue,
+} from './daemon'
 
 describe('daemon merge recovery helpers', () => {
   test('resumes working issues with a local worktree after daemon restart', () => {
@@ -44,6 +50,70 @@ describe('daemon merge recovery helpers', () => {
       now + 60_000,
       now,
       2,
+    )).toBe(false)
+  })
+
+  test('requeues failed issues without local recovery state after cooldown', () => {
+    const now = Date.now()
+
+    expect(shouldRequeueFailedIssue(
+      {
+        state: 'failed',
+        updatedAt: new Date(now - 6 * 60_000).toISOString(),
+        hasExecutableContract: true,
+      },
+      false,
+      false,
+      now,
+      5 * 60_000,
+    )).toBe(true)
+
+    expect(shouldRequeueFailedIssue(
+      {
+        state: 'failed',
+        updatedAt: new Date(now - 60_000).toISOString(),
+        hasExecutableContract: true,
+      },
+      false,
+      false,
+      now,
+      5 * 60_000,
+    )).toBe(false)
+
+    expect(shouldRequeueFailedIssue(
+      {
+        state: 'failed',
+        updatedAt: new Date(now - 6 * 60_000).toISOString(),
+        hasExecutableContract: true,
+      },
+      true,
+      false,
+      now,
+      5 * 60_000,
+    )).toBe(false)
+
+    expect(shouldRequeueFailedIssue(
+      {
+        state: 'failed',
+        updatedAt: new Date(now - 6 * 60_000).toISOString(),
+        hasExecutableContract: true,
+      },
+      false,
+      true,
+      now,
+      5 * 60_000,
+    )).toBe(false)
+
+    expect(shouldRequeueFailedIssue(
+      {
+        state: 'failed',
+        updatedAt: new Date(now - 6 * 60_000).toISOString(),
+        hasExecutableContract: false,
+      },
+      false,
+      false,
+      now,
+      5 * 60_000,
     )).toBe(false)
   })
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -323,6 +323,13 @@ export class AgentDaemon {
       return
     }
 
+    if (await this.maybeRequeueFailedIssue()) {
+      recordPoll('success')
+      recordPollDuration(Date.now() - pollStartTime)
+      this.scheduleNextPoll()
+      return
+    }
+
     // Claim an issue
     const claimedIssue = await pollAndClaim(this.config, this.logger)
 
@@ -415,6 +422,61 @@ export class AgentDaemon {
 
     this._inFlightProcess = processPromise
     return true
+  }
+
+  private async maybeRequeueFailedIssue(): Promise<boolean> {
+    const issue = await this.findFailedIssueToRequeue()
+    if (!issue) return false
+
+    await transitionIssueState(
+      issue.number,
+      ISSUE_LABELS.READY,
+      ISSUE_LABELS.FAILED,
+      {
+        event: 'failed-requeue',
+        machine: this.config.machineId,
+        ts: new Date().toISOString(),
+        reason: 'auto-requeue-no-recovery-state',
+      },
+      this.config,
+    )
+
+    this.logger.log(`[daemon] re-queued failed issue #${issue.number} into ${ISSUE_LABELS.READY} because no local worktree or open PR remained`)
+    return true
+  }
+
+  private async findFailedIssueToRequeue(): Promise<AgentIssue | null> {
+    const [issues, prs] = await Promise.all([
+      listOpenAgentIssues(this.config),
+      listOpenAgentPullRequests(this.config),
+    ])
+    const now = Date.now()
+    const openPrIssueNumbers = new Set(
+      prs
+        .map((pr) => extractIssueNumberFromPrTitle(pr.title))
+        .filter((issueNumber): issueNumber is number => issueNumber !== null),
+    )
+
+    for (const issue of issues) {
+      const eligible = shouldRequeueFailedIssue(
+        issue,
+        hasWorktreeForIssue(issue.number, this.config),
+        openPrIssueNumbers.has(issue.number),
+        now,
+        AgentDaemon.FAILED_ISSUE_RESUME_COOLDOWN_MS,
+      )
+      if (!eligible) continue
+
+      const activeClaimMachine = await this.getActiveClaimMachine(issue.number)
+      if (activeClaimMachine && activeClaimMachine !== this.config.machineId) {
+        this.logger.log(`[daemon] skipping failed requeue for #${issue.number}; active machine is ${activeClaimMachine}`)
+        continue
+      }
+
+      return issue
+    }
+
+    return null
   }
 
   private async findResumableIssue(): Promise<AgentIssue | null> {
@@ -1136,6 +1198,24 @@ export function shouldResumeManagedIssue(
   if (cooldownUntil > now) return false
 
   return true
+}
+
+export function shouldRequeueFailedIssue(
+  issue: Pick<AgentIssue, 'state' | 'updatedAt' | 'hasExecutableContract'>,
+  hasLocalWorktree: boolean,
+  hasOpenPr: boolean,
+  now: number,
+  cooldownMs: number,
+): boolean {
+  if (issue.state !== 'failed') return false
+  if (hasLocalWorktree) return false
+  if (hasOpenPr) return false
+  if (!issue.hasExecutableContract) return false
+
+  const updatedAtMs = Date.parse(issue.updatedAt)
+  if (!Number.isFinite(updatedAtMs)) return true
+
+  return updatedAtMs + cooldownMs <= now
 }
 
 function shouldMergeManagedPr(pr: ManagedPullRequest): boolean {

--- a/packages/agent-shared/src/state-machine.test.ts
+++ b/packages/agent-shared/src/state-machine.test.ts
@@ -59,6 +59,10 @@ describe('canTransition', () => {
   it('allows failed issues to resume into working', () => {
     expect(canTransition('failed', 'working')).toBe(true)
   })
+
+  it('allows failed issues to requeue into ready for a fresh attempt', () => {
+    expect(canTransition('failed', 'ready')).toBe(true)
+  })
 })
 
 describe('parseClaimEventComment', () => {
@@ -133,6 +137,38 @@ describe('resolveActiveClaimMachine', () => {
           machine: 'codex-a',
           ts: '2026-04-04T08:30:00.000Z',
           reason: 'startup-reconcile-requeue',
+        }),
+        createdAt: '2026-04-04T08:30:01Z',
+      },
+      {
+        body: buildEventComment({
+          event: 'claimed',
+          machine: 'codex-b',
+          ts: '2026-04-04T08:31:00.000Z',
+        }),
+        createdAt: '2026-04-04T08:31:02Z',
+      },
+    ]
+
+    expect(resolveActiveClaimMachine(comments)).toBe('codex-b')
+  })
+
+  it('hands ownership to a later claimant after failed-requeue resets the epoch', () => {
+    const comments = [
+      {
+        body: buildEventComment({
+          event: 'claimed',
+          machine: 'codex-a',
+          ts: '2026-04-04T08:00:03.369Z',
+        }),
+        createdAt: '2026-04-04T08:00:04Z',
+      },
+      {
+        body: buildEventComment({
+          event: 'failed-requeue',
+          machine: 'codex-a',
+          ts: '2026-04-04T08:30:00.000Z',
+          reason: 'auto-requeue-no-recovery-state',
         }),
         createdAt: '2026-04-04T08:30:01Z',
       },

--- a/packages/agent-shared/src/state-machine.ts
+++ b/packages/agent-shared/src/state-machine.ts
@@ -7,7 +7,7 @@ const VALID_TRANSITIONS: Record<IssueState, IssueState[]> = {
   claimed: ['working', 'stale'],
   working: ['done', 'failed', 'stale'],
   done: [],       // terminal
-  failed: ['working'], // resumable when the daemon preserves local state
+  failed: ['working', 'ready'], // resumable locally or requeueable for a fresh attempt
   stale: ['ready'],
   unknown: [],
 }
@@ -45,7 +45,7 @@ export function buildEventComment(event: ClaimEvent): string {
 }
 
 const CLAIM_EVENT_PATTERN = /<!--\s*({[\s\S]*})\s*-->/
-const CLAIM_RESET_EVENTS = new Set<ClaimEvent['event']>(['done', 'failed', 'stale', 'stale-requeue'])
+const CLAIM_RESET_EVENTS = new Set<ClaimEvent['event']>(['done', 'failed', 'stale', 'stale-requeue', 'failed-requeue'])
 
 export function parseClaimEventComment(body: string): ClaimEvent | null {
   const match = body.match(CLAIM_EVENT_PATTERN)
@@ -60,6 +60,7 @@ export function parseClaimEventComment(body: string): ClaimEvent | null {
       && parsed.event !== 'failed'
       && parsed.event !== 'stale'
       && parsed.event !== 'stale-requeue'
+      && parsed.event !== 'failed-requeue'
     ) {
       return null
     }

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -111,7 +111,7 @@ export interface ProjectProfileConfig {
 // ─── Claim Event (JSON in issue comment) ────────────────────────────────────
 
 export interface ClaimEvent {
-  event: 'claimed' | 'done' | 'failed' | 'stale' | 'stale-requeue'
+  event: 'claimed' | 'done' | 'failed' | 'stale' | 'stale-requeue' | 'failed-requeue'
   machine: string
   ts: string
   worktreeId?: string


### PR DESCRIPTION
## Summary
- let the daemon auto-requeue failed issues back into `agent:ready` when no local worktree or open PR remains
- add a dedicated `failed-requeue` issue event and teach the state machine that `failed -> ready` is a valid reset path
- document the new failed-issue recovery path in the README state machine

## Validation
- bun run typecheck
- bun test
- node - <<'NODE'
const now = Date.now();
const updatedAt = Date.parse('2026-04-03T16:19:33Z');
console.log(JSON.stringify({ eligible: updatedAt + 5 * 60_000 <= now }));
NODE
