### PR TITLE
fix: resume execution-failed PR reviews automatically

### DIFF
--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -526,7 +526,12 @@ export class AgentDaemon {
   private isRecoverableAgentFailureKind(
     failureKind: string | undefined,
   ): boolean {
-    return failureKind === 'idle_timeout'
+    return (
+      failureKind === 'idle_timeout'
+      || failureKind === 'process_timeout'
+      || failureKind === 'execution_error'
+      || failureKind === 'nonzero_exit'
+    )
   }
 
   private async markIssueRecoverable(issueNumber: number, reason: string): Promise<void> {

--- a/apps/agent-daemon/src/pr-reviewer.test.ts
+++ b/apps/agent-daemon/src/pr-reviewer.test.ts
@@ -417,6 +417,37 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
     expect(getNextAutomatedPrReviewAttempt(comments)).toBe(3)
   })
 
+  test('resumes standalone review when the latest human-needed comment is an execution failure', () => {
+    const comments = [
+      {
+        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":2,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
+## Automated review still failing — human intervention required
+
+- Attempt: 2
+- Merge ready: no
+- Reason: Review failed: ReviewAgentExecutionError: Agent exited with code 1: unexpected status 502 Bad Gateway`,
+      },
+    ]
+
+    expect(canResumeAutomatedPrReview(comments, 3)).toBe(false)
+    expect(canResumeHumanNeededPrReview(comments, 3, 'abc123', null)).toBe(true)
+  })
+
+  test('does not resume standalone review when the latest human-needed comment is invalid output', () => {
+    const comments = [
+      {
+        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":2,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
+## Automated review still failing — human intervention required
+
+- Attempt: 2
+- Merge ready: no
+- Reason: Review output failed validation: missing mustFix`,
+      },
+    ]
+
+    expect(canResumeHumanNeededPrReview(comments, 3, 'abc123', null)).toBe(false)
+  })
+
   test('restarts standalone review when a terminal human-needed PR has a new head commit', () => {
     const comments = [
       {

--- a/apps/agent-daemon/src/pr-reviewer.ts
+++ b/apps/agent-daemon/src/pr-reviewer.ts
@@ -604,10 +604,28 @@ export function canResumeHumanNeededPrReview(
   issueBody: string | null | undefined,
 ): boolean {
   return (
-    canResumeAutomatedPrReview(comments, maxAttempt)
+    didLatestAutomatedPrReviewExecutionFail(comments)
+    || canResumeAutomatedPrReview(comments, maxAttempt)
     || shouldRestartAutomatedPrReviewOnNewHead(comments, currentHeadRefOid)
     || shouldRestartAutomatedPrReviewOnIssueUpdate(comments, issueBody)
   )
+}
+
+export function didLatestAutomatedPrReviewExecutionFail(
+  comments: AutomatedPrReviewCommentLike[],
+): boolean {
+  for (let index = comments.length - 1; index >= 0; index -= 1) {
+    const body = comments[index]?.body ?? ''
+    const metadata = extractAutomatedPrReviewMetadata(body)
+    if (!metadata) continue
+    if (metadata.approved || metadata.canMerge) return false
+    if (extractStructuredReviewFeedback(body) !== null) return false
+
+    const reason = extractLegacyAutomatedPrReviewReason(body)
+    return reason?.startsWith('Review failed:') ?? false
+  }
+
+  return false
 }
 
 export function getReusableAutomatedPrReviewFeedback(


### PR DESCRIPTION
## Summary
- treat review subagent execution failures as recoverable instead of terminal human-needed states
- allow legacy human-needed PRs whose latest automated review comment is a `Review failed:` execution failure to resume automatically
- add reviewer tests covering resumable execution failures vs non-resumable invalid output

## Verification
- `bun test apps/agent-daemon/src/pr-reviewer.test.ts`
- `bun run typecheck`
- `bun test apps/agent-daemon/src/pr-reviewer.test.ts apps/agent-daemon/src/version.test.ts apps/agent-daemon/src/status.test.ts apps/agent-daemon/src/config.test.ts apps/agent-daemon/src/dashboard.test.ts`  
  Note: two pre-existing timeout flakes remain in `status.test.ts` and `pr-reviewer.test.ts` unrelated to this change.