### PR TITLE
feat: add non-disruptive agent-loop upgrade awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,54 @@ agent-loop --doctor
 - `agent-loop --runtimes` 可以让新打开的 Codex/终端会话快速找回当前机器上正在运行的 daemon 实例
 - `launchd` service 会把 plist 写到 `~/Library/LaunchAgents/`，并沿用同一套 runtime record/log 路径，方便和 detached 模式统一排障
 
+## Agent Loop Upgrade Channel
+
+agent-loop 现在内置了一套“非打断式升级提醒”机制，目标是让参与开发的多台机器尽量在空闲窗口升级，而不是在执行 issue 过程中被打断。
+
+默认行为：
+
+- daemon 会后台检查 `agent-loop` 自身仓库的目标 channel 最新版本与 commit
+- `--status` / `--doctor` / `/health` 会显示本机 `agent-loop` 的本地版本、revision、upgrade 状态
+- GitHub presence 心跳也会上报这些字段，所以 dashboard 和远端机器视图能直接看出谁落后、谁现在空闲可升
+- 只有在 daemon 当前没有 startup recovery、active worktree、active lease、in-flight issue/review task 时，才会把 `safeToUpgradeNow` 标记为 `true`
+
+默认策略可以在 `~/.agent-loop/config.json` 里配置：
+
+```json
+{
+  "upgrade": {
+    "enabled": true,
+    "repo": "JamesWuHK/agent-loop",
+    "channel": "master",
+    "checkIntervalMs": 900000,
+    "reminderIntervalMs": 3600000
+  }
+}
+```
+
+字段说明：
+
+- `enabled`：是否启用升级检查
+- `repo`：用于比较版本的 agent-loop 仓库 slug；不填时默认取当前 agent-loop 仓库 origin
+- `channel`：跟踪的分支；不填时默认取目标仓库 default branch
+- `checkIntervalMs`：后台检查最新版本的最小间隔
+- `reminderIntervalMs`：升级提醒日志的冷却时间，避免刷屏
+
+版本发布时，统一用下面的命令 bump 根版本号，避免手改：
+
+```bash
+bun run agent:version:bump patch
+bun run agent:version:bump minor
+bun run agent:version:bump major
+bun run agent:version:bump set 0.2.0
+```
+
+建议的升级执行原则：
+
+- 当 `upgrade.status=upgrade-available` 且 `safeToUpgradeNow=true` 时，再重启 daemon 升级
+- 如果 daemon 仍在处理 worktree / lease / review，先继续消费，等它回到 idle 再升
+- 多机部署时，以 dashboard / presence 里显示的升级状态为准，不要求所有机器同时强制重启
+
 ## Key Design Decisions
 
 - **GitHub = coordination layer**: no shared DB; labels + assignee + comments are the state machine

