### PR TITLE
fix: bypass gh api timeouts with PAT-backed direct GitHub API calls

### DIFF
--- a/apps/agent-daemon/src/presence.ts
+++ b/apps/agent-daemon/src/presence.ts
@@ -2,8 +2,6 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
-  commentOnIssue,
-  listIssueComments,
   runBoundedGhCommand,
   type AgentConfig,
   type IssueComment,
@@ -58,6 +56,13 @@ interface RawIssueRecord {
   number?: unknown
 }
 
+interface RawIssueCommentRecord {
+  id?: unknown
+  body?: unknown
+  created_at?: unknown
+  updated_at?: unknown
+}
+
 function buildManagedDaemonPresenceRegistryBody(repo: string): string {
   return `${MANAGED_DAEMON_PRESENCE_ISSUE_MARKER}
 ## Agent Loop Presence Registry
@@ -89,6 +94,92 @@ async function runGhCommand(
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const { stdout, stderr, exitCode } = await runBoundedGhCommand(args, config)
   return { stdout, stderr, exitCode }
+}
+
+async function runGitHubRestRequest(
+  path: string,
+  config: AgentConfig,
+  options: {
+    method?: 'GET' | 'POST' | 'PATCH'
+    body?: Record<string, unknown>
+  } = {},
+): Promise<string> {
+  const normalizedPath = path.replace(/^\/+/, '')
+  const method = options.method ?? 'GET'
+
+  if (!config.pat) {
+    const args = ['api', normalizedPath]
+    if (method !== 'GET') {
+      args.push('-X', method)
+    }
+    if (options.body) {
+      return withTempJsonFile(
+        'agent-loop-presence-rest-fallback',
+        options.body,
+        async (payloadPath) => {
+          const response = await runGhCommand([...args, '--input', payloadPath], config)
+          if (response.exitCode !== 0) {
+            throw new Error(`gh api ${normalizedPath} failed (exit ${response.exitCode}): ${response.stderr}`)
+          }
+          return response.stdout
+        },
+      )
+    }
+
+    const response = await runGhCommand(args, config)
+    if (response.exitCode !== 0) {
+      throw new Error(`gh api ${normalizedPath} failed (exit ${response.exitCode}): ${response.stderr}`)
+    }
+    return response.stdout
+  }
+
+  const response = await fetch(`https://api.github.com/${normalizedPath}`, {
+    method,
+    headers: {
+      Authorization: `token ${config.pat}`,
+      Accept: 'application/vnd.github+json',
+      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`GitHub REST ${method} ${normalizedPath} failed (HTTP ${response.status}): ${parseGitHubRestErrorMessage(text)}`)
+  }
+  return text
+}
+
+function parseGitHubRestErrorMessage(body: string): string {
+  const trimmed = body.trim()
+  if (!trimmed) {
+    return 'empty response body'
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as { message?: unknown }
+    if (typeof parsed.message === 'string' && parsed.message.trim().length > 0) {
+      return parsed.message
+    }
+  } catch {
+    // fall back to raw response text
+  }
+
+  return trimmed
+}
+
+function mapIssueCommentRecord(
+  comment: RawIssueCommentRecord,
+  fallback: {
+    commentId?: number
+    body?: string
+  } = {},
+): IssueComment {
+  return {
+    commentId: typeof comment.id === 'number' ? comment.id : (fallback.commentId ?? 0),
+    body: typeof comment.body === 'string' ? comment.body : (fallback.body ?? ''),
+    createdAt: typeof comment.created_at === 'string' ? comment.created_at : '',
+    updatedAt: typeof comment.updated_at === 'string' ? comment.updated_at : '',
+  }
 }
 
 function isPresenceRegistryIssue(issue: RawIssueListItem): boolean {
@@ -227,16 +318,11 @@ export async function findManagedDaemonPresenceIssue(
   config: AgentConfig,
 ): Promise<number | null> {
   for (let page = 1; ; page += 1) {
-    const response = await runGhCommand([
-      'api',
+    const stdout = await runGitHubRestRequest(
       `repos/${config.repo}/issues?state=open&per_page=100&page=${page}`,
-    ], config)
-
-    if (response.exitCode !== 0) {
-      throw new Error(`gh api repos/${config.repo}/issues failed (exit ${response.exitCode}): ${response.stderr}`)
-    }
-
-    const issues = JSON.parse(response.stdout) as RawIssueListItem[]
+      config,
+    )
+    const issues = JSON.parse(stdout) as RawIssueListItem[]
     const match = extractManagedDaemonPresenceIssueNumber(issues)
     if (match !== null) return match
 
@@ -249,27 +335,18 @@ export async function findManagedDaemonPresenceIssue(
 async function createManagedDaemonPresenceIssue(
   config: AgentConfig,
 ): Promise<number> {
-  const response = await withTempJsonFile(
-    'agent-loop-presence-issue',
+  const stdout = await runGitHubRestRequest(
+    `repos/${config.repo}/issues`,
+    config,
     {
+      method: 'POST',
+      body: {
       title: MANAGED_DAEMON_PRESENCE_ISSUE_TITLE,
       body: buildManagedDaemonPresenceRegistryBody(config.repo),
     },
-    async (path) => runGhCommand([
-      'api',
-      `repos/${config.repo}/issues`,
-      '-X',
-      'POST',
-      '--input',
-      path,
-    ], config),
+    },
   )
-
-  if (response.exitCode !== 0) {
-    throw new Error(`gh api repos/${config.repo}/issues failed (exit ${response.exitCode}): ${response.stderr}`)
-  }
-
-  const issue = JSON.parse(response.stdout) as RawIssueRecord
+  const issue = JSON.parse(stdout) as RawIssueRecord
   if (typeof issue.number !== 'number') {
     throw new Error('Presence issue create response did not include an issue number')
   }
@@ -290,36 +367,65 @@ export async function updateIssueComment(
   body: string,
   config: AgentConfig,
 ): Promise<IssueComment> {
-  const response = await withTempJsonFile(
-    'agent-loop-issue-comment-update',
-    { body },
-    async (path) => runGhCommand([
-      'api',
-      `repos/${config.repo}/issues/comments/${commentId}`,
-      '-X',
-      'PATCH',
-      '--input',
-      path,
-    ], config),
+  const stdout = await runGitHubRestRequest(
+    `repos/${config.repo}/issues/comments/${commentId}`,
+    config,
+    {
+      method: 'PATCH',
+      body: { body },
+    },
   )
 
-  if (response.exitCode !== 0) {
-    throw new Error(`gh api issues/comments/${commentId} failed (exit ${response.exitCode}): ${response.stderr}`)
+  const comment = JSON.parse(stdout) as RawIssueCommentRecord
+  return mapIssueCommentRecord(comment, { commentId, body })
+}
+
+export async function listIssueComments(
+  issueNumber: number,
+  config: AgentConfig,
+): Promise<IssueComment[]> {
+  if (!config.pat) {
+    const response = await runGhCommand([
+      'api',
+      `repos/${config.repo}/issues/${issueNumber}/comments`,
+      '--paginate',
+    ], config)
+    if (response.exitCode !== 0) {
+      throw new Error(`gh api repos/${config.repo}/issues/${issueNumber}/comments failed (exit ${response.exitCode}): ${response.stderr}`)
+    }
+    const comments = JSON.parse(response.stdout) as RawIssueCommentRecord[]
+    return comments.map((comment) => mapIssueCommentRecord(comment))
   }
 
-  const comment = JSON.parse(response.stdout) as {
-    id?: unknown
-    body?: unknown
-    created_at?: unknown
-    updated_at?: unknown
+  const comments: IssueComment[] = []
+  for (let page = 1; ; page += 1) {
+    const stdout = await runGitHubRestRequest(
+      `repos/${config.repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+      config,
+    )
+    const batch = JSON.parse(stdout) as RawIssueCommentRecord[]
+    comments.push(...batch.map((comment) => mapIssueCommentRecord(comment)))
+    if (batch.length < 100) {
+      return comments
+    }
   }
+}
 
-  return {
-    commentId: typeof comment.id === 'number' ? comment.id : commentId,
-    body: typeof comment.body === 'string' ? comment.body : body,
-    createdAt: typeof comment.created_at === 'string' ? comment.created_at : '',
-    updatedAt: typeof comment.updated_at === 'string' ? comment.updated_at : '',
-  }
+export async function commentOnIssue(
+  issueNumber: number,
+  body: string,
+  config: AgentConfig,
+): Promise<IssueComment> {
+  const stdout = await runGitHubRestRequest(
+    `repos/${config.repo}/issues/${issueNumber}/comments`,
+    config,
+    {
+      method: 'POST',
+      body: { body },
+    },
+  )
+  const comment = JSON.parse(stdout) as RawIssueCommentRecord
+  return mapIssueCommentRecord(comment, { body })
 }
 
 const defaultPresenceApi: PresenceApiAdapter = {

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from 'bun:test'
 import {
   applyDependencyClaimability,
   buildListOpenIssuesQuery,
+  buildDirectGitHubApiRequest,
   buildManagedLeaseComment,
   buildGhEnv,
   canDaemonAdoptManagedLease,
   derivePullRequestStateFromRaw,
   deriveIssueStateFromRaw,
+  extractNextPageUrl,
   extractRestOpenIssueListPage,
   extractRestPullRequestListPage,
   extractOpenIssueConnectionPage,
@@ -16,6 +18,7 @@ import {
   isGraphQlRateLimitErrorMessage,
   isManagedLeaseExpired,
   isManagedLeaseProgressStale,
+  mergePaginatedRestBodies,
   parseManagedLeaseComments,
   parseGhApiErrorMessage,
   parseMergePrResponse,
@@ -73,6 +76,59 @@ describe('qualifyGhApiArgs', () => {
       ['repos/JamesWuHK/digital-employee/issues/334/comments'],
       { repo: 'JamesWuHK/digital-employee' },
     )).toEqual(['repos/JamesWuHK/digital-employee/issues/334/comments'])
+  })
+})
+
+describe('buildDirectGitHubApiRequest', () => {
+  test('converts graphql raw fields into a direct GraphQL payload', () => {
+    const request = buildDirectGitHubApiRequest(
+      [
+        'graphql',
+        '--raw-field',
+        'query=query($cursor: String) { viewer { login } }',
+        '--raw-field',
+        'cursor=cursor-2',
+      ],
+      { repo: 'JamesWuHK/digital-employee' },
+    )
+
+    expect(request).toMatchObject({
+      kind: 'graphql',
+      method: 'POST',
+      url: 'https://api.github.com/graphql',
+      paginate: false,
+    })
+    expect(JSON.parse(request.body ?? '{}')).toEqual({
+      query: 'query($cursor: String) { viewer { login } }',
+      variables: {
+        cursor: 'cursor-2',
+      },
+    })
+  })
+
+  test('converts repeated REST form fields into a JSON array payload', () => {
+    const request = buildDirectGitHubApiRequest(
+      [
+        'repos/JamesWuHK/digital-employee/issues/334/labels',
+        '-X',
+        'POST',
+        '-f',
+        'labels[]=agent:ready',
+        '-f',
+        'labels[]=agent:claimed',
+      ],
+      { repo: 'JamesWuHK/digital-employee' },
+    )
+
+    expect(request).toMatchObject({
+      kind: 'rest',
+      method: 'POST',
+      url: 'https://api.github.com/repos/JamesWuHK/digital-employee/issues/334/labels',
+      paginate: false,
+    })
+    expect(JSON.parse(request.body ?? '{}')).toEqual({
+      labels: ['agent:ready', 'agent:claimed'],
+    })
   })
 })
 
@@ -237,6 +293,20 @@ describe('REST pagination helpers', () => {
     ])
 
     expect(extractRestPullRequestListPage(null)).toEqual([])
+  })
+
+  test('extracts the next REST pagination link', () => {
+    expect(extractNextPageUrl(
+      '<https://api.github.com/resource?page=2>; rel="next", <https://api.github.com/resource?page=4>; rel="last"',
+    )).toBe('https://api.github.com/resource?page=2')
+    expect(extractNextPageUrl(null)).toBeNull()
+  })
+
+  test('merges paginated REST array bodies into one JSON array', () => {
+    expect(mergePaginatedRestBodies([
+      '[{"id":1}]',
+      '[{"id":2},{"id":3}]',
+    ])).toBe('[{"id":1},{"id":2},{"id":3}]')
   })
 })
 

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, rmSync } from 'node:fs'
+import { writeFileSync, rmSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import type {
@@ -162,7 +162,343 @@ async function ghApiRaw(
   args: string[],
   config: AgentConfig,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  return runBoundedGhCommand(['api', ...qualifyGhApiArgs(args, config)], config)
+  const qualifiedArgs = qualifyGhApiArgs(args, config)
+  if (config.pat) {
+    return runDirectGitHubApi(qualifiedArgs, config)
+  }
+  return runBoundedGhCommand(['api', ...qualifiedArgs], config)
+}
+
+interface DirectGitHubApiRequest {
+  kind: 'graphql' | 'rest'
+  url: string
+  method: 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT'
+  body?: string
+  paginate: boolean
+}
+
+function normalizeDirectGitHubMethod(
+  method: string | undefined,
+): DirectGitHubApiRequest['method'] {
+  switch ((method ?? '').toUpperCase()) {
+    case 'DELETE':
+      return 'DELETE'
+    case 'PATCH':
+      return 'PATCH'
+    case 'POST':
+      return 'POST'
+    case 'PUT':
+      return 'PUT'
+    default:
+      return 'GET'
+  }
+}
+
+function parseDirectGitHubApiFields(
+  fields: string[],
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {}
+
+  for (const field of fields) {
+    const separatorIndex = field.indexOf('=')
+    const rawKey = separatorIndex >= 0 ? field.slice(0, separatorIndex) : field
+    const value = separatorIndex >= 0 ? field.slice(separatorIndex + 1) : ''
+
+    if (rawKey.endsWith('[]')) {
+      const key = rawKey.slice(0, -2)
+      const existing = payload[key]
+      if (Array.isArray(existing)) {
+        existing.push(value)
+      } else if (existing === undefined) {
+        payload[key] = [value]
+      } else {
+        payload[key] = [existing, value]
+      }
+      continue
+    }
+
+    payload[rawKey] = value
+  }
+
+  return payload
+}
+
+function appendDirectGitHubQueryParams(
+  url: string,
+  params: Record<string, unknown>,
+): string {
+  const search = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        search.append(`${key}[]`, String(item))
+      }
+      continue
+    }
+
+    search.append(key, String(value))
+  }
+
+  const query = search.toString()
+  if (!query) return url
+  return `${url}${url.includes('?') ? '&' : '?'}${query}`
+}
+
+export function buildDirectGitHubApiRequest(
+  args: string[],
+  config: Pick<AgentConfig, 'repo'>,
+): DirectGitHubApiRequest {
+  const qualifiedArgs = qualifyGhApiArgs(args, config)
+  const [endpoint, ...rest] = qualifiedArgs
+  const fieldArgs: string[] = []
+  let inputPath: string | null = null
+  let method: DirectGitHubApiRequest['method'] = 'GET'
+  let paginate = false
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index]
+    if ((token === '-X' || token === '--method') && typeof rest[index + 1] === 'string') {
+      method = normalizeDirectGitHubMethod(rest[index + 1])
+      index += 1
+      continue
+    }
+
+    if ((token === '-f' || token === '--field' || token === '--raw-field') && typeof rest[index + 1] === 'string') {
+      fieldArgs.push(rest[index + 1]!)
+      index += 1
+      continue
+    }
+
+    if (token === '--input' && typeof rest[index + 1] === 'string') {
+      inputPath = rest[index + 1]!
+      index += 1
+      continue
+    }
+
+    if (token === '--paginate') {
+      paginate = true
+    }
+  }
+
+  if (endpoint === 'graphql') {
+    const payload = parseDirectGitHubApiFields(fieldArgs)
+    const query = typeof payload.query === 'string' ? payload.query : ''
+    delete payload.query
+
+    return {
+      kind: 'graphql',
+      url: 'https://api.github.com/graphql',
+      method: 'POST',
+      body: JSON.stringify({
+        query,
+        variables: payload,
+      }),
+      paginate: false,
+    }
+  }
+
+  let url = `https://api.github.com/${endpoint.replace(/^\/+/, '')}`
+  let body: string | undefined
+
+  if (inputPath) {
+    body = readFileSync(inputPath, 'utf-8')
+  } else if (fieldArgs.length > 0) {
+    const payload = parseDirectGitHubApiFields(fieldArgs)
+    if (method === 'GET') {
+      url = appendDirectGitHubQueryParams(url, payload)
+    } else {
+      body = JSON.stringify(payload)
+    }
+  }
+
+  return {
+    kind: 'rest',
+    url,
+    method,
+    body,
+    paginate,
+  }
+}
+
+function parseDirectGitHubApiErrorMessage(body: string): string {
+  const trimmed = body.trim()
+  if (!trimmed) return 'GitHub API request failed'
+
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      message?: unknown
+      errors?: Array<{ message?: unknown }>
+    }
+    if (typeof parsed.message === 'string' && parsed.message.trim().length > 0) {
+      return parsed.message.trim()
+    }
+    if (Array.isArray(parsed.errors)) {
+      for (const error of parsed.errors) {
+        if (typeof error?.message === 'string' && error.message.trim().length > 0) {
+          return error.message.trim()
+        }
+      }
+    }
+  } catch {
+    // fall through to raw body
+  }
+
+  return trimmed
+}
+
+function parseDirectGraphQlErrorMessage(body: string): string | null {
+  try {
+    const parsed = JSON.parse(body) as {
+      errors?: Array<{ message?: unknown }>
+    }
+    if (!Array.isArray(parsed.errors)) return null
+
+    for (const error of parsed.errors) {
+      if (typeof error?.message === 'string' && error.message.trim().length > 0) {
+        return error.message.trim()
+      }
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+export function extractNextPageUrl(linkHeader: string | null): string | null {
+  if (!linkHeader) return null
+
+  for (const part of linkHeader.split(',')) {
+    const match = part.match(/<([^>]+)>\s*;\s*rel="([^"]+)"/)
+    if (match?.[2] === 'next') {
+      return match[1] ?? null
+    }
+  }
+
+  return null
+}
+
+export function mergePaginatedRestBodies(pages: string[]): string {
+  if (pages.length === 0) return '[]'
+  if (pages.length === 1) return pages[0]!
+
+  try {
+    const parsedPages = pages.map((page) => JSON.parse(page))
+    if (parsedPages.every(Array.isArray)) {
+      return JSON.stringify(parsedPages.flat())
+    }
+  } catch {
+    // fall back to raw concatenation below
+  }
+
+  return pages.join('\n')
+}
+
+async function runDirectGitHubApi(
+  args: string[],
+  config: Pick<AgentConfig, 'pat' | 'repo'>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  let request: DirectGitHubApiRequest
+  try {
+    request = buildDirectGitHubApiRequest(args, config)
+  } catch (error) {
+    return {
+      stdout: '',
+      stderr: error instanceof Error ? error.message : String(error),
+      exitCode: 1,
+    }
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `token ${config.pat}`,
+    Accept: request.kind === 'graphql'
+      ? 'application/json'
+      : 'application/vnd.github+json',
+  }
+
+  if (request.body) {
+    headers['Content-Type'] = 'application/json'
+  }
+
+  const issueRequest = async (
+    url: string,
+    includeBody: boolean,
+  ): Promise<{ stdout: string; stderr: string; exitCode: number; nextPageUrl: string | null }> => {
+    const response = await fetch(url, {
+      method: request.method,
+      headers,
+      body: includeBody ? request.body : undefined,
+    })
+    const stdout = await response.text()
+    if (!response.ok) {
+      return {
+        stdout,
+        stderr: parseDirectGitHubApiErrorMessage(stdout),
+        exitCode: 1,
+        nextPageUrl: null,
+      }
+    }
+
+    if (request.kind === 'graphql') {
+      const graphQlError = parseDirectGraphQlErrorMessage(stdout)
+      if (graphQlError) {
+        return {
+          stdout,
+          stderr: `GraphQL: ${graphQlError}`,
+          exitCode: 1,
+          nextPageUrl: null,
+        }
+      }
+    }
+
+    return {
+      stdout,
+      stderr: '',
+      exitCode: 0,
+      nextPageUrl: request.paginate ? extractNextPageUrl(response.headers.get('link')) : null,
+    }
+  }
+
+  try {
+    if (!request.paginate) {
+      const response = await issueRequest(request.url, true)
+      return {
+        stdout: response.stdout,
+        stderr: response.stderr,
+        exitCode: response.exitCode,
+      }
+    }
+
+    const pages: string[] = []
+    let nextPageUrl: string | null = request.url
+    let includeBody = true
+    while (nextPageUrl) {
+      const response = await issueRequest(nextPageUrl, includeBody)
+      if (response.exitCode !== 0) {
+        return {
+          stdout: response.stdout,
+          stderr: response.stderr,
+          exitCode: response.exitCode,
+        }
+      }
+      pages.push(response.stdout)
+      nextPageUrl = response.nextPageUrl
+      includeBody = false
+    }
+
+    return {
+      stdout: mergePaginatedRestBodies(pages),
+      stderr: '',
+      exitCode: 0,
+    }
+  } catch (error) {
+    return {
+      stdout: '',
+      stderr: error instanceof Error ? error.message : String(error),
+      exitCode: 1,
+    }
+  }
 }
 
 export function qualifyGhApiArgs(


### PR DESCRIPTION
## Summary
- bypass `gh api` for presence and shared GitHub API calls when a PAT is configured
- parse GraphQL and REST arguments into direct GitHub HTTP requests, including pagination and repeated form fields
- add regression coverage for direct request building and pagination helpers

## Verification
- `bun test packages/agent-shared/src/github-api.test.ts apps/agent-daemon/src/presence.test.ts`
- restarted the local daemon and verified `startupRecoveryPending=false` with startup recovery completing successfully
