### PR TITLE
fix(daemon): harden gh auth and command handling

### DIFF
--- a/apps/agent-daemon/src/cli-agent.ts
+++ b/apps/agent-daemon/src/cli-agent.ts
@@ -587,8 +587,13 @@ function buildCleanEnv(config: AgentConfig): Record<string, string> {
   cleanEnv.GIT_COMMITTER_NAME = config.git.authorName
   cleanEnv.GIT_AUTHOR_EMAIL = config.git.authorEmail
   cleanEnv.GIT_COMMITTER_EMAIL = config.git.authorEmail
-  cleanEnv.GH_TOKEN = config.pat
-  cleanEnv.GITHUB_TOKEN = config.pat
+  if (config.pat) {
+    cleanEnv.GH_TOKEN = config.pat
+    cleanEnv.GITHUB_TOKEN = config.pat
+  } else {
+    delete cleanEnv.GH_TOKEN
+    delete cleanEnv.GITHUB_TOKEN
+  }
 
   if (!cleanEnv.OPENAI_API_KEY && cleanEnv.SUB2API_KEY) {
     cleanEnv.OPENAI_API_KEY = cleanEnv.SUB2API_KEY

--- a/apps/agent-daemon/src/config.test.ts
+++ b/apps/agent-daemon/src/config.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
 import { describe, expect, test } from 'bun:test'
 import type { AgentConfig } from '@agent/shared'
 import { buildConfig, ConfigError, resolveLocalDaemonIdentity } from './config'
@@ -297,6 +300,35 @@ describe('buildConfig', () => {
     )
 
     expect(config.pat).toBe('gho-from-gh-cli')
+  })
+
+  test('accepts a logged-in gh CLI session when no PAT is configured elsewhere', () => {
+    const homeDir = mkdtempSync(resolve(tmpdir(), 'agent-loop-gh-session-'))
+    const ghConfigDir = resolve(homeDir, '.config', 'gh')
+    mkdirSync(ghConfigDir, { recursive: true })
+    writeFileSync(resolve(ghConfigDir, 'hosts.yml'), [
+      'github.com:',
+      '    users:',
+      '        JamesWuHK:',
+      '    user: JamesWuHK',
+      '',
+    ].join('\n'))
+
+    const config = buildConfig(
+      {},
+      {
+        fileConfig: {
+          ...baseFileConfig,
+          pat: undefined,
+        },
+        repoConfig: {},
+        env: {},
+        homeDir,
+        ghAuthToken: null,
+      },
+    )
+
+    expect(config.pat).toBe('')
   })
 
   test('raises a config error when no PAT or gh auth token is available', () => {

--- a/apps/agent-daemon/src/config.ts
+++ b/apps/agent-daemon/src/config.ts
@@ -147,8 +147,9 @@ export function buildConfig(
     filePat: fileConfig.pat,
     ghAuthToken: options.ghAuthToken,
   })
+  const hasGhCliSession = pat.length === 0 && canUseGhCliSession(homeDir)
 
-  if (!pat) {
+  if (!pat && !hasGhCliSession) {
     throw new ConfigError(
       'No GitHub PAT found. Set GITHUB_TOKEN/GH_TOKEN, configure pat in ~/.agent-loop/config.json, or log in with gh auth login',
     )
@@ -293,16 +294,12 @@ function resolveGitHubToken(input: {
   filePat?: string
   ghAuthToken?: string | null
 }): string {
-  const explicitGhAuthToken = input.ghAuthToken === undefined
-    ? readGhAuthToken()
-    : input.ghAuthToken
-
   const candidates = [
     input.cliPat,
     input.env.GITHUB_TOKEN,
     input.env.GH_TOKEN,
     input.filePat,
-    explicitGhAuthToken,
+    input.ghAuthToken,
   ]
 
   for (const candidate of candidates) {
@@ -313,15 +310,17 @@ function resolveGitHubToken(input: {
   return ''
 }
 
-function readGhAuthToken(): string | null {
+function canUseGhCliSession(homeDir = homedir()): boolean {
+  const hostsPath = resolve(homeDir, '.config', 'gh', 'hosts.yml')
+  if (!existsSync(hostsPath)) {
+    return false
+  }
+
   try {
-    const token = execFileSync('gh', ['auth', 'token'], {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
-    return normalizeNonEmptyString(token)
+    const hostsFile = readFileSync(hostsPath, 'utf-8')
+    return hostsFile.includes('github.com:')
   } catch {
-    return null
+    return false
   }
 }
 

--- a/apps/agent-daemon/src/presence.ts
+++ b/apps/agent-daemon/src/presence.ts
@@ -2,9 +2,9 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
-  buildGhEnv,
   commentOnIssue,
   listIssueComments,
+  runBoundedGhCommand,
   type AgentConfig,
   type IssueComment,
 } from '@agent/shared'
@@ -87,18 +87,7 @@ async function runGhCommand(
   args: string[],
   config: AgentConfig,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const proc = Bun.spawn(['gh', ...args], {
-    env: buildGhEnv(config),
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
-
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ])
-  const exitCode = await proc.exited
-
+  const { stdout, stderr, exitCode } = await runBoundedGhCommand(args, config)
   return { stdout, stderr, exitCode }
 }
 

--- a/apps/agent-daemon/src/subtask-executor.ts
+++ b/apps/agent-daemon/src/subtask-executor.ts
@@ -690,18 +690,26 @@ async function runValidationCommand(
   command: string,
   config: AgentConfig,
 ): Promise<IssueBranchValidationCommandResult> {
+  const env: Record<string, string> = {
+    ...process.env,
+    PWD: worktreePath,
+    GIT_AUTHOR_NAME: config.git.authorName,
+    GIT_COMMITTER_NAME: config.git.authorName,
+    GIT_AUTHOR_EMAIL: config.git.authorEmail,
+    GIT_COMMITTER_EMAIL: config.git.authorEmail,
+  }
+
+  if (config.pat) {
+    env.GH_TOKEN = config.pat
+    env.GITHUB_TOKEN = config.pat
+  } else {
+    delete env.GH_TOKEN
+    delete env.GITHUB_TOKEN
+  }
+
   const proc = Bun.spawn(['/bin/sh', '-c', command], {
     cwd: worktreePath,
-    env: {
-      ...process.env,
-      PWD: worktreePath,
-      GIT_AUTHOR_NAME: config.git.authorName,
-      GIT_COMMITTER_NAME: config.git.authorName,
-      GIT_AUTHOR_EMAIL: config.git.authorEmail,
-      GIT_COMMITTER_EMAIL: config.git.authorEmail,
-      GH_TOKEN: config.pat,
-      GITHUB_TOKEN: config.pat,
-    },
+    env,
     stdout: 'pipe',
     stderr: 'pipe',
   })

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -19,6 +19,7 @@ import {
   parseManagedLeaseComments,
   parseGhApiErrorMessage,
   parseMergePrResponse,
+  qualifyGhApiArgs,
   shouldClearIssueAssigneesForStateLabel,
 } from './github-api'
 import { ISSUE_LABELS } from './types'
@@ -36,6 +37,42 @@ describe('buildGhEnv', () => {
     expect(env.NO_PROXY).toBe('127.0.0.1,localhost')
     expect(env.GH_TOKEN).toBe('ghp_test')
     expect(env.GITHUB_TOKEN).toBe('ghp_test')
+  })
+
+  test('leaves GitHub auth env unset when no PAT is configured', () => {
+    process.env.GH_TOKEN = 'stale-token'
+    process.env.GITHUB_TOKEN = 'stale-token'
+
+    const env = buildGhEnv({ pat: '' })
+
+    expect(env.GH_TOKEN).toBeUndefined()
+    expect(env.GITHUB_TOKEN).toBeUndefined()
+  })
+})
+
+describe('qualifyGhApiArgs', () => {
+  test('prefixes repo-relative REST endpoints with repos/<owner>/<repo>/', () => {
+    expect(qualifyGhApiArgs(
+      ['issues/334/comments'],
+      { repo: 'JamesWuHK/digital-employee' },
+    )).toEqual(['repos/JamesWuHK/digital-employee/issues/334/comments'])
+
+    expect(qualifyGhApiArgs(
+      ['pulls?state=open&page=1'],
+      { repo: 'JamesWuHK/digital-employee' },
+    )).toEqual(['repos/JamesWuHK/digital-employee/pulls?state=open&page=1'])
+  })
+
+  test('leaves graphql and fully-qualified endpoints unchanged', () => {
+    expect(qualifyGhApiArgs(
+      ['graphql', '--raw-field', 'query=query { viewer { login } }'],
+      { repo: 'JamesWuHK/digital-employee' },
+    )).toEqual(['graphql', '--raw-field', 'query=query { viewer { login } }'])
+
+    expect(qualifyGhApiArgs(
+      ['repos/JamesWuHK/digital-employee/issues/334/comments'],
+      { repo: 'JamesWuHK/digital-employee' },
+    )).toEqual(['repos/JamesWuHK/digital-employee/issues/334/comments'])
   })
 })
 

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -51,10 +51,91 @@ export function buildGhEnv(config: Pick<AgentConfig, 'pat'>): Record<string, str
     delete env[key]
   }
 
-  env.GH_TOKEN = config.pat
-  env.GITHUB_TOKEN = config.pat
+  if (config.pat) {
+    env.GH_TOKEN = config.pat
+    env.GITHUB_TOKEN = config.pat
+  } else {
+    delete env.GH_TOKEN
+    delete env.GITHUB_TOKEN
+  }
 
   return env
+}
+
+const DEFAULT_GH_COMMAND_TIMEOUT_MS = 30_000
+
+export interface GhCommandResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+  timedOut: boolean
+}
+
+export async function runBoundedGhCommand(
+  args: string[],
+  config: Pick<AgentConfig, 'pat'>,
+  options: {
+    timeoutMs?: number
+  } = {},
+): Promise<GhCommandResult> {
+  const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_GH_COMMAND_TIMEOUT_MS)
+  const proc = Bun.spawn(['gh', ...args], {
+    detached: true,
+    env: buildGhEnv(config),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const stdoutPromise = proc.stdout
+    ? new Response(proc.stdout).text().catch(() => '')
+    : Promise.resolve('')
+  const stderrPromise = proc.stderr
+    ? new Response(proc.stderr).text().catch(() => '')
+    : Promise.resolve('')
+
+  const exitOutcome = await Promise.race([
+    proc.exited.then((exitCode) => ({
+      kind: 'exited' as const,
+      exitCode,
+    })),
+    Bun.sleep(timeoutMs).then(() => ({
+      kind: 'timed-out' as const,
+    })),
+  ])
+
+  let timedOut = false
+  let exitCode: number
+  if (exitOutcome.kind === 'exited') {
+    exitCode = exitOutcome.exitCode
+  } else {
+    timedOut = true
+    await terminateProcessTree(proc.pid).catch(() => {
+      // best-effort cleanup only
+    })
+    void proc.stdout?.cancel().catch(() => {
+      // stream may already be closed
+    })
+    void proc.stderr?.cancel().catch(() => {
+      // stream may already be closed
+    })
+    exitCode = await settleWithin(proc.exited, 124, 250)
+    if (exitCode === 0) {
+      exitCode = 124
+    }
+  }
+
+  const [stdout, stderr] = timedOut
+    ? await Promise.all([
+        settleWithin(stdoutPromise, '', 250),
+        settleWithin(stderrPromise, '', 250),
+      ])
+    : await Promise.all([stdoutPromise, stderrPromise])
+
+  return {
+    stdout,
+    stderr: timedOut ? appendGhTimeoutMessage(stderr, args, timeoutMs) : stderr,
+    exitCode,
+    timedOut,
+  }
 }
 
 async function ghRaw(
@@ -81,19 +162,80 @@ async function ghApiRaw(
   args: string[],
   config: AgentConfig,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const proc = Bun.spawn(['gh', 'api', ...args], {
-    env: buildGhEnv(config),
+  return runBoundedGhCommand(['api', ...qualifyGhApiArgs(args, config)], config)
+}
+
+export function qualifyGhApiArgs(
+  args: string[],
+  config: Pick<AgentConfig, 'repo'>,
+): string[] {
+  if (args.length === 0) return args
+
+  const [endpoint, ...rest] = args
+  if (!shouldQualifyGhApiEndpoint(endpoint)) {
+    return args
+  }
+
+  const normalizedEndpoint = endpoint.replace(/^\/+/, '')
+  return [`repos/${config.repo}/${normalizedEndpoint}`, ...rest]
+}
+
+function shouldQualifyGhApiEndpoint(endpoint: string): boolean {
+  const normalized = endpoint.trim()
+  if (normalized.length === 0) return false
+  if (normalized === 'graphql') return false
+  if (normalized.startsWith('repos/')) return false
+  if (normalized.startsWith('/repos/')) return false
+  if (normalized.startsWith('https://')) return false
+  if (normalized.startsWith('http://')) return false
+  return true
+}
+
+function appendGhTimeoutMessage(stderr: string, args: string[], timeoutMs: number): string {
+  const base = stderr.trimEnd()
+  const message = `gh ${args.join(' ')} timed out after ${timeoutMs}ms`
+  return base.length > 0 ? `${base}\n${message}` : message
+}
+
+async function terminateProcessTree(rootPid: number): Promise<void> {
+  if (!Number.isInteger(rootPid) || rootPid <= 0) {
+    return
+  }
+
+  try {
+    process.kill(-rootPid, 'SIGKILL')
+    return
+  } catch {
+    // fall back to best-effort child + parent cleanup
+  }
+
+  await killDirectChildProcesses(rootPid)
+
+  try {
+    process.kill(rootPid, 'SIGKILL')
+  } catch {
+    // process may already be gone
+  }
+}
+
+async function killDirectChildProcesses(parentPid: number): Promise<void> {
+  const proc = Bun.spawn(['pkill', '-KILL', '-P', String(parentPid)], {
     stdout: 'pipe',
     stderr: 'pipe',
   })
 
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ])
-  const exitCode = await proc.exited
+  await settleWithin(proc.exited, 0, 250)
+}
 
-  return { stdout, stderr, exitCode }
+async function settleWithin<T>(
+  promise: Promise<T>,
+  fallback: T,
+  timeoutMs: number,
+): Promise<T> {
+  return Promise.race([
+    promise,
+    Bun.sleep(timeoutMs).then(() => fallback),
+  ])
 }
 
 export class GhError extends Error {


### PR DESCRIPTION
## Summary
- allow daemon startup when gh has a local session but token export hangs
- qualify repo-relative gh api REST endpoints and bound gh subprocess lifetime
- reuse bounded gh execution for presence updates so stalled gh children do not block polls

## Validation
- bun test packages/agent-shared/src/github-api.test.ts apps/agent-daemon/src/presence.test.ts
- bun test apps/agent-daemon/src/config.test.ts
- bun test apps/agent-daemon/src/cli-agent.test.ts