--- a/apps/agent-daemon/src/config.test.ts
+++ b/apps/agent-daemon/src/config.test.ts
@@ -132,6 +132,13 @@ describe('buildConfig', () => {
     expect(config.concurrency).toBe(1)
     expect(config.recovery.leaseTtlMs).toBe(60_000)
     expect(config.recovery.leaseNoProgressTimeoutMs).toBe(360_000)
+    expect(config.upgrade).toEqual({
+      enabled: true,
+      repo: null,
+      channel: null,
+      checkIntervalMs: 900_000,
+      reminderIntervalMs: 3_600_000,
+    })
   })
 
   test('allows repo-local config to disable agent fallback explicitly', () => {

--- a/apps/agent-daemon/src/config.ts
+++ b/apps/agent-daemon/src/config.ts
@@ -8,6 +8,10 @@ import type {
   ProjectPromptContext,
   ProjectPromptGuidanceOverrides,
 } from '@agent/shared'
+import {
+  DEFAULT_AGENT_LOOP_UPGRADE_CHECK_INTERVAL_MS,
+  DEFAULT_AGENT_LOOP_UPGRADE_REMINDER_INTERVAL_MS,
+} from './version'
 
 const CONFIG_DIR = resolve(homedir(), '.agent-loop')
 const CONFIG_PATH = resolve(CONFIG_DIR, 'config.json')
@@ -213,6 +217,19 @@ export function buildConfig(
       defaultBranch: repoConfig.git?.defaultBranch ?? fileConfig.git?.defaultBranch ?? 'main',
       authorName: fileConfig.git?.authorName ?? 'agent-loop',
       authorEmail: fileConfig.git?.authorEmail ?? 'agent-loop@local',
+    },
+    upgrade: {
+      enabled: fileConfig.upgrade?.enabled !== false,
+      repo: normalizeNonEmptyString(fileConfig.upgrade?.repo),
+      channel: normalizeNonEmptyString(fileConfig.upgrade?.channel),
+      checkIntervalMs: normalizePositiveInteger(
+        fileConfig.upgrade?.checkIntervalMs,
+        DEFAULT_AGENT_LOOP_UPGRADE_CHECK_INTERVAL_MS,
+      ),
+      reminderIntervalMs: normalizePositiveInteger(
+        fileConfig.upgrade?.reminderIntervalMs,
+        DEFAULT_AGENT_LOOP_UPGRADE_REMINDER_INTERVAL_MS,
+      ),
     },
   }
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -4,6 +4,8 @@ import { resolve } from 'node:path'
 import type {
   ActiveLeaseRuntimeDetail,
   AgentConfig,
+  AgentLoopBuildMetadata,
+  AgentLoopUpgradeMetadata,
   AgentIssue,
   BlockedIssueResumeRuntimeDetail,
   ClaimEvent,
@@ -67,6 +69,13 @@ import {
   ManagedDaemonPresencePublisher,
   type ManagedDaemonPresenceRuntimeState,
 } from './presence'
+import {
+  abbreviateRevision,
+  checkForAgentLoopUpgrade,
+  createInitialAgentLoopUpgradeMetadata,
+  resolveAgentLoopBuildMetadata,
+  resolveAgentLoopUpgradePolicy,
+} from './version'
 
 export interface HealthServerConfig {
   host: string
@@ -230,6 +239,10 @@ export class AgentDaemon {
   private failedIssueResumeAttempts = new Map<number, number>()
   private failedIssueResumeCooldownUntil = new Map<number, number>()
   private startupRecoveryPending = true
+  private readonly agentLoopBuild: AgentLoopBuildMetadata
+  private agentLoopUpgrade: AgentLoopUpgradeMetadata
+  private upgradeCheckPromise: Promise<void> | null = null
+  private lastUpgradeReminderAt: number | null = null
 
   constructor(
     private config: AgentConfig,
@@ -241,6 +254,12 @@ export class AgentDaemon {
       this.healthServerConfig = { ...this.healthServerConfig, ...healthServerConfig }
     }
     this.metricsPort = metricsPort ?? 9090
+    this.agentLoopBuild = resolveAgentLoopBuildMetadata()
+    this.agentLoopUpgrade = createInitialAgentLoopUpgradeMetadata(
+      this.config,
+      this.agentLoopBuild,
+      this.isSafeToUpgradeNow(),
+    )
   }
 
   private buildLeaseKey(scope: ManagedLeaseScope, targetNumber: number): string {
@@ -521,7 +540,7 @@ export class AgentDaemon {
   }
 
   async start(): Promise<void> {
-    this.logger.log(`[daemon] starting agent-loop v0.1.0`)
+    this.logger.log(`[daemon] starting agent-loop v${this.agentLoopBuild.version} (${abbreviateRevision(this.agentLoopBuild.revision)})`)
     this.logger.log(`[daemon] machineId: ${this.config.machineId}`)
     this.logger.log(`[daemon] repo: ${this.config.repo}`)
     this.logger.log(
@@ -567,6 +586,8 @@ export class AgentDaemon {
     } catch (error) {
       this.logger.warn(`[daemon] failed to start GitHub presence heartbeat: ${formatDaemonError(error)}`)
     }
+
+    void this.maybeRefreshAgentLoopUpgradeStatus(true)
 
     // Run first recovery + poll immediately; subsequent polls are self-scheduled
     await this.runPollCycleSafely()
@@ -645,7 +666,7 @@ export class AgentDaemon {
           return Response.json({
             status: this.running ? 'running' : 'stopped',
             mode: 'agent-loop-daemon',
-            version: '0.1.0',
+            version: this.agentLoopBuild.version,
             ...this.getStatus(),
           })
         }
@@ -738,6 +759,10 @@ export class AgentDaemon {
         primary: this.config.agent.primary,
         fallback: this.config.agent.fallback,
       },
+      agentLoop: {
+        ...this.agentLoopBuild,
+      },
+      upgrade: this.buildUpgradeStatus(),
       endpoints: {
         health: {
           host: this.healthServerConfig.host,
@@ -804,6 +829,7 @@ export class AgentDaemon {
 
   private async runPollCycleSafely(): Promise<void> {
     const startedAt = Date.now()
+    void this.maybeRefreshAgentLoopUpgradeStatus()
 
     try {
       const startupResult = await this.runStartupMaintenanceIfNeeded()
@@ -2793,11 +2819,93 @@ export class AgentDaemon {
 
   private readPresenceRuntimeState(): ManagedDaemonPresenceRuntimeState {
     const runtime = this.buildRuntimeStatus()
+    const upgrade = this.buildUpgradeStatus()
     return {
       activeLeaseCount: runtime.activeLeaseCount,
       activeWorktreeCount: this.activeWorktrees.size,
       effectiveActiveTasks: runtime.effectiveActiveTasks,
+      agentLoopVersion: this.agentLoopBuild.version,
+      agentLoopRevision: this.agentLoopBuild.revision,
+      upgradeStatus: upgrade.status,
+      safeToUpgradeNow: upgrade.safeToUpgradeNow,
+      latestVersion: upgrade.latestVersion,
+      latestRevision: upgrade.latestRevision,
+      upgradeCheckedAt: upgrade.checkedAt,
     }
+  }
+
+  private buildUpgradeStatus(): AgentLoopUpgradeMetadata {
+    return {
+      ...this.agentLoopUpgrade,
+      safeToUpgradeNow: this.isSafeToUpgradeNow(),
+    }
+  }
+
+  private isSafeToUpgradeNow(): boolean {
+    return (
+      !this.startupRecoveryPending
+      && this.activeWorktrees.size === 0
+      && this.activeLeaseReaders.size === 0
+      && this.activeIssueProcesses.size === 0
+      && this.inFlightIssueProcesses.size === 0
+      && this.activePrReviews.size === 0
+      && this.inFlightPrTasks.size === 0
+    )
+  }
+
+  private async maybeRefreshAgentLoopUpgradeStatus(force = false): Promise<void> {
+    const policy = resolveAgentLoopUpgradePolicy(this.config, this.agentLoopBuild)
+    const lastCheckedAt = this.agentLoopUpgrade.checkedAt
+      ? Date.parse(this.agentLoopUpgrade.checkedAt)
+      : Number.NaN
+
+    if (
+      !force
+      && Number.isFinite(lastCheckedAt)
+      && lastCheckedAt + policy.checkIntervalMs > Date.now()
+    ) {
+      return
+    }
+
+    if (this.upgradeCheckPromise) {
+      return this.upgradeCheckPromise
+    }
+
+    this.upgradeCheckPromise = (async () => {
+      const next = await checkForAgentLoopUpgrade(
+        this.config,
+        this.agentLoopBuild,
+        this.isSafeToUpgradeNow(),
+      )
+      this.agentLoopUpgrade = next
+      this.maybeLogAgentLoopUpgradeNotice(next)
+    })().finally(() => {
+      this.upgradeCheckPromise = null
+    })
+
+    return this.upgradeCheckPromise
+  }
+
+  private maybeLogAgentLoopUpgradeNotice(upgrade: AgentLoopUpgradeMetadata): void {
+    if (upgrade.status !== 'upgrade-available') {
+      return
+    }
+
+    const policy = resolveAgentLoopUpgradePolicy(this.config, this.agentLoopBuild)
+    const now = Date.now()
+    if (
+      this.lastUpgradeReminderAt !== null
+      && this.lastUpgradeReminderAt + policy.reminderIntervalMs > now
+    ) {
+      return
+    }
+
+    this.lastUpgradeReminderAt = now
+    const local = `v${this.agentLoopBuild.version}@${abbreviateRevision(this.agentLoopBuild.revision)}`
+    const latest = `v${upgrade.latestVersion ?? 'unknown'}@${abbreviateRevision(upgrade.latestRevision)}`
+    this.logger.warn(
+      `[daemon] agent-loop upgrade available on ${upgrade.channel ?? 'default'}: ${local} -> ${latest}; ${upgrade.safeToUpgradeNow ? 'safe to upgrade now' : 'defer upgrade until this daemon is idle'}`,
+    )
   }
 
   private syncRuntimeMetrics(): void {

--- a/apps/agent-daemon/src/dashboard.test.ts
+++ b/apps/agent-daemon/src/dashboard.test.ts
@@ -92,6 +92,13 @@ function buildPresence(overrides: Partial<DashboardPresenceView> = {}): Dashboar
     activeLeaseCount: 0,
     activeWorktreeCount: 0,
     effectiveActiveTasks: 0,
+    agentLoopVersion: '0.1.0',
+    agentLoopRevision: 'abcdef1234567890',
+    upgradeStatus: 'up-to-date',
+    safeToUpgradeNow: true,
+    latestVersion: '0.1.0',
+    latestRevision: 'abcdef1234567890',
+    upgradeCheckedAt: '2026-04-05T09:10:00.000Z',
     source: 'github',
     ...overrides,
   }

--- a/apps/agent-daemon/src/dashboard.ts
+++ b/apps/agent-daemon/src/dashboard.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import {
+  type AgentLoopUpgradeStatusKind,
   PR_REVIEW_LABELS,
   getActiveManagedLease,
   listIssueComments,
@@ -115,6 +116,13 @@ export interface DashboardPresenceView {
   activeLeaseCount: number
   activeWorktreeCount: number
   effectiveActiveTasks: number
+  agentLoopVersion: string
+  agentLoopRevision: string | null
+  upgradeStatus: AgentLoopUpgradeStatusKind
+  safeToUpgradeNow: boolean
+  latestVersion: string | null
+  latestRevision: string | null
+  upgradeCheckedAt: string | null
   source: 'github'
 }
 
@@ -821,6 +829,13 @@ function mergeDashboardLease(machine: DashboardMachineCard, lease: DashboardLeas
 function mergeDashboardPresence(machine: DashboardMachineCard, presence: DashboardPresenceView): void {
   if (!machine.presence) {
     machine.presence = presence
+    if (presence.upgradeStatus === 'upgrade-available') {
+      mergeDashboardWarnings(machine, [
+        presence.safeToUpgradeNow
+          ? `agent-loop upgrade available on ${presence.machineId}; this machine is idle enough to upgrade now`
+          : `agent-loop upgrade available on ${presence.machineId}; wait for the machine to go idle before restarting`,
+      ])
+    }
     return
   }
 
@@ -962,6 +977,13 @@ function buildDashboardPresenceView(comment: ManagedDaemonPresenceComment): Dash
     activeLeaseCount: comment.presence.activeLeaseCount,
     activeWorktreeCount: comment.presence.activeWorktreeCount,
     effectiveActiveTasks: comment.presence.effectiveActiveTasks,
+    agentLoopVersion: comment.presence.agentLoopVersion,
+    agentLoopRevision: comment.presence.agentLoopRevision,
+    upgradeStatus: comment.presence.upgradeStatus,
+    safeToUpgradeNow: comment.presence.safeToUpgradeNow,
+    latestVersion: comment.presence.latestVersion,
+    latestRevision: comment.presence.latestRevision,
+    upgradeCheckedAt: comment.presence.upgradeCheckedAt,
     source: 'github',
   }
 }
@@ -1826,6 +1848,9 @@ function renderPresenceItem(presence) {
     presence.heartbeatAgeSeconds === null ? null : '心跳 ' + presence.heartbeatAgeSeconds + ' 秒',
     presence.expiresInSeconds === null ? null : 'TTL ' + presence.expiresInSeconds + ' 秒',
   ].filter(Boolean).join(' | ');
+  const upgradeHint = presence.upgradeStatus === 'upgrade-available'
+    ? (presence.safeToUpgradeNow ? '可安全升级' : '待空闲后升级')
+    : null;
 
   return [
     '<div class="lease-item">',
@@ -1833,10 +1858,14 @@ function renderPresenceItem(presence) {
     '<div class="chip-row" style="margin-top:8px">',
     renderChip(localizePresenceStatus(presence.status), presence.status === 'busy' ? 'accent' : 'gold'),
     renderChip(shortDaemonId(presence.daemonInstanceId), ''),
+    renderChip('v' + presence.agentLoopVersion, ''),
+    renderChip(presence.upgradeStatus, presence.upgradeStatus === 'upgrade-available' ? 'danger' : ''),
     renderChip('工作树 ' + presence.activeWorktreeCount, ''),
     renderChip('租约 ' + presence.activeLeaseCount, ''),
     '</div>',
     '<div class="muted" style="margin-top:8px">启动于 ' + escapeHtml(formatTimestamp(presence.startedAt)) + '</div>',
+    '<div class="muted" style="margin-top:6px">revision ' + escapeHtml(shortDaemonId(presence.agentLoopRevision || 'unknown')) + (presence.latestVersion ? ' | latest v' + escapeHtml(String(presence.latestVersion)) : '') + '</div>',
+    upgradeHint ? '<div class="muted" style="margin-top:6px">' + escapeHtml(upgradeHint) + '</div>' : '',
     timing ? '<div class="muted" style="margin-top:6px">' + escapeHtml(timing) + '</div>' : '',
     '</div>',
   ].join('');

--- a/apps/agent-daemon/src/presence.test.ts
+++ b/apps/agent-daemon/src/presence.test.ts
@@ -67,6 +67,13 @@ function buildPresence(overrides: Partial<ManagedDaemonPresence> = {}): ManagedD
     activeLeaseCount: 0,
     activeWorktreeCount: 0,
     effectiveActiveTasks: 0,
+    agentLoopVersion: '0.1.0',
+    agentLoopRevision: 'abcdef1234567890',
+    upgradeStatus: 'up-to-date',
+    safeToUpgradeNow: true,
+    latestVersion: '0.1.0',
+    latestRevision: 'abcdef1234567890',
+    upgradeCheckedAt: '2026-04-05T08:00:20.000Z',
     ...overrides,
   }
 }
@@ -195,10 +202,26 @@ describe('managed daemon presence helpers', () => {
 describe('managed daemon presence publisher', () => {
   test('publishes idle, busy, and stopped presence updates through the injected API', async () => {
     const { api, comments } = createFakePresenceApi()
-    const runtime = {
+    const runtime: ManagedDaemonPresence = {
+      repo: TEST_CONFIG.repo,
+      machineId: TEST_CONFIG.machineId,
+      daemonInstanceId: 'daemon-a',
+      status: 'idle',
+      startedAt: '2026-04-05T08:00:00.000Z',
+      lastHeartbeatAt: '2026-04-05T08:00:00.000Z',
+      expiresAt: '2026-04-05T08:02:00.000Z',
+      healthPort: 9312,
+      metricsPort: 9092,
       activeLeaseCount: 0,
       activeWorktreeCount: 0,
       effectiveActiveTasks: 0,
+      agentLoopVersion: '0.1.0',
+      agentLoopRevision: 'abcdef1234567890',
+      upgradeStatus: 'up-to-date',
+      safeToUpgradeNow: true,
+      latestVersion: '0.1.0',
+      latestRevision: 'abcdef1234567890',
+      upgradeCheckedAt: '2026-04-05T08:00:20.000Z',
     }
 
     const publisher = new ManagedDaemonPresencePublisher({
@@ -217,11 +240,17 @@ describe('managed daemon presence publisher', () => {
     runtime.activeLeaseCount = 1
     runtime.activeWorktreeCount = 1
     runtime.effectiveActiveTasks = 1
+    runtime.upgradeStatus = 'upgrade-available'
+    runtime.safeToUpgradeNow = false
+    runtime.latestVersion = '0.1.1'
+    runtime.latestRevision = 'fedcba9876543210'
 
     await publisher.flushHeartbeat()
     expect(comments).toHaveLength(1)
     expect(comments[0]?.body).toContain('"status":"busy"')
     expect(comments[0]?.body).toContain('"activeLeaseCount":1')
+    expect(comments[0]?.body).toContain('"upgradeStatus":"upgrade-available"')
+    expect(comments[0]?.body).toContain('"safeToUpgradeNow":false')
 
     await publisher.stop()
     expect(comments[0]?.body).toContain('"status":"stopped"')

--- a/apps/agent-daemon/src/presence.ts
+++ b/apps/agent-daemon/src/presence.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import {
   runBoundedGhCommand,
   type AgentConfig,
+  type AgentLoopUpgradeStatusKind,
   type IssueComment,
 } from '@agent/shared'
 
@@ -26,6 +27,13 @@ export interface ManagedDaemonPresence {
   activeLeaseCount: number
   activeWorktreeCount: number
   effectiveActiveTasks: number
+  agentLoopVersion: string
+  agentLoopRevision: string | null
+  upgradeStatus: AgentLoopUpgradeStatusKind
+  safeToUpgradeNow: boolean
+  latestVersion: string | null
+  latestRevision: string | null
+  upgradeCheckedAt: string | null
 }
 
 export interface ManagedDaemonPresenceComment extends IssueComment {
@@ -36,6 +44,13 @@ export interface ManagedDaemonPresenceRuntimeState {
   activeLeaseCount: number
   activeWorktreeCount: number
   effectiveActiveTasks: number
+  agentLoopVersion: string
+  agentLoopRevision: string | null
+  upgradeStatus: AgentLoopUpgradeStatusKind
+  safeToUpgradeNow: boolean
+  latestVersion: string | null
+  latestRevision: string | null
+  upgradeCheckedAt: string | null
 }
 
 export interface PresenceApiAdapter {
@@ -209,7 +224,12 @@ export function buildManagedDaemonPresenceComment(presence: ManagedDaemonPresenc
 - Metrics port: ${presence.metricsPort}
 - Worktrees: ${presence.activeWorktreeCount}
 - Leases: ${presence.activeLeaseCount}
-- Effective tasks: ${presence.effectiveActiveTasks}`
+- Effective tasks: ${presence.effectiveActiveTasks}
+- Agent Loop: v${presence.agentLoopVersion} (${presence.agentLoopRevision ?? 'unknown'})
+- Upgrade status: ${presence.upgradeStatus}
+- Safe to upgrade now: ${presence.safeToUpgradeNow ? 'yes' : 'no'}
+- Latest known version: ${presence.latestVersion ?? 'unknown'}
+- Latest known revision: ${presence.latestRevision ?? 'unknown'}`
 }
 
 export function extractManagedDaemonPresenceComment(body: string): ManagedDaemonPresence | null {
@@ -231,6 +251,30 @@ export function extractManagedDaemonPresenceComment(body: string): ManagedDaemon
     const activeLeaseCount = parsed.activeLeaseCount as number
     const activeWorktreeCount = parsed.activeWorktreeCount as number
     const effectiveActiveTasks = parsed.effectiveActiveTasks as number
+    const agentLoopVersion = typeof parsed.agentLoopVersion === 'string' && parsed.agentLoopVersion.trim().length > 0
+      ? parsed.agentLoopVersion
+      : 'unknown'
+    const agentLoopRevision = typeof parsed.agentLoopRevision === 'string' && parsed.agentLoopRevision.trim().length > 0
+      ? parsed.agentLoopRevision
+      : null
+    const upgradeStatus = parsed.upgradeStatus === 'disabled'
+      || parsed.upgradeStatus === 'unknown'
+      || parsed.upgradeStatus === 'up-to-date'
+      || parsed.upgradeStatus === 'upgrade-available'
+      || parsed.upgradeStatus === 'ahead-of-channel'
+      || parsed.upgradeStatus === 'error'
+      ? parsed.upgradeStatus
+      : 'unknown'
+    const safeToUpgradeNow = parsed.safeToUpgradeNow === true
+    const latestVersion = typeof parsed.latestVersion === 'string' && parsed.latestVersion.trim().length > 0
+      ? parsed.latestVersion
+      : null
+    const latestRevision = typeof parsed.latestRevision === 'string' && parsed.latestRevision.trim().length > 0
+      ? parsed.latestRevision
+      : null
+    const upgradeCheckedAt = typeof parsed.upgradeCheckedAt === 'string' && parsed.upgradeCheckedAt.trim().length > 0
+      ? parsed.upgradeCheckedAt
+      : null
 
     return {
       repo: parsed.repo,
@@ -245,6 +289,13 @@ export function extractManagedDaemonPresenceComment(body: string): ManagedDaemon
       activeLeaseCount,
       activeWorktreeCount,
       effectiveActiveTasks,
+      agentLoopVersion,
+      agentLoopRevision,
+      upgradeStatus,
+      safeToUpgradeNow,
+      latestVersion,
+      latestRevision,
+      upgradeCheckedAt,
     }
   } catch {
     return null
@@ -536,6 +587,13 @@ export class ManagedDaemonPresencePublisher {
       activeLeaseCount: runtime.activeLeaseCount,
       activeWorktreeCount: runtime.activeWorktreeCount,
       effectiveActiveTasks: runtime.effectiveActiveTasks,
+      agentLoopVersion: runtime.agentLoopVersion,
+      agentLoopRevision: runtime.agentLoopRevision,
+      upgradeStatus: runtime.upgradeStatus,
+      safeToUpgradeNow: runtime.safeToUpgradeNow,
+      latestVersion: runtime.latestVersion,
+      latestRevision: runtime.latestRevision,
+      upgradeCheckedAt: runtime.upgradeCheckedAt,
     }
   }
 

--- a/apps/agent-daemon/src/status.test.ts
+++ b/apps/agent-daemon/src/status.test.ts
@@ -48,6 +48,23 @@ const baseHealth: DaemonStatus & {
     primary: 'codex',
     fallback: 'claude',
   },
+  agentLoop: {
+    repo: 'JamesWuHK/agent-loop',
+    version: '0.1.0',
+    revision: 'd51749d9e5583c77efc70b7aec5d6858b4b959a3',
+  },
+  upgrade: {
+    enabled: true,
+    repo: 'JamesWuHK/agent-loop',
+    channel: 'master',
+    checkedAt: '2026-04-05T08:09:45.000Z',
+    status: 'upgrade-available',
+    latestVersion: '0.1.1',
+    latestRevision: '2222222222222222222222222222222222222222',
+    latestCommitAt: '2026-04-05T08:09:40.000Z',
+    safeToUpgradeNow: false,
+    message: 'channel master is newer: local v0.1.0, latest v0.1.1',
+  },
   endpoints: {
     health: {
       host: '127.0.0.1',
@@ -368,6 +385,7 @@ describe('status helpers', () => {
     })
 
     expect(report).toContain('repo: JamesWuHK/digital-employee')
+    expect(report).toContain('agent-loop: repo JamesWuHK/agent-loop | revision d51749d | upgrade upgrade-available | latest v0.1.1@2222222 | checked 2026-04-05T08:09:45.000Z | safe now no')
     expect(report).toContain('daemon: codex-dev / daemon-codex-dev-1')
     expect(report).toContain('process: launchd | pid 12345 | cwd /Users/wujames/codeRepo/digital-employee-main')
     expect(report).toContain('concurrency: effective 2 (requested 5; repo cap 4; profile cap 2; project cap 3)')
@@ -464,6 +482,7 @@ describe('status helpers', () => {
     expect(report).toContain('blocked-issue-resumes: 1')
     expect(report).toContain('blocked-issue-resume-age-seconds: 45')
     expect(report).toContain('oldest blocked issue resume age: 45s')
+    expect(report).toContain('- agent-loop upgrade available; defer restart until the daemon is idle to avoid interrupting active work')
     expect(report).toContain('- open PR review blockers: pr#239')
     expect(report).toContain('- review auto-fix push failures observed: 1')
   })

--- a/apps/agent-daemon/src/status.ts
+++ b/apps/agent-daemon/src/status.ts
@@ -383,6 +383,8 @@ function inspectLocalLaunchdRuntime(runtime: LocalRuntimeDiagnostic): LocalLaunc
 }
 
 export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): string {
+  const warnings = snapshot.health ? buildDoctorWarnings(snapshot) : snapshot.warnings
+
   if (!snapshot.ok || !snapshot.health) {
     return [
       'daemon: unreachable',
@@ -409,6 +411,7 @@ export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): strin
   const startupRecoveryDeferredCount = health.runtime.startupRecoveryDeferredCount ?? 0
   const lines = [
     `daemon: ${health.status} v${health.version} (${health.mode})`,
+    `agent-loop: repo ${health.agentLoop?.repo ?? 'unknown'} | revision ${formatRevision(health.agentLoop?.revision ?? null)} | upgrade ${formatUpgradeSummary(health.upgrade)}`,
     `repo: ${health.repo}`,
     `project: ${health.project.profile} | agents: ${health.agent.primary} -> ${health.agent.fallback ?? 'none'}`,
     `daemon: ${health.machineId} / ${health.daemonInstanceId}`,
@@ -456,14 +459,16 @@ export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): strin
     lines.push(`pr blockers: ${formatGitHubPrBlockersInlineSummary(snapshot.githubAudit.prBlockers)}`)
   }
 
-  if (snapshot.warnings.length > 0) {
-    lines.push(`warnings: ${snapshot.warnings.join(' | ')}`)
+  if (warnings.length > 0) {
+    lines.push(`warnings: ${warnings.join(' | ')}`)
   }
 
   return lines.join('\n')
 }
 
 export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): string {
+  const warnings = snapshot.health ? buildDoctorWarnings(snapshot) : snapshot.warnings
+
   if (!snapshot.ok || !snapshot.health) {
     const gitHubAuditLines = snapshot.githubAudit === null
       ? ['not available']
@@ -506,7 +511,7 @@ export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): strin
       ...gitHubAuditLines,
       '',
       'Warnings',
-      ...(snapshot.warnings.length > 0 ? snapshot.warnings.map((warning) => `- ${warning}`) : ['none']),
+      ...(warnings.length > 0 ? warnings.map((warning) => `- ${warning}`) : ['none']),
       '',
       'Next checks',
       ...buildOfflineDoctorNextChecks(snapshot),
@@ -641,7 +646,7 @@ export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): strin
     ...gitHubAuditLines,
     '',
     'Warnings',
-    ...(snapshot.warnings.length > 0 ? snapshot.warnings.map((warning) => `- ${warning}`) : ['none']),
+    ...(warnings.length > 0 ? warnings.map((warning) => `- ${warning}`) : ['none']),
   ].join('\n')
 }
 
@@ -924,6 +929,16 @@ function buildDoctorWarnings(snapshot: DaemonObservabilitySnapshot): string[] {
   }
   if ((snapshot.health.runtime.startupRecoveryDeferredCount ?? 0) > 0) {
     warnings.push(`startup recovery has been deferred ${snapshot.health.runtime.startupRecoveryDeferredCount} time(s) by transient GitHub/network errors`)
+  }
+  if (snapshot.health.upgrade?.status === 'upgrade-available') {
+    warnings.push(
+      snapshot.health.upgrade.safeToUpgradeNow
+        ? 'agent-loop upgrade available and this daemon is currently idle enough to restart safely'
+        : 'agent-loop upgrade available; defer restart until the daemon is idle to avoid interrupting active work',
+    )
+  }
+  if (snapshot.health.upgrade?.status === 'error' && snapshot.health.upgrade.message) {
+    warnings.push(`agent-loop upgrade check failed: ${snapshot.health.upgrade.message}`)
   }
   if (snapshot.health.runtime.supervisor === 'direct') {
     warnings.push('daemon is running in direct mode; closing the current terminal/session will stop it')
@@ -1329,6 +1344,18 @@ function formatBlockedIssueResumeIdentity(
 
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+function formatRevision(revision: string | null): string {
+  return revision ? revision.slice(0, 7) : 'unknown'
+}
+
+function formatUpgradeSummary(upgrade: DaemonHealthPayload['upgrade'] | undefined): string {
+  if (!upgrade) {
+    return 'unavailable'
+  }
+
+  return `${upgrade.status} | latest v${upgrade.latestVersion ?? 'unknown'}@${formatRevision(upgrade.latestRevision)} | checked ${upgrade.checkedAt ?? 'never'} | safe now ${formatBoolean(upgrade.safeToUpgradeNow)}`
 }
 
 function inferIssueStateFromLabels(labels: string[]): string {

--- a/apps/agent-daemon/src/version.test.ts
+++ b/apps/agent-daemon/src/version.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import type { AgentConfig, AgentLoopBuildMetadata } from '@agent/shared'
+import {
+  abbreviateRevision,
+  checkForAgentLoopUpgrade,
+  compareAgentLoopVersions,
+  createInitialAgentLoopUpgradeMetadata,
+} from './version'
+
+const TEST_CONFIG: AgentConfig = {
+  machineId: 'machine-a',
+  repo: 'JamesWuHK/digital-employee',
+  pat: 'ghp_test',
+  pollIntervalMs: 60_000,
+  concurrency: 1,
+  requestedConcurrency: 1,
+  concurrencyPolicy: {
+    requested: 1,
+    effective: 1,
+    repoCap: null,
+    profileCap: null,
+    projectCap: null,
+  },
+  scheduling: {
+    concurrencyByRepo: {},
+    concurrencyByProfile: {},
+  },
+  recovery: {
+    heartbeatIntervalMs: 30_000,
+    leaseTtlMs: 60_000,
+    workerIdleTimeoutMs: 300_000,
+    leaseAdoptionBackoffMs: 5_000,
+    leaseNoProgressTimeoutMs: 360_000,
+  },
+  worktreesBase: '/tmp/agent-loop-test',
+  project: {
+    profile: 'generic',
+  },
+  agent: {
+    primary: 'codex',
+    fallback: null,
+    claudePath: 'claude',
+    codexPath: 'codex',
+    timeoutMs: 60_000,
+  },
+  git: {
+    defaultBranch: 'main',
+    authorName: 'agent-loop',
+    authorEmail: 'agent-loop@local',
+  },
+  upgrade: {
+    enabled: true,
+    repo: 'JamesWuHK/agent-loop',
+    channel: 'master',
+    checkIntervalMs: 60_000,
+    reminderIntervalMs: 3_600_000,
+  },
+}
+
+const LOCAL_BUILD: AgentLoopBuildMetadata = {
+  repo: 'JamesWuHK/agent-loop',
+  version: '0.1.0',
+  revision: '1111111111111111111111111111111111111111',
+}
+
+const realFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+describe('compareAgentLoopVersions', () => {
+  test('compares semantic version segments numerically', () => {
+    expect(compareAgentLoopVersions('0.1.9', '0.1.10')).toBe(-1)
+    expect(compareAgentLoopVersions('0.2.0', '0.1.99')).toBe(1)
+    expect(compareAgentLoopVersions('0.1.0', '0.1.0')).toBe(0)
+  })
+})
+
+describe('abbreviateRevision', () => {
+  test('shortens git revisions for display', () => {
+    expect(abbreviateRevision('abcdef1234567890')).toBe('abcdef1')
+    expect(abbreviateRevision(null)).toBe('unknown')
+  })
+})
+
+describe('createInitialAgentLoopUpgradeMetadata', () => {
+  test('marks disabled upgrade checks explicitly', () => {
+    const metadata = createInitialAgentLoopUpgradeMetadata({
+      ...TEST_CONFIG,
+      upgrade: {
+        ...TEST_CONFIG.upgrade!,
+        enabled: false,
+      },
+    }, LOCAL_BUILD, true)
+
+    expect(metadata.status).toBe('disabled')
+    expect(metadata.safeToUpgradeNow).toBe(true)
+  })
+})
+
+describe('checkForAgentLoopUpgrade', () => {
+  test('flags same-version newer revisions as upgrade-available', async () => {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.includes('/branches/master')) {
+        return new Response(JSON.stringify({
+          name: 'master',
+          commit: {
+            sha: '2222222222222222222222222222222222222222',
+            commit: {
+              committer: {
+                date: '2026-04-09T04:00:00Z',
+              },
+            },
+          },
+        }), { status: 200 })
+      }
+
+      if (url.includes('/contents/package.json')) {
+        return new Response(JSON.stringify({
+          encoding: 'base64',
+          content: Buffer.from(JSON.stringify({ version: '0.1.0' })).toString('base64'),
+        }), { status: 200 })
+      }
+
+      return new Response('not found', { status: 404 })
+    }) as unknown as typeof fetch
+
+    const metadata = await checkForAgentLoopUpgrade(TEST_CONFIG, LOCAL_BUILD, false)
+
+    expect(metadata.status).toBe('upgrade-available')
+    expect(metadata.latestVersion).toBe('0.1.0')
+    expect(metadata.latestRevision).toBe('2222222222222222222222222222222222222222')
+    expect(metadata.safeToUpgradeNow).toBe(false)
+  })
+
+  test('reports up-to-date when version and revision match', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      name: 'master',
+      commit: {
+        sha: LOCAL_BUILD.revision,
+        commit: {
+          committer: {
+            date: '2026-04-09T04:00:00Z',
+          },
+        },
+      },
+      encoding: 'base64',
+      content: Buffer.from(JSON.stringify({ version: LOCAL_BUILD.version })).toString('base64'),
+    }), { status: 200 })) as unknown as typeof fetch
+
+    const metadata = await checkForAgentLoopUpgrade(TEST_CONFIG, LOCAL_BUILD, true)
+
+    expect(metadata.status).toBe('up-to-date')
+    expect(metadata.safeToUpgradeNow).toBe(true)
+  })
+})

--- a/apps/agent-daemon/src/version.ts
+++ b/apps/agent-daemon/src/version.ts
@@ -1,0 +1,392 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type {
+  AgentConfig,
+  AgentLoopBuildMetadata,
+  AgentLoopUpgradeMetadata,
+} from '@agent/shared'
+
+export const DEFAULT_AGENT_LOOP_VERSION = '0.1.0'
+export const DEFAULT_AGENT_LOOP_UPGRADE_CHECK_INTERVAL_MS = 15 * 60 * 1000
+export const DEFAULT_AGENT_LOOP_UPGRADE_REMINDER_INTERVAL_MS = 60 * 60 * 1000
+
+const AGENT_LOOP_REPO_ROOT = resolve(import.meta.dir, '../../..')
+const AGENT_LOOP_PACKAGE_JSON_PATH = resolve(AGENT_LOOP_REPO_ROOT, 'package.json')
+
+interface GitHubRepoRecord {
+  default_branch?: unknown
+}
+
+interface GitHubBranchRecord {
+  name?: unknown
+  commit?: {
+    sha?: unknown
+    commit?: {
+      committer?: {
+        date?: unknown
+      }
+    }
+  }
+}
+
+interface GitHubContentRecord {
+  content?: unknown
+  encoding?: unknown
+}
+
+interface VersionFileRecord {
+  version?: unknown
+}
+
+interface ResolvedUpgradeTarget {
+  repo: string
+  channel: string
+}
+
+export function resolveAgentLoopBuildMetadata(): AgentLoopBuildMetadata {
+  return {
+    repo: detectGitHubRepoSlug(AGENT_LOOP_REPO_ROOT),
+    version: readAgentLoopVersion(),
+    revision: readGitOutput(['-C', AGENT_LOOP_REPO_ROOT, 'rev-parse', 'HEAD']),
+  }
+}
+
+export function readAgentLoopVersion(): string {
+  if (!existsSync(AGENT_LOOP_PACKAGE_JSON_PATH)) {
+    return DEFAULT_AGENT_LOOP_VERSION
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(AGENT_LOOP_PACKAGE_JSON_PATH, 'utf-8')) as VersionFileRecord
+    return typeof parsed.version === 'string' && parsed.version.trim().length > 0
+      ? parsed.version.trim()
+      : DEFAULT_AGENT_LOOP_VERSION
+  } catch {
+    return DEFAULT_AGENT_LOOP_VERSION
+  }
+}
+
+export function abbreviateRevision(revision: string | null, length = 7): string {
+  if (!revision) return 'unknown'
+  return revision.slice(0, Math.max(1, length))
+}
+
+export function compareAgentLoopVersions(left: string, right: string): number {
+  const leftParts = parseVersionParts(left)
+  const rightParts = parseVersionParts(right)
+  const length = Math.max(leftParts.length, rightParts.length)
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = leftParts[index] ?? 0
+    const rightPart = rightParts[index] ?? 0
+    if (leftPart < rightPart) return -1
+    if (leftPart > rightPart) return 1
+  }
+
+  return 0
+}
+
+export function createInitialAgentLoopUpgradeMetadata(
+  config: AgentConfig,
+  build: AgentLoopBuildMetadata,
+  safeToUpgradeNow = false,
+): AgentLoopUpgradeMetadata {
+  const policy = resolveAgentLoopUpgradePolicy(config, build)
+
+  if (!policy.enabled) {
+    return {
+      enabled: false,
+      repo: policy.repo,
+      channel: policy.channel,
+      checkedAt: null,
+      status: 'disabled',
+      latestVersion: null,
+      latestRevision: null,
+      latestCommitAt: null,
+      safeToUpgradeNow,
+      message: 'upgrade checks are disabled',
+    }
+  }
+
+  return {
+    enabled: true,
+    repo: policy.repo,
+    channel: policy.channel,
+    checkedAt: null,
+    status: 'unknown',
+    latestVersion: null,
+    latestRevision: null,
+    latestCommitAt: null,
+    safeToUpgradeNow,
+    message: null,
+  }
+}
+
+export function resolveAgentLoopUpgradePolicy(
+  config: AgentConfig,
+  build: AgentLoopBuildMetadata,
+): {
+  enabled: boolean
+  repo: string | null
+  channel: string | null
+  checkIntervalMs: number
+  reminderIntervalMs: number
+} {
+  return {
+    enabled: config.upgrade?.enabled !== false,
+    repo: normalizeOptionalString(config.upgrade?.repo) ?? build.repo,
+    channel: normalizeOptionalString(config.upgrade?.channel),
+    checkIntervalMs: normalizePositiveInteger(
+      config.upgrade?.checkIntervalMs,
+      DEFAULT_AGENT_LOOP_UPGRADE_CHECK_INTERVAL_MS,
+    ),
+    reminderIntervalMs: normalizePositiveInteger(
+      config.upgrade?.reminderIntervalMs,
+      DEFAULT_AGENT_LOOP_UPGRADE_REMINDER_INTERVAL_MS,
+    ),
+  }
+}
+
+export async function checkForAgentLoopUpgrade(
+  config: AgentConfig,
+  build: AgentLoopBuildMetadata,
+  safeToUpgradeNow: boolean,
+): Promise<AgentLoopUpgradeMetadata> {
+  const checkedAt = new Date().toISOString()
+  const policy = resolveAgentLoopUpgradePolicy(config, build)
+
+  if (!policy.enabled) {
+    return {
+      ...createInitialAgentLoopUpgradeMetadata(config, build, safeToUpgradeNow),
+      checkedAt,
+      safeToUpgradeNow,
+    }
+  }
+
+  if (!policy.repo) {
+    return {
+      enabled: true,
+      repo: null,
+      channel: policy.channel,
+      checkedAt,
+      status: 'error',
+      latestVersion: null,
+      latestRevision: null,
+      latestCommitAt: null,
+      safeToUpgradeNow,
+      message: 'agent-loop upgrade repo could not be resolved',
+    }
+  }
+
+  try {
+    const target = await resolveUpgradeTarget(policy.repo, policy.channel, config.pat)
+    const branch = await requestGitHubJson<GitHubBranchRecord>(
+      `https://api.github.com/repos/${target.repo}/branches/${encodeURIComponent(target.channel)}`,
+      config.pat,
+    )
+    const remotePackage = await requestGitHubJson<GitHubContentRecord>(
+      `https://api.github.com/repos/${target.repo}/contents/package.json?ref=${encodeURIComponent(target.channel)}`,
+      config.pat,
+    )
+
+    const latestVersion = extractVersionFromGitHubContent(remotePackage)
+    const latestRevision = typeof branch.commit?.sha === 'string' && branch.commit.sha.length > 0
+      ? branch.commit.sha
+      : null
+    const latestCommitAt = typeof branch.commit?.commit?.committer?.date === 'string'
+      ? branch.commit.commit.committer.date
+      : null
+
+    const message = describeUpgradeState({
+      build,
+      latestVersion,
+      latestRevision,
+      channel: target.channel,
+    })
+
+    return {
+      enabled: true,
+      repo: target.repo,
+      channel: target.channel,
+      checkedAt,
+      status: message.status,
+      latestVersion,
+      latestRevision,
+      latestCommitAt,
+      safeToUpgradeNow,
+      message: message.message,
+    }
+  } catch (error) {
+    return {
+      enabled: true,
+      repo: policy.repo,
+      channel: policy.channel,
+      checkedAt,
+      status: 'error',
+      latestVersion: null,
+      latestRevision: null,
+      latestCommitAt: null,
+      safeToUpgradeNow,
+      message: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+function describeUpgradeState(input: {
+  build: AgentLoopBuildMetadata
+  latestVersion: string
+  latestRevision: string | null
+  channel: string
+}): {
+  status: AgentLoopUpgradeMetadata['status']
+  message: string
+} {
+  const versionComparison = compareAgentLoopVersions(input.build.version, input.latestVersion)
+
+  if (versionComparison < 0) {
+    return {
+      status: 'upgrade-available',
+      message: `channel ${input.channel} is newer: local v${input.build.version}, latest v${input.latestVersion}`,
+    }
+  }
+
+  if (versionComparison > 0) {
+    return {
+      status: 'ahead-of-channel',
+      message: `local build v${input.build.version} is ahead of channel ${input.channel} v${input.latestVersion}`,
+    }
+  }
+
+  if (!input.build.revision || !input.latestRevision) {
+    return {
+      status: 'unknown',
+      message: `local and latest versions are both v${input.latestVersion}, but one side is missing a git revision`,
+    }
+  }
+
+  if (input.build.revision === input.latestRevision) {
+    return {
+      status: 'up-to-date',
+      message: `running latest ${input.channel} revision ${abbreviateRevision(input.latestRevision)}`,
+    }
+  }
+
+  return {
+    status: 'upgrade-available',
+    message: `channel ${input.channel} has a newer revision on the same version v${input.latestVersion}`,
+  }
+}
+
+async function resolveUpgradeTarget(
+  repo: string,
+  channel: string | null,
+  pat: string,
+): Promise<ResolvedUpgradeTarget> {
+  if (channel) {
+    return { repo, channel }
+  }
+
+  const repoRecord = await requestGitHubJson<GitHubRepoRecord>(
+    `https://api.github.com/repos/${repo}`,
+    pat,
+  )
+  const defaultBranch = typeof repoRecord.default_branch === 'string' && repoRecord.default_branch.trim().length > 0
+    ? repoRecord.default_branch.trim()
+    : 'master'
+
+  return {
+    repo,
+    channel: defaultBranch,
+  }
+}
+
+async function requestGitHubJson<T>(
+  url: string,
+  pat: string,
+): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+  }
+  if (pat) {
+    headers.Authorization = `token ${pat}`
+  }
+
+  const response = await fetch(url, { headers })
+  const body = await response.text()
+  if (!response.ok) {
+    throw new Error(`GitHub request failed (${response.status}): ${parseGitHubErrorMessage(body)}`)
+  }
+
+  return JSON.parse(body) as T
+}
+
+function extractVersionFromGitHubContent(record: GitHubContentRecord): string {
+  if (record.encoding !== 'base64' || typeof record.content !== 'string') {
+    throw new Error('remote package.json response did not contain base64 content')
+  }
+
+  const decoded = Buffer.from(record.content.replace(/\n/g, ''), 'base64').toString('utf-8')
+  const parsed = JSON.parse(decoded) as VersionFileRecord
+  if (typeof parsed.version !== 'string' || parsed.version.trim().length === 0) {
+    throw new Error('remote package.json did not include a version field')
+  }
+
+  return parsed.version.trim()
+}
+
+function parseGitHubErrorMessage(body: string): string {
+  const trimmed = body.trim()
+  if (!trimmed) return 'empty response body'
+
+  try {
+    const parsed = JSON.parse(trimmed) as { message?: unknown }
+    if (typeof parsed.message === 'string' && parsed.message.trim().length > 0) {
+      return parsed.message.trim()
+    }
+  } catch {
+    // fall through to raw body
+  }
+
+  return trimmed
+}
+
+function parseVersionParts(version: string): number[] {
+  const [core] = version.trim().split('-')
+  return (core ?? version)
+    .split('.')
+    .map((segment) => Number.parseInt(segment, 10))
+    .map((value) => (Number.isFinite(value) ? value : 0))
+}
+
+function detectGitHubRepoSlug(repoRoot: string): string | null {
+  const remoteUrl = readGitOutput(['-C', repoRoot, 'remote', 'get-url', 'origin'])
+  if (!remoteUrl) return null
+
+  const match =
+    remoteUrl.match(/github\.com[/:]([\w-]+\/[\w.-]+?)(?:\.git)?$/)
+    ?? remoteUrl.match(/^https:\/\/github\.com\/([\w-]+\/[\w.-]+?)(?:\.git)?$/)
+
+  return match?.[1] ?? null
+}
+
+function readGitOutput(args: string[]): string | null {
+  try {
+    const output = execFileSync('git', args, { encoding: 'utf-8' }).trim()
+    return output.length > 0 ? output : null
+  } catch {
+    return null
+  }
+}
+
+function normalizeOptionalString(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : fallback
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "agent:issues:audit": "bun apps/agent-daemon/src/audit-issue-contracts.ts",
     "agent:issues:enforce-ready": "bun apps/agent-daemon/src/ready-gate.ts",
     "agent:join-project": "bun apps/agent-daemon/src/index.ts --join-project",
+    "agent:version:bump": "bun scripts/bump-version.ts",
     "start": "bun run apps/agent-daemon/src/index.ts",
     "dev": "bun --watch run apps/agent-daemon/src/index.ts",
     "typecheck": "bun run --cwd packages/agent-shared typecheck && bun run --cwd apps/agent-daemon typecheck",

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -251,6 +251,9 @@ export function buildDirectGitHubApiRequest(
 ): DirectGitHubApiRequest {
   const qualifiedArgs = qualifyGhApiArgs(args, config)
   const [endpoint, ...rest] = qualifiedArgs
+  if (!endpoint) {
+    throw new Error('missing GitHub API endpoint')
+  }
   const fieldArgs: string[] = []
   let inputPath: string | null = null
   let method: DirectGitHubApiRequest['method'] = 'GET'
@@ -505,9 +508,8 @@ export function qualifyGhApiArgs(
   args: string[],
   config: Pick<AgentConfig, 'repo'>,
 ): string[] {
-  if (args.length === 0) return args
-
   const [endpoint, ...rest] = args
+  if (!endpoint) return args
   if (!shouldQualifyGhApiEndpoint(endpoint)) {
     return args
   }

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -131,6 +131,41 @@ export interface RecoveryConfig {
   leaseNoProgressTimeoutMs: number
 }
 
+export interface AgentLoopUpgradeConfig {
+  enabled: boolean
+  repo: string | null
+  channel: string | null
+  checkIntervalMs: number
+  reminderIntervalMs: number
+}
+
+export interface AgentLoopBuildMetadata {
+  repo: string | null
+  version: string
+  revision: string | null
+}
+
+export type AgentLoopUpgradeStatusKind =
+  | 'disabled'
+  | 'unknown'
+  | 'up-to-date'
+  | 'upgrade-available'
+  | 'ahead-of-channel'
+  | 'error'
+
+export interface AgentLoopUpgradeMetadata {
+  enabled: boolean
+  repo: string | null
+  channel: string | null
+  checkedAt: string | null
+  status: AgentLoopUpgradeStatusKind
+  latestVersion: string | null
+  latestRevision: string | null
+  latestCommitAt: string | null
+  safeToUpgradeNow: boolean
+  message: string | null
+}
+
 export type ManagedLeaseScope = 'issue-process' | 'pr-review' | 'pr-merge'
 export type ManagedLeaseStatus = 'active' | 'completed' | 'recoverable' | 'released'
 export type ManagedLeaseProgressKind = 'stdout' | 'stderr' | 'git-state' | 'phase'
@@ -255,6 +290,7 @@ export interface AgentConfig {
     authorName: string
     authorEmail: string
   }
+  upgrade?: AgentLoopUpgradeConfig
 }
 
 // ─── Worktree ────────────────────────────────────────────────────────────────
@@ -314,6 +350,8 @@ export interface DaemonStatus {
     primary: AgentConfig['agent']['primary']
     fallback: AgentConfig['agent']['fallback']
   }
+  agentLoop?: AgentLoopBuildMetadata
+  upgrade?: AgentLoopUpgradeMetadata
   endpoints: {
     health: {
       host: string

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env bun
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+type BumpMode = 'major' | 'minor' | 'patch' | 'set'
+
+interface PackageJsonRecord {
+  version?: unknown
+  [key: string]: unknown
+}
+
+const packageJsonPath = resolve(import.meta.dir, '..', 'package.json')
+
+function main(): void {
+  const [modeArg, valueArg] = process.argv.slice(2)
+  const mode = normalizeMode(modeArg)
+  if (!mode) {
+    throw new Error('Usage: bun scripts/bump-version.ts <major|minor|patch|set> [version]')
+  }
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJsonRecord
+  const currentVersion = readVersion(packageJson)
+  const nextVersion = mode === 'set'
+    ? parseVersion(valueArg)
+    : formatVersion(bumpVersion(parseVersion(currentVersion), mode))
+
+  packageJson.version = nextVersion
+  writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf-8')
+
+  console.log(`agent-loop version updated: ${currentVersion} -> ${nextVersion}`)
+}
+
+function normalizeMode(value: string | undefined): BumpMode | null {
+  switch (value) {
+    case 'major':
+    case 'minor':
+    case 'patch':
+    case 'set':
+      return value
+    default:
+      return null
+  }
+}
+
+function readVersion(packageJson: PackageJsonRecord): string {
+  if (typeof packageJson.version !== 'string' || packageJson.version.trim().length === 0) {
+    throw new Error('package.json does not contain a valid version field')
+  }
+
+  return packageJson.version.trim()
+}
+
+function parseVersion(input: string | undefined): [number, number, number] {
+  if (!input) {
+    throw new Error('A version value is required')
+  }
+
+  const match = input.trim().match(/^(\d+)\.(\d+)\.(\d+)$/)
+  if (!match) {
+    throw new Error(`Invalid version "${input}". Expected x.y.z`)
+  }
+
+  return [
+    Number.parseInt(match[1]!, 10),
+    Number.parseInt(match[2]!, 10),
+    Number.parseInt(match[3]!, 10),
+  ]
+}
+
+function bumpVersion(
+  [major, minor, patch]: [number, number, number],
+  mode: Exclude<BumpMode, 'set'>,
+): [number, number, number] {
+  switch (mode) {
+    case 'major':
+      return [major + 1, 0, 0]
+    case 'minor':
+      return [major, minor + 1, 0]
+    case 'patch':
+      return [major, minor, patch + 1]
+  }
+}
+
+function formatVersion([major, minor, patch]: [number, number, number]): string {
+  return `${major}.${minor}.${patch}`
+}
+
+main()


### PR DESCRIPTION
## Summary
- add a unified agent-loop version and upgrade-check module with background GitHub channel checks
- expose local build metadata, latest-channel status, and safe-to-upgrade windows in daemon health, status, doctor, presence, and dashboard views
- add a version bump command plus README guidance for multi-machine upgrade policy

## Verification
- `bun test apps/agent-daemon/src/version.test.ts apps/agent-daemon/src/presence.test.ts apps/agent-daemon/src/status.test.ts apps/agent-daemon/src/config.test.ts apps/agent-daemon/src/dashboard.test.ts`
- `bun run typecheck`
