### PR TITLE
feat: stabilize single-repo multi-machine automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,13 +407,14 @@ agent-loop --doctor
 
 ## Agent Loop Upgrade Channel
 
-agent-loop 现在内置了一套“非打断式升级提醒”机制，目标是让参与开发的多台机器尽量在空闲窗口升级，而不是在执行 issue 过程中被打断。
+agent-loop 现在内置了一套“多机感知 + 空闲自升级”机制，目标是让参与开发的多台机器在发现新版本后尽快同步到最新版，并在升级完成后继续投入开发。
 
 默认行为：
 
 - daemon 会后台检查 `agent-loop` 自身仓库的目标 channel 最新版本与 commit
 - `--status` / `--doctor` / `/health` 会显示本机 `agent-loop` 的本地版本、revision、upgrade 状态
 - GitHub presence 心跳也会上报这些字段，所以 dashboard 和远端机器视图能直接看出谁落后、谁现在空闲可升
+- 任意一台机器发现新版本后，会在 shared presence registry 里广播一个 upgrade announcement；其他机器会在下一次 presence 心跳周期内强制刷新本地 upgrade 状态，而不是死等自己的 `checkIntervalMs`
 - 只有在 daemon 当前没有 startup recovery、active worktree、active lease、in-flight issue/review task 时，才会把 `safeToUpgradeNow` 标记为 `true`
 
 默认策略可以在 `~/.agent-loop/config.json` 里配置：
@@ -426,7 +427,7 @@ agent-loop 现在内置了一套“非打断式升级提醒”机制，目标是
     "channel": "master",
     "checkIntervalMs": 900000,
     "reminderIntervalMs": 3600000,
-    "autoApply": true
+    "autoApply": false
   }
 }
 ```
@@ -438,7 +439,7 @@ agent-loop 现在内置了一套“非打断式升级提醒”机制，目标是
 - `channel`：跟踪的分支；不填时默认取目标仓库 default branch
 - `checkIntervalMs`：后台检查最新版本的最小间隔
 - `reminderIntervalMs`：升级提醒日志的冷却时间，避免刷屏
-- `autoApply`：当本机 daemon 空闲且当前 poll 轮次也没有领到新活时，是否自动执行升级并重启托管 runtime
+- `autoApply`：默认关闭；当本机 daemon 已空闲且本轮 poll 最终没有领到新活时，是否自动执行升级并重启托管 runtime
 
 版本发布时，统一用下面的命令 bump 根版本号，避免手改：
 
@@ -449,13 +450,7 @@ bun run agent:version:bump major
 bun run agent:version:bump set 0.2.0
 ```
 
-建议的升级执行原则：
-
-- 当 `upgrade.status=upgrade-available` 且 `safeToUpgradeNow=true` 时，再重启 daemon 升级
-- 如果 daemon 仍在处理 worktree / lease / review，先继续消费，等它回到 idle 再升
-- 多机部署时，以 dashboard / presence 里显示的升级状态为准，不要求所有机器同时强制重启
-
-如果把 `upgrade.autoApply=true` 打开，daemon 会在满足 `safeToUpgradeNow=true` 且本轮 poll 最终没有启动任何新任务时，自动执行下面的本地升级流程：
+开启 `upgrade.autoApply=true` 后，daemon 会在满足 `safeToUpgradeNow=true` 且本轮 poll 最终没有启动任何新任务时，自动执行下面的升级流程：
 
 - 在本地 `agent-loop` checkout 上执行 `git pull --ff-only origin <channel>`
 - 执行 `bun install --frozen-lockfile`

--- a/README.md
+++ b/README.md
@@ -64,6 +64,42 @@ agent-loop --launchd-install --health-port 9311 --metrics-port 9091
 agent-loop --once
 ```
 
+## Single-Repo Multi-Machine Mode
+
+当前这一版的重点不是“模仿 OpenHands”，而是把“多台机器协同开发同一个仓库”做稳定：
+
+- 显式调度优先级：给 issue 加 `agent:priority-high` 或 `agent:priority-low`；未打标的 issue 走默认优先级。claim 顺序固定为 `high > default > low`，同优先级内再按更早的 `updatedAt` 和更小的 issue number 稳定排序。
+- 低延迟唤醒：除了周期性 polling，还可以主动唤醒本机 daemon。
+
+```bash
+agent-loop --wake-now
+agent-loop --wake-issue 123
+agent-loop --wake-pr 456
+```
+
+这些 wake request 会先落到本地 durable queue，再由 daemon 在启动时和空闲期间消费，所以即使 loopback notify 失败，也不会直接丢信号。默认路径：
+
+```text
+~/.agent-loop/wake-queue/{owner-repo}/{machineId}.jsonl
+```
+
+- 离线回放评估：daemon 行为变更可以用 fixture 目录做 replay/eval，而不是只靠手工盯日志。
+
+```bash
+bun run agent:replay:eval -- --fixtures-dir apps/agent-daemon/src/fixtures/replay
+```
+
+- 人机接力恢复：如果某个 failed issue 被关联 PR 的 `agent:human-needed` 状态卡住，可以在 issue 评论区写入一个更新、更晚的 resolution comment，daemon 就会在下一次 reconcile 尝试恢复。
+
+```md
+<!-- agent-loop:issue-resume-resolved {"issueNumber":104,"prNumber":205,"resolvedAt":"2026-04-11T09:10:00.000Z","resolution":"manual fix applied and ready for daemon retry"} -->
+## agent-loop issue resume resolution
+
+This blocked failed issue has a matching manual resolution signal and may be retried.
+```
+
+这个 resolution signal 必须发在 issue comment，不是 PR comment。`agent-loop --status` 和 `agent-loop --doctor` 也会把它识别出来并报告出来。
+
 ## Self-Hosting（用 Agent Loop 开发 Agent Loop）
 
 Issue body format is defined in [docs/issue-writing.md](docs/issue-writing.md).

--- a/README.md
+++ b/README.md
@@ -425,7 +425,8 @@ agent-loop 现在内置了一套“非打断式升级提醒”机制，目标是
     "repo": "JamesWuHK/agent-loop",
     "channel": "master",
     "checkIntervalMs": 900000,
-    "reminderIntervalMs": 3600000
+    "reminderIntervalMs": 3600000,
+    "autoApply": true
   }
 }
 ```
@@ -437,6 +438,7 @@ agent-loop 现在内置了一套“非打断式升级提醒”机制，目标是
 - `channel`：跟踪的分支；不填时默认取目标仓库 default branch
 - `checkIntervalMs`：后台检查最新版本的最小间隔
 - `reminderIntervalMs`：升级提醒日志的冷却时间，避免刷屏
+- `autoApply`：当本机 daemon 空闲且当前 poll 轮次也没有领到新活时，是否自动执行升级并重启托管 runtime
 
 版本发布时，统一用下面的命令 bump 根版本号，避免手改：
 
@@ -452,6 +454,19 @@ bun run agent:version:bump set 0.2.0
 - 当 `upgrade.status=upgrade-available` 且 `safeToUpgradeNow=true` 时，再重启 daemon 升级
 - 如果 daemon 仍在处理 worktree / lease / review，先继续消费，等它回到 idle 再升
 - 多机部署时，以 dashboard / presence 里显示的升级状态为准，不要求所有机器同时强制重启
+
+如果把 `upgrade.autoApply=true` 打开，daemon 会在满足 `safeToUpgradeNow=true` 且本轮 poll 最终没有启动任何新任务时，自动执行下面的本地升级流程：
+
+- 在本地 `agent-loop` checkout 上执行 `git pull --ff-only origin <channel>`
+- 执行 `bun install --frozen-lockfile`
+- `detached` runtime 会自举拉起新版后台进程，再退出旧进程
+- `launchd` runtime 会优雅退出，让 launchd 自动拉起新版
+
+保守限制：
+
+- 只对托管 runtime 生效；`direct` 模式仍保持提醒，不会擅自接管你当前终端
+- 本地 `agent-loop` checkout 有未提交改动时不会自动升级
+- 当前 checkout 分支必须和配置的 `channel` 一致，避免开发分支被自动切回稳定分支
 
 ## Key Design Decisions
 

--- a/apps/agent-daemon/package.json
+++ b/apps/agent-daemon/package.json
@@ -11,6 +11,7 @@
     "start": "bun run src/index.ts",
     "dev": "bun --watch run src/index.ts",
     "issues:audit": "bun run src/audit-issue-contracts.ts",
+    "replay:eval": "bun run src/replay-eval.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test"
   },

--- a/apps/agent-daemon/src/claimer.test.ts
+++ b/apps/agent-daemon/src/claimer.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  ISSUE_LABELS,
+  ISSUE_PRIORITY_LABELS,
+  sortClaimableIssuesForScheduling,
+  type AgentConfig,
+  type AgentIssue,
+} from '@agent/shared'
+import { pollAndClaim, type ClaimerDependencies } from './claimer'
+
+function buildConfig(): AgentConfig {
+  return {
+    machineId: 'machine-a',
+    repo: 'JamesWuHK/agent-loop',
+    pat: '',
+    pollIntervalMs: 30_000,
+    concurrency: 1,
+    requestedConcurrency: 1,
+    concurrencyPolicy: {
+      requested: 1,
+      effective: 1,
+      repoCap: null,
+      profileCap: null,
+      projectCap: null,
+    },
+    scheduling: {
+      concurrencyByRepo: {},
+      concurrencyByProfile: {},
+    },
+    recovery: {
+      heartbeatIntervalMs: 30_000,
+      leaseTtlMs: 120_000,
+      workerIdleTimeoutMs: 600_000,
+      leaseAdoptionBackoffMs: 30_000,
+      leaseNoProgressTimeoutMs: 300_000,
+    },
+    worktreesBase: '/tmp/agent-loop',
+    project: {
+      profile: 'generic',
+    },
+    agent: {
+      primary: 'codex',
+      fallback: null,
+      claudePath: 'claude',
+      codexPath: 'codex',
+      timeoutMs: 1_800_000,
+    },
+    git: {
+      defaultBranch: 'main',
+      authorName: 'Agent Loop',
+      authorEmail: 'agent-loop@example.com',
+    },
+  }
+}
+
+function buildIssue(input: Partial<AgentIssue> & Pick<AgentIssue, 'number'>): AgentIssue {
+  const { number, ...rest } = input
+
+  return {
+    number,
+    title: `issue-${number}`,
+    body: '',
+    state: 'ready',
+    labels: [ISSUE_LABELS.READY],
+    assignee: null,
+    isClaimable: true,
+    updatedAt: '2026-04-11T08:00:00.000Z',
+    dependencyIssueNumbers: [],
+    hasDependencyMetadata: true,
+    dependencyParseError: false,
+    claimBlockedBy: [],
+    hasExecutableContract: true,
+    contractValidationErrors: [],
+    ...rest,
+  }
+}
+
+function buildDependencies(
+  issues: AgentIssue[],
+  claimIssue: ClaimerDependencies['claimIssue'],
+): ClaimerDependencies {
+  return {
+    fetchClaimableIssues: async () => issues,
+    claimIssue,
+    sortClaimableIssuesForScheduling,
+    recordClaim: () => {},
+    sleep: async () => {},
+    random: () => 0,
+  }
+}
+
+describe('pollAndClaim', () => {
+  test('tries claimable issues in scheduling priority order before claiming', async () => {
+    const claimAttempts: number[] = []
+    const issues = [
+      buildIssue({ number: 14 }),
+      buildIssue({ number: 13, labels: [ISSUE_LABELS.READY, ISSUE_PRIORITY_LABELS.LOW] }),
+      buildIssue({
+        number: 12,
+        labels: [ISSUE_LABELS.READY, ISSUE_PRIORITY_LABELS.HIGH],
+        updatedAt: '2026-04-11T08:05:00.000Z',
+      }),
+      buildIssue({
+        number: 11,
+        labels: [ISSUE_LABELS.READY, ISSUE_PRIORITY_LABELS.HIGH],
+        updatedAt: '2026-04-11T08:01:00.000Z',
+      }),
+    ]
+
+    const claimed = await pollAndClaim(
+      buildConfig(),
+      {
+        log: () => {},
+        warn: () => {},
+        error: () => {},
+      } as typeof console,
+      buildDependencies(issues, async (issueNumber) => {
+        claimAttempts.push(issueNumber)
+        if (issueNumber === 11) {
+          return { success: false, issueNumber, reason: 'already-claimed' }
+        }
+        if (issueNumber === 12) {
+          return { success: true, issueNumber, reason: 'claimed' }
+        }
+        return { success: false, issueNumber, reason: 'already-claimed' }
+      }),
+    )
+
+    expect(claimAttempts).toEqual([11, 12])
+    expect(claimed?.number).toBe(12)
+  })
+})

--- a/apps/agent-daemon/src/claimer.ts
+++ b/apps/agent-daemon/src/claimer.ts
@@ -1,9 +1,27 @@
 import type { AgentConfig, AgentIssue } from '@agent/shared'
-import { fetchClaimableIssues, claimIssue } from '@agent/shared'
+import { fetchClaimableIssues, claimIssue, sortClaimableIssuesForScheduling } from '@agent/shared'
 import { recordClaim } from './metrics'
 
 const BASE_DELAY_MS = 1000
 const MAX_ATTEMPTS = 3
+
+export interface ClaimerDependencies {
+  fetchClaimableIssues: typeof fetchClaimableIssues
+  claimIssue: typeof claimIssue
+  sortClaimableIssuesForScheduling: typeof sortClaimableIssuesForScheduling
+  recordClaim: typeof recordClaim
+  sleep: (ms: number) => Promise<void>
+  random: () => number
+}
+
+const DEFAULT_CLAIMER_DEPENDENCIES: ClaimerDependencies = {
+  fetchClaimableIssues,
+  claimIssue,
+  sortClaimableIssuesForScheduling,
+  recordClaim,
+  sleep,
+  random: () => Math.random(),
+}
 
 export interface ClaimAttempt {
   issueNumber: number
@@ -18,12 +36,13 @@ export interface ClaimAttempt {
 export async function pollAndClaim(
   config: AgentConfig,
   logger = console,
+  dependencies: ClaimerDependencies = DEFAULT_CLAIMER_DEPENDENCIES,
 ): Promise<AgentIssue | null> {
   logger.log(`[claimer] polling for claimable issues...`)
 
   let issues: AgentIssue[]
   try {
-    issues = await fetchClaimableIssues(config)
+    issues = await dependencies.fetchClaimableIssues(config)
   } catch (err) {
     logger.error(`[claimer] failed to fetch issues:`, err)
     return null
@@ -36,16 +55,23 @@ export async function pollAndClaim(
 
   logger.log(`[claimer] found ${issues.length} claimable issues`)
 
+  const orderedIssues = dependencies.sortClaimableIssuesForScheduling(issues)
+
   // Try each issue in order with retry + jitter
-  for (const issue of issues) {
-    const claimed: boolean | 'rate-limited' = await claimWithRetry(issue.number, config, logger)
+  for (const issue of orderedIssues) {
+    const claimed: boolean | 'rate-limited' = await claimWithRetry(
+      issue.number,
+      config,
+      logger,
+      dependencies,
+    )
     if (claimed === true) {
       return issue
     }
     // If rate-limited, wait and retry the whole poll cycle
     if (claimed === 'rate-limited') {
       logger.warn(`[claimer] rate limited, waiting before retry...`)
-      await sleep(30_000)
+      await dependencies.sleep(30_000)
       return null
     }
     // false (already-claimed) → try next issue
@@ -61,36 +87,37 @@ async function claimWithRetry(
   issueNumber: number,
   config: AgentConfig,
   logger: typeof console,
+  dependencies: ClaimerDependencies,
 ): Promise<boolean | 'rate-limited'> {
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
-      const result = await claimIssue(issueNumber, config, config.machineId)
+      const result = await dependencies.claimIssue(issueNumber, config, config.machineId)
 
       if (result.success) {
         logger.log(`[claimer] claimed issue #${issueNumber}`)
-        recordClaim('claimed')
+        dependencies.recordClaim('claimed')
         return true
       }
 
       if (result.reason === 'already-claimed') {
         logger.log(`[claimer] issue #${issueNumber} already claimed by another machine`)
-        recordClaim('already_claimed')
+        dependencies.recordClaim('already_claimed')
         return false
       }
 
       if (result.reason === 'rate-limited') {
-        recordClaim('rate_limited')
+        dependencies.recordClaim('rate_limited')
         return 'rate-limited'
       }
     } catch (err) {
       logger.error(`[claimer] claim attempt ${attempt} failed:`, err)
-      recordClaim('error')
+      dependencies.recordClaim('error')
     }
 
     if (attempt < MAX_ATTEMPTS) {
-      const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1) + Math.random() * 500
+      const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1) + dependencies.random() * 500
       logger.log(`[claimer] retrying #${issueNumber} in ${Math.round(delay)}ms...`)
-      await sleep(delay)
+      await dependencies.sleep(delay)
     }
   }
 

--- a/apps/agent-daemon/src/config.test.ts
+++ b/apps/agent-daemon/src/config.test.ts
@@ -138,7 +138,32 @@ describe('buildConfig', () => {
       channel: null,
       checkIntervalMs: 900_000,
       reminderIntervalMs: 3_600_000,
+      autoApply: false,
     })
+  })
+
+  test('allows home config to opt into automatic agent-loop upgrades', () => {
+    const config = buildConfig(
+      {},
+      {
+        fileConfig: {
+          ...baseFileConfig,
+          upgrade: {
+            enabled: true,
+            repo: 'JamesWuHK/agent-loop',
+            channel: 'master',
+            checkIntervalMs: 900_000,
+            reminderIntervalMs: 3_600_000,
+            autoApply: true,
+          },
+        },
+        repoConfig: {},
+        env: {},
+        homeDir: '/tmp/agent-loop-home',
+      },
+    )
+
+    expect(config.upgrade?.autoApply).toBe(true)
   })
 
   test('allows repo-local config to disable agent fallback explicitly', () => {

--- a/apps/agent-daemon/src/config.ts
+++ b/apps/agent-daemon/src/config.ts
@@ -230,6 +230,7 @@ export function buildConfig(
         fileConfig.upgrade?.reminderIntervalMs,
         DEFAULT_AGENT_LOOP_UPGRADE_REMINDER_INTERVAL_MS,
       ),
+      autoApply: fileConfig.upgrade?.autoApply === true,
     },
   }
 

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -5,11 +5,14 @@ import { join } from 'node:path'
 import type { AgentConfig, ManagedLeaseComment } from '@agent/shared'
 import {
   AgentDaemon,
+  WAKE_PATH,
   buildIssueWorkingTransitionEvent,
   buildBlockedIssueResumeEscalationComment,
+  buildIssueResumeResolutionComment,
   buildDaemonRuntimeStatus,
   buildIssuePreflightFailureComment,
   buildPrReviewRefreshFailureComment,
+  canResumeBlockedIssueFromResolution,
   canRetryPrReviewRefresh,
   canResumeIssueFromLease,
   getEffectiveActiveTaskCount,
@@ -17,6 +20,7 @@ import {
   createWorktreeFromRemoteBranch,
   extractAutomatedIssuePreflightReasons,
   extractBlockedIssueResumeEscalationComment,
+  extractIssueResumeResolutionComment,
   getResumableIssueLinkedPrHandoff,
   getFailedIssueResumeBlock,
   isMissingRemoteBranchRecoveryReason,
@@ -42,8 +46,15 @@ import {
   shouldResumeManagedIssue,
 } from './daemon'
 import { ISSUE_LABELS, PR_REVIEW_LABELS } from '@agent/shared'
+import { appendWakeRequest, buildWakeQueuePath } from './wake-queue'
 
-function createTestDaemon(configOverrides: Partial<AgentConfig> = {}): AgentDaemon {
+function createTestDaemon(
+  configOverrides: Partial<AgentConfig> = {},
+  healthServerConfig?: {
+    host?: string
+    port?: number
+  },
+): AgentDaemon {
   const config: AgentConfig = {
     machineId: 'codex-dev',
     repo: 'JamesWuHK/digital-employee',
@@ -88,7 +99,7 @@ function createTestDaemon(configOverrides: Partial<AgentConfig> = {}): AgentDaem
     ...configOverrides,
   }
 
-  return new AgentDaemon(config, console)
+  return new AgentDaemon(config, console, healthServerConfig)
 }
 
 async function createResumableIssueWorktreeFixture(issueNumber = 329, machineId = 'codex-20260403') {
@@ -164,6 +175,74 @@ describe('issue preflight comments', () => {
     ])).toEqual([
       'Issue preflight failed before PR creation: changed forbidden files: apps/desktop/src/App.tsx',
     ])
+  })
+})
+
+describe('wake queue integration', () => {
+  test('drains queued wake requests and forces the next reconcile immediately', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'agent-loop-daemon-wake-'))
+    const queuePath = buildWakeQueuePath({
+      homeDir,
+      repo: 'JamesWuHK/agent-loop',
+      machineId: 'codex-dev',
+    })
+
+    appendWakeRequest(queuePath, {
+      kind: 'now',
+      reason: 'workflow_dispatch',
+      sourceEvent: 'workflow_dispatch',
+      dedupeKey: 'wake-now',
+      requestedAt: '2026-04-11T09:10:00.000Z',
+    })
+
+    const daemon = createTestDaemon({
+      repo: 'JamesWuHK/agent-loop',
+      machineId: 'codex-dev',
+      worktreesBase: join(homeDir, 'worktrees'),
+    })
+
+    await daemon.drainWakeQueueOnce()
+
+    const status = daemon.getStatus()
+    expect(status.nextPollReason).toBe('wake-request')
+    expect(status.nextPollDelayMs).toBe(0)
+    expect(existsSync(queuePath)).toBe(false)
+  })
+
+  test('loopback wake endpoint forces the next reconcile immediately', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'agent-loop-daemon-wake-endpoint-'))
+    const daemon = createTestDaemon({
+      repo: 'JamesWuHK/agent-loop',
+      machineId: 'codex-dev',
+      worktreesBase: join(homeDir, 'worktrees'),
+    }, {
+      port: 0,
+    })
+    const daemonInternal = daemon as unknown as {
+      running: boolean
+      pollTimeoutId: ReturnType<typeof setTimeout> | null
+      healthServer: { port: number } | null
+      startHealthServer: () => void
+      scheduleNextPoll: (options?: {
+        delayMs?: number
+        reason?: string
+      }) => void
+    }
+
+    daemonInternal.running = true
+    daemonInternal.pollTimeoutId = setTimeout(() => undefined, 60_000)
+    daemonInternal.scheduleNextPoll = () => undefined
+    daemonInternal.startHealthServer()
+
+    const response = await fetch(`http://127.0.0.1:${daemonInternal.healthServer!.port}${WAKE_PATH}`, {
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(202)
+    expect(daemon.getStatus().nextPollReason).toBe('wake-request')
+    expect(daemon.getStatus().nextPollDelayMs).toBe(0)
+
+    await daemon.stop()
   })
 })
 
@@ -603,6 +682,95 @@ describe('daemon merge recovery helpers', () => {
       machineId: 'codex-dev',
       daemonInstanceId: 'daemon-codex-dev-1',
     })
+  })
+
+  test('round-trips blocked issue resume resolution comments', () => {
+    const comment = buildIssueResumeResolutionComment({
+      issueNumber: 91,
+      prNumber: 110,
+      resolvedAt: '2026-04-11T08:25:00.000Z',
+      resolution: 'human-follow-up-complete',
+    })
+
+    expect(extractIssueResumeResolutionComment(comment)).toEqual({
+      issueNumber: 91,
+      prNumber: 110,
+      resolvedAt: '2026-04-11T08:25:00.000Z',
+      resolution: 'human-follow-up-complete',
+    })
+  })
+
+  test('unblocks only when a newer matching resolution comment exists', () => {
+    const blockedComment = {
+      commentId: 1,
+      createdAt: '2026-04-11T08:10:00.000Z',
+      updatedAt: '2026-04-11T08:10:00.000Z',
+      body: buildBlockedIssueResumeEscalationComment({
+        issueNumber: 91,
+        prNumber: 110,
+        blockedSince: '2026-04-11T08:00:00.000Z',
+        escalatedAt: '2026-04-11T08:10:00.000Z',
+        thresholdSeconds: 300,
+        reason: 'linked PR #110 is in terminal agent:human-needed; automated review has no remaining structured retry path',
+        machineId: 'codex-dev',
+        daemonInstanceId: 'daemon-1',
+      }),
+    }
+
+    const resolutionComment = {
+      commentId: 2,
+      createdAt: '2026-04-11T08:25:00.000Z',
+      updatedAt: '2026-04-11T08:25:00.000Z',
+      body: buildIssueResumeResolutionComment({
+        issueNumber: 91,
+        prNumber: 110,
+        resolvedAt: '2026-04-11T08:25:00.000Z',
+        resolution: 'human-follow-up-complete',
+      }),
+    }
+
+    expect(canResumeBlockedIssueFromResolution(
+      [blockedComment, resolutionComment],
+      91,
+      110,
+    )).toBe(true)
+
+    expect(canResumeBlockedIssueFromResolution(
+      [
+        blockedComment,
+        {
+          ...resolutionComment,
+          commentId: 3,
+          updatedAt: '2026-04-11T08:05:00.000Z',
+          body: buildIssueResumeResolutionComment({
+            issueNumber: 91,
+            prNumber: 110,
+            resolvedAt: '2026-04-11T08:05:00.000Z',
+            resolution: 'too-early',
+          }),
+        },
+      ],
+      91,
+      110,
+    )).toBe(false)
+
+    expect(canResumeBlockedIssueFromResolution(
+      [
+        blockedComment,
+        {
+          ...resolutionComment,
+          commentId: 4,
+          body: buildIssueResumeResolutionComment({
+            issueNumber: 91,
+            prNumber: 111,
+            resolvedAt: '2026-04-11T08:25:00.000Z',
+            resolution: 'wrong-pr',
+          }),
+        },
+      ],
+      91,
+      110,
+    )).toBe(false)
   })
 
   test('finds blocked issue resume escalations for the same issue and linked PR', () => {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -46,6 +46,7 @@ import {
   shouldResumeManagedIssue,
 } from './daemon'
 import { ISSUE_LABELS, PR_REVIEW_LABELS } from '@agent/shared'
+import { buildManagedDaemonUpgradeAnnouncementComment } from './presence'
 import { appendWakeRequest, buildWakeQueuePath } from './wake-queue'
 
 function createTestDaemon(
@@ -246,7 +247,52 @@ describe('wake queue integration', () => {
   })
 })
 
-describe('agent-loop auto upgrade', () => {
+describe('agent-loop upgrade coordination', () => {
+  test('refreshes upgrade status and wakes the scheduler when a newer remote upgrade announcement appears', async () => {
+    const daemon = createTestDaemon({
+      upgrade: {
+        enabled: true,
+        repo: 'JamesWuHK/agent-loop',
+        channel: 'master',
+        checkIntervalMs: 60_000,
+        reminderIntervalMs: 3_600_000,
+        autoApply: false,
+      },
+    })
+
+    let refreshes = 0
+    let immediateReason: string | null = null
+
+    ;(daemon as any).ensurePresenceIssueNumber = async () => 500
+    ;(daemon as any).listPresenceRegistryComments = async () => [{
+      commentId: 11,
+      body: buildManagedDaemonUpgradeAnnouncementComment({
+        repo: 'JamesWuHK/digital-employee',
+        channel: 'master',
+        latestVersion: '0.1.2',
+        latestRevision: '2222222222222222222222222222222222222222',
+        latestCommitAt: '2026-04-11T09:10:00.000Z',
+        announcedAt: '2026-04-11T09:10:10.000Z',
+        announcedByMachineId: 'machine-b',
+        announcedByDaemonInstanceId: 'daemon-b',
+      }),
+      createdAt: '2026-04-11T09:10:10.000Z',
+      updatedAt: '2026-04-11T09:10:10.000Z',
+    }]
+    ;(daemon as any).maybeRefreshAgentLoopUpgradeStatus = async (force: boolean) => {
+      refreshes += force ? 1 : 0
+    }
+    ;(daemon as any).requestImmediateReconcile = (reason: string) => {
+      immediateReason = reason
+    }
+
+    await (daemon as any).maybeProcessRemoteUpgradeAnnouncement()
+    await (daemon as any).maybeProcessRemoteUpgradeAnnouncement()
+
+    expect(refreshes).toBe(1)
+    expect(immediateReason as string | null).toBe('agent-loop-upgrade')
+  })
+
   test('attempts automatic self-upgrade after an idle no-issues poll when enabled', async () => {
     const daemon = createTestDaemon({
       upgrade: {
@@ -283,11 +329,11 @@ describe('agent-loop auto upgrade', () => {
       channel: 'master',
       checkedAt: '2026-04-11T11:00:00.000Z',
       status: 'upgrade-available',
-      latestVersion: '0.1.1',
+      latestVersion: '0.1.2',
       latestRevision: '2222222222222222222222222222222222222222',
       latestCommitAt: '2026-04-11T10:59:30.000Z',
       safeToUpgradeNow: true,
-      message: 'channel master is newer: local v0.1.0, latest v0.1.1',
+      message: 'channel master is newer: local v0.1.0, latest v0.1.2',
     }
 
     await (daemon as any).pollCycle()

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -298,6 +298,41 @@ describe('agent-loop auto upgrade', () => {
 })
 
 describe('daemon merge recovery helpers', () => {
+  test('skips deferred resumable issue handoffs and keeps scanning for another local resume candidate', async () => {
+    const daemon = createTestDaemon({ concurrency: 2 }) as any
+    const seen: number[] = []
+    const started: number[] = []
+    const candidate330 = {
+      issue: { number: 330 },
+      priorLease: null,
+      requiresRemoteAdoption: false,
+    }
+    const candidate348 = {
+      issue: { number: 348 },
+      priorLease: null,
+      requiresRemoteAdoption: false,
+    }
+
+    daemon.findResumableIssue = async (skipIssueNumbers: ReadonlySet<number> = new Set<number>()) => {
+      if (!skipIssueNumbers.has(330)) return candidate330
+      if (!skipIssueNumbers.has(348)) return candidate348
+      return null
+    }
+    daemon.shouldPreferLinkedPrHandoff = async (candidate: { issue: { number: number } }) => {
+      seen.push(candidate.issue.number)
+      return candidate.issue.number === 330
+    }
+    daemon.processResumableIssue = async (candidate: { issue: { number: number } }) => {
+      started.push(candidate.issue.number)
+    }
+
+    await expect(daemon.maybeStartResumableIssue()).resolves.toBe(true)
+    await Promise.resolve()
+
+    expect(seen).toEqual([330, 348])
+    expect(started).toEqual([348])
+  })
+
   test('skips duplicate claimed comments when a freshly claimed issue enters working', () => {
     expect(buildIssueWorkingTransitionEvent('fresh-claim', 'codex-dev')).toBeNull()
   })

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -246,6 +246,57 @@ describe('wake queue integration', () => {
   })
 })
 
+describe('agent-loop auto upgrade', () => {
+  test('attempts automatic self-upgrade after an idle no-issues poll when enabled', async () => {
+    const daemon = createTestDaemon({
+      upgrade: {
+        enabled: true,
+        repo: 'JamesWuHK/agent-loop',
+        channel: 'master',
+        checkIntervalMs: 60_000,
+        reminderIntervalMs: 3_600_000,
+        autoApply: true,
+      },
+    })
+
+    let scheduledPolls = 0
+    let autoUpgradeAttempts = 0
+
+    ;(daemon as any).running = true
+    ;(daemon as any).startupRecoveryPending = false
+    ;(daemon as any).maybeStartResumableIssue = async () => false
+    ;(daemon as any).maybeStartStandaloneApprovedPrMerge = async () => false
+    ;(daemon as any).maybeRequeueFailedIssue = async () => false
+    ;(daemon as any).maybeStartClaimedIssue = async () => false
+    ;(daemon as any).maybeStartStandalonePrReview = async () => false
+    ;(daemon as any).maybeRefreshAgentLoopUpgradeStatus = async () => {}
+    ;(daemon as any).performAutomaticAgentLoopUpgrade = async () => {
+      autoUpgradeAttempts += 1
+      return true
+    }
+    ;(daemon as any).scheduleNextPoll = () => {
+      scheduledPolls += 1
+    }
+    ;(daemon as any).agentLoopUpgrade = {
+      enabled: true,
+      repo: 'JamesWuHK/agent-loop',
+      channel: 'master',
+      checkedAt: '2026-04-11T11:00:00.000Z',
+      status: 'upgrade-available',
+      latestVersion: '0.1.1',
+      latestRevision: '2222222222222222222222222222222222222222',
+      latestCommitAt: '2026-04-11T10:59:30.000Z',
+      safeToUpgradeNow: true,
+      message: 'channel master is newer: local v0.1.0, latest v0.1.1',
+    }
+
+    await (daemon as any).pollCycle()
+
+    expect(autoUpgradeAttempts).toBe(1)
+    expect(scheduledPolls).toBe(0)
+  })
+})
+
 describe('daemon merge recovery helpers', () => {
   test('skips duplicate claimed comments when a freshly claimed issue enters working', () => {
     expect(buildIssueWorkingTransitionEvent('fresh-claim', 'codex-dev')).toBeNull()

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -1180,9 +1180,13 @@ export class AgentDaemon {
   }
 
   private async maybeStartResumableIssue(): Promise<boolean> {
-    const resumableIssue = await this.findResumableIssue()
+    const deferredIssueNumbers = new Set<number>()
+    let resumableIssue = await this.findResumableIssue(deferredIssueNumbers)
+    while (resumableIssue && await this.shouldPreferLinkedPrHandoff(resumableIssue)) {
+      deferredIssueNumbers.add(resumableIssue.issue.number)
+      resumableIssue = await this.findResumableIssue(deferredIssueNumbers)
+    }
     if (!resumableIssue) return false
-    if (await this.shouldPreferLinkedPrHandoff(resumableIssue)) return false
 
     this.activeIssueProcesses.add(resumableIssue.issue.number)
     const processPromise = this.processResumableIssue(resumableIssue)
@@ -1330,7 +1334,9 @@ export class AgentDaemon {
     )
   }
 
-  private async findResumableIssue(): Promise<ResumableIssueCandidate | null> {
+  private async findResumableIssue(
+    skipIssueNumbers: ReadonlySet<number> = new Set<number>(),
+  ): Promise<ResumableIssueCandidate | null> {
     const issues = await listOpenAgentIssues(this.config)
     const prs = await listOpenAgentPullRequests(this.config)
     const now = Date.now()
@@ -1338,6 +1344,7 @@ export class AgentDaemon {
     let candidate: ResumableIssueCandidate | null = null
 
     for (const issue of issues) {
+      if (skipIssueNumbers.has(issue.number)) continue
       if (this.activeIssueProcesses.has(issue.number)) continue
       if (this.activeWorktrees.has(issue.number)) continue
       const attempts = this.failedIssueResumeAttempts.get(issue.number) ?? 0

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -1,5 +1,6 @@
 import { $ } from 'bun'
-import { existsSync, mkdirSync } from 'node:fs'
+import { spawn } from 'node:child_process'
+import { existsSync, mkdirSync, openSync } from 'node:fs'
 import { resolve } from 'node:path'
 import type {
   ActiveLeaseRuntimeDetail,
@@ -64,7 +65,7 @@ import {
   METRICS_PATH,
   type MetricsServer,
 } from './metrics'
-import { resolveCurrentRuntimeSupervisor } from './background'
+import { resolveCurrentRuntimeSupervisor, sanitizeDaemonBackgroundArgs } from './background'
 import {
   buildWakeQueuePath,
   drainWakeQueue,
@@ -77,6 +78,7 @@ import {
 } from './presence'
 import {
   abbreviateRevision,
+  applyAgentLoopUpgradeToLocalCheckout,
   checkForAgentLoopUpgrade,
   createInitialAgentLoopUpgradeMetadata,
   resolveAgentLoopBuildMetadata,
@@ -266,6 +268,9 @@ export class AgentDaemon {
   private agentLoopUpgrade: AgentLoopUpgradeMetadata
   private upgradeCheckPromise: Promise<void> | null = null
   private lastUpgradeReminderAt: number | null = null
+  private autoUpgradePromise: Promise<boolean> | null = null
+  private lastAutoUpgradeAttemptAt: number | null = null
+  private lastAutoUpgradeAttemptTarget: string | null = null
 
   constructor(
     private config: AgentConfig,
@@ -1103,6 +1108,9 @@ export class AgentDaemon {
 
       recordPoll(startedWork ? 'success' : 'no_issues')
       recordPollDuration(Date.now() - pollStartTime)
+      if (!startedWork && await this.maybeAutoApplyAgentLoopUpgrade()) {
+        return
+      }
       this.scheduleNextPoll()
       return
     }
@@ -3049,6 +3057,127 @@ export class AgentDaemon {
     })
 
     return this.upgradeCheckPromise
+  }
+
+  private async maybeAutoApplyAgentLoopUpgrade(): Promise<boolean> {
+    const policy = resolveAgentLoopUpgradePolicy(this.config, this.agentLoopBuild)
+    if (!policy.enabled || !policy.autoApply) {
+      return false
+    }
+    if (this.shutdownRequested || !this.running || !this.isSafeToUpgradeNow()) {
+      return false
+    }
+
+    await this.maybeRefreshAgentLoopUpgradeStatus()
+    const upgrade = this.buildUpgradeStatus()
+    if (upgrade.status !== 'upgrade-available' || !upgrade.safeToUpgradeNow) {
+      return false
+    }
+
+    const attemptTarget = upgrade.latestRevision ?? `${upgrade.channel ?? 'default'}:${upgrade.latestVersion ?? 'unknown'}`
+    if (
+      this.lastAutoUpgradeAttemptTarget === attemptTarget
+      && this.lastAutoUpgradeAttemptAt !== null
+      && this.lastAutoUpgradeAttemptAt + policy.checkIntervalMs > Date.now()
+    ) {
+      return false
+    }
+
+    if (this.autoUpgradePromise) {
+      return this.autoUpgradePromise
+    }
+
+    this.lastAutoUpgradeAttemptTarget = attemptTarget
+    this.lastAutoUpgradeAttemptAt = Date.now()
+    this.autoUpgradePromise = this.performAutomaticAgentLoopUpgrade(upgrade)
+      .catch((error) => {
+        this.logger.warn(`[daemon] automatic agent-loop upgrade failed: ${formatDaemonError(error)}`)
+        return false
+      })
+      .finally(() => {
+        this.autoUpgradePromise = null
+      })
+
+    return this.autoUpgradePromise
+  }
+
+  private async performAutomaticAgentLoopUpgrade(
+    upgrade: AgentLoopUpgradeMetadata,
+  ): Promise<boolean> {
+    const supervisor = resolveCurrentRuntimeSupervisor()
+    if (supervisor === 'direct') {
+      this.logger.warn('[daemon] automatic agent-loop upgrade requires a managed detached or launchd runtime; direct mode will keep reminder-only behavior')
+      return false
+    }
+    if (supervisor === 'detached') {
+      this.assertDetachedUpgradeRestartReady()
+    }
+
+    const result = applyAgentLoopUpgradeToLocalCheckout({
+      build: this.agentLoopBuild,
+      upgrade,
+    })
+    if (!result.changed) {
+      this.logger.log('[daemon] agent-loop auto-upgrade found no local revision change after pull; keeping current daemon process')
+      return false
+    }
+    const fromRevision = abbreviateRevision(result.previousRevision)
+    const toRevision = abbreviateRevision(result.nextRevision)
+    this.logger.log(
+      `[daemon] upgraded local agent-loop checkout on ${result.currentBranch}: v${this.agentLoopBuild.version}@${fromRevision} -> v${upgrade.latestVersion ?? this.agentLoopBuild.version}@${toRevision}`,
+    )
+
+    await this.stop()
+
+    if (supervisor === 'detached') {
+      const pid = this.spawnDetachedUpgradeSuccessor()
+      this.logger.log(`[daemon] started upgraded detached daemon successor pid ${pid}`)
+    } else {
+      this.logger.log('[daemon] exiting so launchd can restart the upgraded daemon')
+    }
+
+    this.exitProcess(0)
+    return true
+  }
+
+  private assertDetachedUpgradeRestartReady(): void {
+    if (!process.env.AGENT_LOOP_RUNTIME_FILE || !process.env.AGENT_LOOP_LOG_FILE || !process.argv[1]) {
+      throw new Error('managed detached auto-upgrade restart requires runtime file, log path, and script path')
+    }
+  }
+
+  private spawnDetachedUpgradeSuccessor(): number {
+    this.assertDetachedUpgradeRestartReady()
+    const runtimeFile = process.env.AGENT_LOOP_RUNTIME_FILE!
+    const logPath = process.env.AGENT_LOOP_LOG_FILE!
+    const scriptPath = process.argv[1]!
+
+    const logFd = openSync(logPath, 'a')
+    const child = spawn(process.execPath, [
+      scriptPath,
+      ...sanitizeDaemonBackgroundArgs(process.argv.slice(2)),
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        AGENT_LOOP_RUNTIME_FILE: runtimeFile,
+        AGENT_LOOP_LOG_FILE: logPath,
+        AGENT_LOOP_RUNTIME_MANAGER: 'detached',
+      },
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+    })
+    child.unref()
+
+    if (!child.pid) {
+      throw new Error('failed to spawn upgraded detached daemon successor')
+    }
+
+    return child.pid
+  }
+
+  private exitProcess(code: number): never {
+    process.exit(code)
   }
 
   private maybeLogAgentLoopUpgradeNotice(upgrade: AgentLoopUpgradeMetadata): void {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -66,6 +66,12 @@ import {
 } from './metrics'
 import { resolveCurrentRuntimeSupervisor } from './background'
 import {
+  buildWakeQueuePath,
+  drainWakeQueue,
+  hasPendingWakeRequests,
+  resolveWakeQueueHomeDirFromWorktreesBase,
+} from './wake-queue'
+import {
   ManagedDaemonPresencePublisher,
   type ManagedDaemonPresenceRuntimeState,
 } from './presence'
@@ -83,9 +89,11 @@ export interface HealthServerConfig {
 }
 
 export const HEALTH_PATH = '/health'
+export const WAKE_PATH = '/wake'
 export const DEFAULT_HEALTH_SERVER_PORT = 9310
 export const DEFAULT_HEALTH_SERVER_HOST = '127.0.0.1'
 const LOCAL_METRICS_HOST = '127.0.0.1'
+const WAKE_QUEUE_CHECK_INTERVAL_MS = 1_000
 
 export type IssueWorkingTransitionKind = 'fresh-claim' | 'resume' | 'recoverable'
 
@@ -108,6 +116,7 @@ const RETRYABLE_DAEMON_ERROR_PATTERNS = [
 ] as const
 const BLOCKED_ISSUE_RESUME_ESCALATION_COOLDOWN_SECONDS = 30 * 60
 const BLOCKED_ISSUE_RESUME_ESCALATION_COMMENT_PREFIX = '<!-- agent-loop:issue-resume-blocked '
+const ISSUE_RESUME_RESOLUTION_COMMENT_PREFIX = '<!-- agent-loop:issue-resume-resolved '
 export const BLOCKED_ISSUE_RESUME_WARNING_AGE_SECONDS = 5 * 60
 const MISSING_REMOTE_BRANCH_RECOVERY_REASON_PREFIX = 'missing-remote-branch:'
 
@@ -197,6 +206,17 @@ export interface BlockedIssueResumeEscalationRecord extends IssueComment {
   escalation: BlockedIssueResumeEscalationComment
 }
 
+export interface IssueResumeResolutionComment {
+  issueNumber: number
+  prNumber: number
+  resolvedAt: string
+  resolution: string
+}
+
+export interface IssueResumeResolutionRecord extends IssueComment {
+  resolutionComment: IssueResumeResolutionComment
+}
+
 export class AgentDaemon {
   private static readonly MAX_AUTOMATED_PR_REVIEW_ATTEMPTS = 3
   private running = false
@@ -219,14 +239,17 @@ export class AgentDaemon {
   private lastPollAt: string | null = null
   private lastClaimedAt: string | null = null
   private pollTimeoutId: ReturnType<typeof setTimeout> | null = null
+  private wakeQueueCheckIntervalId: ReturnType<typeof setInterval> | null = null
   private nextPollAt: string | null = null
   private nextPollReason: string | null = null
   private nextPollDelayMs: number | null = null
+  private pendingWakeRequested = false
   private healthServer: ReturnType<typeof Bun.serve> | null = null
   private healthServerConfig: HealthServerConfig = {
     host: DEFAULT_HEALTH_SERVER_HOST,
     port: DEFAULT_HEALTH_SERVER_PORT,
   }
+  private readonly wakeQueuePath: string
   private metricsServer: MetricsServer | null = null
   private metricsPort: number
   private presencePublisher: ManagedDaemonPresencePublisher | null = null
@@ -254,6 +277,11 @@ export class AgentDaemon {
       this.healthServerConfig = { ...this.healthServerConfig, ...healthServerConfig }
     }
     this.metricsPort = metricsPort ?? 9090
+    this.wakeQueuePath = buildWakeQueuePath({
+      repo: this.config.repo,
+      machineId: this.config.machineId,
+      homeDir: resolveWakeQueueHomeDirFromWorktreesBase(this.config.worktreesBase),
+    })
     this.agentLoopBuild = resolveAgentLoopBuildMetadata()
     this.agentLoopUpgrade = createInitialAgentLoopUpgradeMetadata(
       this.config,
@@ -544,6 +572,74 @@ export class AgentDaemon {
     )
   }
 
+  async drainWakeQueueOnce(options: {
+    scheduleImmediate?: boolean
+  } = {}): Promise<void> {
+    let drained
+
+    try {
+      drained = drainWakeQueue(this.wakeQueuePath)
+    } catch (error) {
+      this.logger.warn(`[daemon] failed to drain wake queue at ${this.wakeQueuePath}: ${formatDaemonError(error)}`)
+      return
+    }
+
+    for (const invalidEntry of drained.invalidEntries) {
+      this.logger.warn(
+        `[daemon] skipped invalid wake queue entry at ${this.wakeQueuePath}:${invalidEntry.lineNumber}: ${invalidEntry.error}`,
+      )
+    }
+
+    if (drained.requests.length === 0) {
+      return
+    }
+
+    this.logger.log(
+      `[daemon] drained ${drained.requests.length} wake request(s) from ${this.wakeQueuePath}`,
+    )
+
+    if (options.scheduleImmediate !== false) {
+      this.requestImmediateReconcile('wake-request')
+    }
+  }
+
+  private startWakeQueueMonitor(): void {
+    if (this.wakeQueueCheckIntervalId !== null) {
+      clearInterval(this.wakeQueueCheckIntervalId)
+    }
+
+    this.wakeQueueCheckIntervalId = setInterval(() => {
+      if (!this.running || this.shutdownRequested) {
+        return
+      }
+
+      if (!hasPendingWakeRequests(this.wakeQueuePath)) {
+        return
+      }
+
+      this.requestImmediateReconcile('wake-request')
+    }, WAKE_QUEUE_CHECK_INTERVAL_MS)
+  }
+
+  private requestImmediateReconcile(reason: string): void {
+    if (this.shutdownRequested) {
+      return
+    }
+
+    this.pendingWakeRequested = true
+    this.nextPollAt = new Date().toISOString()
+    this.nextPollReason = reason
+    this.nextPollDelayMs = 0
+    this.syncRuntimeMetrics()
+
+    if (this.pollTimeoutId !== null) {
+      this.scheduleNextPoll({
+        delayMs: 0,
+        reason,
+      })
+    }
+  }
+
   async start(): Promise<void> {
     this.logger.log(`[daemon] starting agent-loop v${this.agentLoopBuild.version} (${abbreviateRevision(this.agentLoopBuild.revision)})`)
     this.logger.log(`[daemon] machineId: ${this.config.machineId}`)
@@ -577,6 +673,7 @@ export class AgentDaemon {
 
     this.running = true
     this.syncRuntimeMetrics()
+    this.startWakeQueueMonitor()
 
     this.presencePublisher = new ManagedDaemonPresencePublisher({
       config: this.config,
@@ -676,6 +773,11 @@ export class AgentDaemon {
           })
         }
 
+        if (request.method === 'POST' && url.pathname === WAKE_PATH) {
+          this.requestImmediateReconcile('wake-request')
+          return new Response(null, { status: 202 })
+        }
+
         return new Response('Not Found', { status: 404 })
       },
     })
@@ -694,6 +796,12 @@ export class AgentDaemon {
     this.nextPollAt = null
     this.nextPollReason = null
     this.nextPollDelayMs = null
+    this.pendingWakeRequested = false
+
+    if (this.wakeQueueCheckIntervalId !== null) {
+      clearInterval(this.wakeQueueCheckIntervalId)
+      this.wakeQueueCheckIntervalId = null
+    }
 
     // Stop health server
     if (this.healthServer) {
@@ -813,9 +921,12 @@ export class AgentDaemon {
       clearTimeout(this.pollTimeoutId)
     }
 
-    const delayMs = Math.max(0, options.delayMs ?? this.config.pollIntervalMs)
+    const shouldWakeImmediately = this.pendingWakeRequested || hasPendingWakeRequests(this.wakeQueuePath)
+    const delayMs = shouldWakeImmediately
+      ? 0
+      : Math.max(0, options.delayMs ?? this.config.pollIntervalMs)
     this.nextPollAt = new Date(Date.now() + delayMs).toISOString()
-    this.nextPollReason = options.reason ?? 'normal'
+    this.nextPollReason = shouldWakeImmediately ? 'wake-request' : options.reason ?? 'normal'
     this.nextPollDelayMs = delayMs
     this.syncRuntimeMetrics()
 
@@ -825,6 +936,7 @@ export class AgentDaemon {
         this.nextPollAt = null
         this.nextPollReason = null
         this.nextPollDelayMs = null
+        this.pendingWakeRequested = false
         this.syncRuntimeMetrics()
         this.runPollCycleSafely().catch(err => this.logger.error('[daemon] poll wrapper error:', err))
       },
@@ -835,6 +947,11 @@ export class AgentDaemon {
   private async runPollCycleSafely(): Promise<void> {
     const startedAt = Date.now()
     void this.maybeRefreshAgentLoopUpgradeStatus()
+    this.pendingWakeRequested = false
+
+    await this.drainWakeQueueOnce({
+      scheduleImmediate: false,
+    })
 
     try {
       const startupResult = await this.runStartupMaintenanceIfNeeded()
@@ -1266,10 +1383,20 @@ export class AgentDaemon {
         ? getFailedIssueResumeBlock(linkedPr, linkedPrCanResumeHumanNeededReview)
         : null
       if (blockedResume) {
-        blockedIssueNumbers.add(issue.number)
-        this.noteBlockedIssueResume(issue.number, blockedResume.prNumber, blockedResume.reason)
-        await this.maybeEscalateBlockedIssueResume(issue.number, blockedResume.prNumber, blockedResume.reason, comments)
-        continue
+        if (
+          blockedResume.prNumber !== null
+          && canResumeBlockedIssueFromResolution(comments, issue.number, blockedResume.prNumber)
+        ) {
+          this.logger.log(
+            `[daemon] issue #${issue.number} received a matching resolution signal for linked PR #${blockedResume.prNumber}; retrying failed issue recovery`,
+          )
+          this.clearBlockedIssueResume(issue.number)
+        } else {
+          blockedIssueNumbers.add(issue.number)
+          this.noteBlockedIssueResume(issue.number, blockedResume.prNumber, blockedResume.reason)
+          await this.maybeEscalateBlockedIssueResume(issue.number, blockedResume.prNumber, blockedResume.reason, comments)
+          continue
+        }
       }
       this.clearBlockedIssueResume(issue.number)
       if (!canAdoptLease) continue
@@ -3265,6 +3392,22 @@ Reason:
 Next step: clear or replace the linked PR state before expecting automatic issue resume.`
 }
 
+export function buildIssueResumeResolutionComment(
+  payload: IssueResumeResolutionComment,
+): string {
+  return `${ISSUE_RESUME_RESOLUTION_COMMENT_PREFIX}${JSON.stringify(payload)} -->
+## agent-loop issue resume resolution
+
+This blocked failed issue has a matching manual resolution signal and may be retried.
+
+- Issue: #${payload.issueNumber}
+- Linked PR: #${payload.prNumber}
+- Resolved at: ${payload.resolvedAt}
+- Resolution: ${payload.resolution}
+
+Next step: the daemon may retry failed issue recovery on the next reconcile.`
+}
+
 export function extractBlockedIssueResumeEscalationComment(
   body: string,
 ): BlockedIssueResumeEscalationComment | null {
@@ -3296,6 +3439,29 @@ export function extractBlockedIssueResumeEscalationComment(
   }
 }
 
+export function extractIssueResumeResolutionComment(
+  body: string,
+): IssueResumeResolutionComment | null {
+  const match = body.match(/<!-- agent-loop:issue-resume-resolved (\{.*\}) -->/)
+  if (!match?.[1]) return null
+
+  try {
+    const parsed = JSON.parse(match[1]) as Partial<IssueResumeResolutionComment>
+    if (!parsed || typeof parsed !== 'object') return null
+    if (!Number.isInteger(parsed.issueNumber) || !Number.isInteger(parsed.prNumber)) return null
+    if (typeof parsed.resolvedAt !== 'string' || typeof parsed.resolution !== 'string') return null
+
+    return {
+      issueNumber: parsed.issueNumber as number,
+      prNumber: parsed.prNumber as number,
+      resolvedAt: parsed.resolvedAt,
+      resolution: parsed.resolution,
+    }
+  } catch {
+    return null
+  }
+}
+
 export function listBlockedIssueResumeEscalationComments(
   comments: IssueComment[],
   issueNumber: number,
@@ -3316,6 +3482,63 @@ export function listBlockedIssueResumeEscalationComments(
     .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
 }
 
+export function listIssueResumeResolutionComments(
+  comments: IssueComment[],
+  issueNumber: number,
+  prNumber: number,
+): IssueResumeResolutionRecord[] {
+  return comments
+    .map((comment) => {
+      const resolutionComment = extractIssueResumeResolutionComment(comment.body)
+      if (!resolutionComment) return null
+      if (resolutionComment.issueNumber !== issueNumber) return null
+      if (resolutionComment.prNumber !== prNumber) return null
+      return {
+        ...comment,
+        resolutionComment,
+      } satisfies IssueResumeResolutionRecord
+    })
+    .filter((comment): comment is IssueResumeResolutionRecord => comment !== null)
+    .sort((left, right) => readIssueCommentTimestamp(right, right.resolutionComment.resolvedAt) - readIssueCommentTimestamp(left, left.resolutionComment.resolvedAt))
+}
+
+export function evaluateBlockedIssueResumeResolution(
+  comments: IssueComment[],
+  issueNumber: number,
+  prNumber: number,
+): {
+  latestEscalation: BlockedIssueResumeEscalationRecord | null
+  latestResolution: IssueResumeResolutionRecord | null
+  canResume: boolean
+} {
+  const latestEscalation = listBlockedIssueResumeEscalationComments(comments, issueNumber, prNumber)[0] ?? null
+  const latestResolution = listIssueResumeResolutionComments(comments, issueNumber, prNumber)[0] ?? null
+
+  if (!latestEscalation || !latestResolution) {
+    return {
+      latestEscalation,
+      latestResolution,
+      canResume: false,
+    }
+  }
+
+  return {
+    latestEscalation,
+    latestResolution,
+    canResume:
+      readIssueCommentTimestamp(latestResolution, latestResolution.resolutionComment.resolvedAt)
+      > readIssueCommentTimestamp(latestEscalation, latestEscalation.escalation.escalatedAt),
+  }
+}
+
+export function canResumeBlockedIssueFromResolution(
+  comments: IssueComment[],
+  issueNumber: number,
+  prNumber: number,
+): boolean {
+  return evaluateBlockedIssueResumeResolution(comments, issueNumber, prNumber).canResume
+}
+
 export function summarizeBlockedIssueResumeEscalations(
   comments: IssueComment[],
   issueNumber: number,
@@ -3326,6 +3549,23 @@ export function summarizeBlockedIssueResumeEscalations(
     escalationCount: matches.length,
     lastEscalatedAt: matches[0]?.updatedAt ?? matches[0]?.createdAt ?? matches[0]?.escalation.escalatedAt ?? null,
   }
+}
+
+function readIssueCommentTimestamp(
+  comment: Pick<IssueComment, 'updatedAt' | 'createdAt'>,
+  fallbackIso: string | null = null,
+): number {
+  const candidates = [comment.updatedAt, comment.createdAt, fallbackIso]
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue
+    const parsed = Date.parse(candidate)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return 0
 }
 
 export function shouldEscalateBlockedIssueResume(input: {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -74,6 +74,11 @@ import {
 } from './wake-queue'
 import {
   ManagedDaemonPresencePublisher,
+  buildManagedDaemonUpgradeAnnouncementComment,
+  commentOnIssue as commentOnPresenceIssue,
+  ensureManagedDaemonPresenceIssue,
+  getLatestManagedDaemonUpgradeAnnouncement,
+  listIssueComments as listPresenceIssueComments,
   type ManagedDaemonPresenceRuntimeState,
 } from './presence'
 import {
@@ -255,6 +260,8 @@ export class AgentDaemon {
   private metricsServer: MetricsServer | null = null
   private metricsPort: number
   private presencePublisher: ManagedDaemonPresencePublisher | null = null
+  private presenceIssueNumber: number | null = null
+  private upgradeAnnouncementCheckIntervalId: ReturnType<typeof setInterval> | null = null
   private inFlightIssueProcesses = new Set<Promise<void>>()
   private inFlightPrTasks = new Set<Promise<void>>()
   private activePrReviews = new Set<number>()
@@ -271,6 +278,9 @@ export class AgentDaemon {
   private autoUpgradePromise: Promise<boolean> | null = null
   private lastAutoUpgradeAttemptAt: number | null = null
   private lastAutoUpgradeAttemptTarget: string | null = null
+  private lastPublishedUpgradeAnnouncementKey: string | null = null
+  private lastObservedUpgradeAnnouncementKey: string | null = null
+  private upgradeAnnouncementCheckPromise: Promise<void> | null = null
 
   constructor(
     private config: AgentConfig,
@@ -626,6 +636,26 @@ export class AgentDaemon {
     }, WAKE_QUEUE_CHECK_INTERVAL_MS)
   }
 
+  private startUpgradeAnnouncementMonitor(): void {
+    if (this.upgradeAnnouncementCheckIntervalId !== null) {
+      clearInterval(this.upgradeAnnouncementCheckIntervalId)
+    }
+
+    const intervalMs = Math.max(
+      this.config.recovery.heartbeatIntervalMs,
+      15_000,
+    )
+    this.upgradeAnnouncementCheckIntervalId = setInterval(() => {
+      if (!this.running || this.shutdownRequested) {
+        return
+      }
+
+      void this.maybeProcessRemoteUpgradeAnnouncement().catch((error) => {
+        this.logger.warn(`[daemon] failed to process remote upgrade announcement: ${formatDaemonError(error)}`)
+      })
+    }, intervalMs)
+  }
+
   private requestImmediateReconcile(reason: string): void {
     if (this.shutdownRequested) {
       return
@@ -679,6 +709,7 @@ export class AgentDaemon {
     this.running = true
     this.syncRuntimeMetrics()
     this.startWakeQueueMonitor()
+    this.startUpgradeAnnouncementMonitor()
 
     this.presencePublisher = new ManagedDaemonPresencePublisher({
       config: this.config,
@@ -695,6 +726,7 @@ export class AgentDaemon {
     }
 
     void this.maybeRefreshAgentLoopUpgradeStatus(true)
+    void this.maybeProcessRemoteUpgradeAnnouncement()
 
     // Run first recovery + poll immediately; subsequent polls are self-scheduled
     await this.runPollCycleSafely()
@@ -806,6 +838,11 @@ export class AgentDaemon {
     if (this.wakeQueueCheckIntervalId !== null) {
       clearInterval(this.wakeQueueCheckIntervalId)
       this.wakeQueueCheckIntervalId = null
+    }
+
+    if (this.upgradeAnnouncementCheckIntervalId !== null) {
+      clearInterval(this.upgradeAnnouncementCheckIntervalId)
+      this.upgradeAnnouncementCheckIntervalId = null
     }
 
     // Stop health server
@@ -3058,12 +3095,119 @@ export class AgentDaemon {
         this.isSafeToUpgradeNow(),
       )
       this.agentLoopUpgrade = next
+      await this.maybeBroadcastAgentLoopUpgradeAnnouncement(next)
       this.maybeLogAgentLoopUpgradeNotice(next)
     })().finally(() => {
       this.upgradeCheckPromise = null
     })
 
     return this.upgradeCheckPromise
+  }
+
+  private async maybeProcessRemoteUpgradeAnnouncement(): Promise<void> {
+    if (this.upgradeAnnouncementCheckPromise) {
+      return this.upgradeAnnouncementCheckPromise
+    }
+
+    this.upgradeAnnouncementCheckPromise = (async () => {
+      const issueNumber = await this.ensurePresenceIssueNumber()
+      const comments = await this.listPresenceRegistryComments(issueNumber)
+      const latest = getLatestManagedDaemonUpgradeAnnouncement(comments, this.config.repo)
+      if (!latest) {
+        return
+      }
+
+      const key = this.getUpgradeAnnouncementKey({
+        channel: latest.announcement.channel,
+        latestVersion: latest.announcement.latestVersion,
+        latestRevision: latest.announcement.latestRevision,
+      })
+      if (!key || key === this.lastObservedUpgradeAnnouncementKey) {
+        return
+      }
+      if (!this.shouldRefreshFromUpgradeAnnouncement(latest.announcement.announcedAt, key)) {
+        this.lastObservedUpgradeAnnouncementKey = key
+        return
+      }
+
+      this.logger.log(
+        `[daemon] observed remote agent-loop upgrade announcement for ${latest.announcement.channel ?? 'default'} -> v${latest.announcement.latestVersion ?? 'unknown'}@${abbreviateRevision(latest.announcement.latestRevision)}`,
+      )
+      await this.maybeRefreshAgentLoopUpgradeStatus(true)
+      this.lastObservedUpgradeAnnouncementKey = key
+      this.requestImmediateReconcile('agent-loop-upgrade')
+    })().finally(() => {
+      this.upgradeAnnouncementCheckPromise = null
+    })
+
+    return this.upgradeAnnouncementCheckPromise
+  }
+
+  private async maybeBroadcastAgentLoopUpgradeAnnouncement(
+    upgrade: AgentLoopUpgradeMetadata,
+  ): Promise<void> {
+    if (upgrade.status !== 'upgrade-available') {
+      return
+    }
+
+    const key = this.getUpgradeAnnouncementKey(upgrade)
+    if (!key || key === this.lastPublishedUpgradeAnnouncementKey) {
+      return
+    }
+
+    const issueNumber = await this.ensurePresenceIssueNumber()
+    const comments = await this.listPresenceRegistryComments(issueNumber)
+    const latest = getLatestManagedDaemonUpgradeAnnouncement(comments, this.config.repo)
+    const latestKey = latest
+      ? this.getUpgradeAnnouncementKey({
+          channel: latest.announcement.channel,
+          latestVersion: latest.announcement.latestVersion,
+          latestRevision: latest.announcement.latestRevision,
+        })
+      : null
+    if (latestKey === key) {
+      this.lastPublishedUpgradeAnnouncementKey = key
+      return
+    }
+
+    await this.commentOnPresenceRegistryIssue(
+      issueNumber,
+      buildManagedDaemonUpgradeAnnouncementComment({
+        repo: this.config.repo,
+        channel: upgrade.channel,
+        latestVersion: upgrade.latestVersion,
+        latestRevision: upgrade.latestRevision,
+        latestCommitAt: upgrade.latestCommitAt,
+        announcedAt: new Date().toISOString(),
+        announcedByMachineId: this.config.machineId,
+        announcedByDaemonInstanceId: this.daemonInstanceId,
+      }),
+    )
+    this.lastPublishedUpgradeAnnouncementKey = key
+    this.logger.log(
+      `[daemon] broadcasted agent-loop upgrade announcement for ${upgrade.channel ?? 'default'} -> v${upgrade.latestVersion ?? 'unknown'}@${abbreviateRevision(upgrade.latestRevision)}`,
+    )
+  }
+
+  private shouldRefreshFromUpgradeAnnouncement(
+    announcedAt: string,
+    key: string,
+  ): boolean {
+    const currentKey = this.getUpgradeAnnouncementKey(this.agentLoopUpgrade)
+    const currentCheckedAt = this.agentLoopUpgrade.checkedAt
+      ? Date.parse(this.agentLoopUpgrade.checkedAt)
+      : Number.NaN
+    const announcedAtMs = Date.parse(announcedAt)
+
+    if (currentKey !== key) {
+      return true
+    }
+
+    if (!Number.isFinite(currentCheckedAt) || !Number.isFinite(announcedAtMs)) {
+      return true
+    }
+
+    return announcedAtMs > currentCheckedAt
   }
 
   private async maybeAutoApplyAgentLoopUpgrade(): Promise<boolean> {
@@ -3081,9 +3225,10 @@ export class AgentDaemon {
       return false
     }
 
-    const attemptTarget = upgrade.latestRevision ?? `${upgrade.channel ?? 'default'}:${upgrade.latestVersion ?? 'unknown'}`
+    const attemptTarget = this.getUpgradeAnnouncementKey(upgrade)
     if (
-      this.lastAutoUpgradeAttemptTarget === attemptTarget
+      attemptTarget
+      && this.lastAutoUpgradeAttemptTarget === attemptTarget
       && this.lastAutoUpgradeAttemptAt !== null
       && this.lastAutoUpgradeAttemptAt + policy.checkIntervalMs > Date.now()
     ) {
@@ -3144,7 +3289,35 @@ export class AgentDaemon {
     }
 
     this.exitProcess(0)
-    return true
+  }
+
+  private async ensurePresenceIssueNumber(): Promise<number> {
+    if (this.presenceIssueNumber !== null) {
+      return this.presenceIssueNumber
+    }
+
+    this.presenceIssueNumber = await ensureManagedDaemonPresenceIssue(this.config)
+    return this.presenceIssueNumber
+  }
+
+  private async listPresenceRegistryComments(issueNumber: number): Promise<IssueComment[]> {
+    return listPresenceIssueComments(issueNumber, this.config)
+  }
+
+  private async commentOnPresenceRegistryIssue(issueNumber: number, body: string): Promise<void> {
+    await commentOnPresenceIssue(issueNumber, body, this.config)
+  }
+
+  private getUpgradeAnnouncementKey(input: {
+    channel: string | null
+    latestVersion: string | null
+    latestRevision: string | null
+  }): string | null {
+    if (!input.latestVersion && !input.latestRevision) {
+      return null
+    }
+
+    return `${input.channel ?? 'default'}:${input.latestVersion ?? 'unknown'}:${input.latestRevision ?? 'unknown'}`
   }
 
   private assertDetachedUpgradeRestartReady(): void {
@@ -3158,7 +3331,6 @@ export class AgentDaemon {
     const runtimeFile = process.env.AGENT_LOOP_RUNTIME_FILE!
     const logPath = process.env.AGENT_LOOP_LOG_FILE!
     const scriptPath = process.argv[1]!
-
     const logFd = openSync(logPath, 'a')
     const child = spawn(process.execPath, [
       scriptPath,

--- a/apps/agent-daemon/src/fixtures/replay/blocked-resume-basic.json
+++ b/apps/agent-daemon/src/fixtures/replay/blocked-resume-basic.json
@@ -1,0 +1,42 @@
+{
+  "name": "blocked-resume-basic",
+  "openIssues": [
+    {
+      "number": 104,
+      "title": "failed issue with terminal linked pr",
+      "body": "## 用户故事\n\n作为 工程负责人，我希望 daemon 能识别 blocked resume。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/example.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- preserve failed issue state\n\n### OutOfScope\n- real GitHub calls\n\n### RequiredSemantics\n- linked PR can block automated resume\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('blocked resume fixture')\n```\n\n## 实现步骤\n1. add replay fixture\n\n## 验收\n- [ ] blocked resume recognized",
+      "labels": [
+        "agent:failed"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T09:05:00.000Z"
+    }
+  ],
+  "issueComments": [
+    {
+      "issueNumber": 104,
+      "commentId": 1,
+      "body": "<!-- agent-loop:issue-resume-blocked {\"issueNumber\":104,\"prNumber\":205,\"blockedSince\":\"2026-04-11T09:00:00.000Z\",\"escalatedAt\":\"2026-04-11T09:05:00.000Z\",\"thresholdSeconds\":300,\"reason\":\"linked PR #205 is in terminal agent:human-needed; automated review has no remaining structured retry path\",\"machineId\":\"codex-dev\",\"daemonInstanceId\":\"daemon-1\"} -->\n## agent-loop blocked resume escalation",
+      "createdAt": "2026-04-11T09:05:00.000Z",
+      "updatedAt": "2026-04-11T09:05:00.000Z"
+    }
+  ],
+  "openPullRequests": [
+    {
+      "number": 205,
+      "title": "Fix #104: failed issue with terminal linked pr",
+      "labels": [
+        "agent:human-needed"
+      ],
+      "isDraft": false,
+      "headRefName": "agent/104/codex-dev",
+      "headRefOid": "abc123"
+    }
+  ],
+  "expected": {
+    "claimable": 0,
+    "blocked": 1,
+    "invalid": 0
+  }
+}

--- a/apps/agent-daemon/src/fixtures/replay/claimability-basic.json
+++ b/apps/agent-daemon/src/fixtures/replay/claimability-basic.json
@@ -1,0 +1,34 @@
+{
+  "name": "claimability-basic",
+  "openIssues": [
+    {
+      "number": 91,
+      "title": "ready issue",
+      "body": "## 用户故事\n\n作为 开发者，我希望 daemon 能 claim 这个 issue。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/example.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- ready issue remains ready\n\n### OutOfScope\n- unrelated scheduler changes\n\n### RequiredSemantics\n- issue is claimable\n\n### ReviewHints\n- check contract validity\n\n### Validation\n- `bun run typecheck`\n\n## RED 测试\n\n```ts\nthrow new Error('fixture red test body')\n```\n\n## 实现步骤\n1. add test\n\n## 验收\n- [ ] contract valid",
+      "labels": [
+        "agent:ready"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T09:00:00.000Z"
+    },
+    {
+      "number": 92,
+      "title": "invalid ready issue",
+      "body": "## 用户故事\n\n作为 开发者，我希望 daemon 发现这个 issue contract 不完整。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/example.ts\n\n## 实现步骤\n1. missing sections on purpose\n\n## 验收\n- [ ] this issue should be invalid",
+      "labels": [
+        "agent:ready"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T09:01:00.000Z"
+    }
+  ],
+  "issueComments": [],
+  "openPullRequests": [],
+  "expected": {
+    "claimable": 1,
+    "blocked": 0,
+    "invalid": 1
+  }
+}

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from 'bun:test'
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  buildWakeRequestFromCli,
   buildManagedRestartArgs,
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
+  executeWakeCommand,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
+  resolveWakeCommand,
   startManagedRuntime,
   reconcileManagedRuntime,
   formatLaunchdStatus,
@@ -17,6 +20,7 @@ import {
   stopManagedRuntime,
 } from './index'
 import type { BackgroundRuntimeSnapshot } from './background'
+import { appendWakeRequest, buildWakeQueuePath } from './wake-queue'
 
 describe('index helpers', () => {
   test('builds stable restart args for a managed runtime', () => {
@@ -31,6 +35,96 @@ describe('index helpers', () => {
       '--health-port', '9311',
       '--metrics-port', '9091',
     ])
+  })
+
+  test('resolves wake commands and validates targeted wake numbers', () => {
+    expect(resolveWakeCommand({
+      'wake-now': true,
+    })).toEqual({
+      kind: 'now',
+    })
+
+    expect(resolveWakeCommand({
+      'wake-issue': '42',
+    })).toEqual({
+      kind: 'issue',
+      issueNumber: 42,
+    })
+
+    expect(resolveWakeCommand({
+      'wake-pr': '381',
+    })).toEqual({
+      kind: 'pr',
+      prNumber: 381,
+    })
+
+    expect(() => resolveWakeCommand({
+      'wake-issue': 'abc',
+    })).toThrow('--wake-issue must be a positive integer')
+
+    expect(() => resolveWakeCommand({
+      'wake-now': true,
+      'wake-pr': '381',
+    })).toThrow('Only one of --wake-now, --wake-issue, or --wake-pr can be used at a time')
+  })
+
+  test('builds stable wake requests from CLI commands', () => {
+    expect(buildWakeRequestFromCli(
+      { kind: 'issue', issueNumber: 374 },
+      '2026-04-11T09:30:00.000Z',
+    )).toEqual({
+      kind: 'issue',
+      issueNumber: 374,
+      reason: 'cli:wake-issue',
+      sourceEvent: 'cli',
+      dedupeKey: 'cli:wake-issue:374',
+      requestedAt: '2026-04-11T09:30:00.000Z',
+    })
+  })
+
+  test('persists wake requests even when local daemon notification fails', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'agent-loop-wake-command-test-'))
+
+    const result = await executeWakeCommand({
+      command: { kind: 'pr', prNumber: 381 },
+      healthPort: 9311,
+    }, {
+      resolveLocalDaemonIdentity: () => ({
+        repo: 'JamesWuHK/agent-loop',
+        machineId: 'macbook-pro-b',
+      }),
+      buildWakeQueuePath: (input) => buildWakeQueuePath({
+        ...input,
+        homeDir,
+      }),
+      appendWakeRequest,
+      notifyLocalWake: async () => {
+        throw new Error('connection refused')
+      },
+      now: () => new Date('2026-04-11T09:40:00.000Z'),
+    })
+
+    const queuePath = buildWakeQueuePath({
+      repo: 'JamesWuHK/agent-loop',
+      machineId: 'macbook-pro-b',
+      homeDir,
+    })
+
+    expect(result).toEqual({
+      queuePath,
+      request: {
+        kind: 'pr',
+        prNumber: 381,
+        reason: 'cli:wake-pr',
+        sourceEvent: 'cli',
+        dedupeKey: 'cli:wake-pr:381',
+        requestedAt: '2026-04-11T09:40:00.000Z',
+      },
+      notified: false,
+    })
+    expect(readFileSync(queuePath, 'utf-8')).toBe(
+      '{"kind":"pr","prNumber":381,"reason":"cli:wake-pr","sourceEvent":"cli","dedupeKey":"cli:wake-pr:381","requestedAt":"2026-04-11T09:40:00.000Z"}\n',
+    )
   })
 
   test('preserves existing managed runtime launch args and replaces explicit overrides', () => {
@@ -171,15 +265,20 @@ describe('index helpers', () => {
   })
 
   test('reports when no managed daemon log file exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-loop-missing-log-test-'))
+    const missingLogPath = join(dir, 'missing-daemon.log')
+
     const result = readManagedRuntimeLog({
-      discoveredRuntime: null,
+      discoveredRuntime: buildRuntimeSnapshot({
+        logPath: missingLogPath,
+      }),
       repo: 'JamesWuHK/digital-employee',
       machineId: 'codex-dev',
       healthPort: 9311,
     })
 
     expect(result.found).toBe(false)
-    expect(result.path).toContain('jameswuhk-digital-employee__codex-dev__9311.log')
+    expect(result.path).toBe(missingLogPath)
     expect(formatManagedRuntimeLog(result)).toContain('No managed daemon log file found')
   })
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -14,6 +14,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { AgentDaemon, DEFAULT_HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_HOST, type HealthServerConfig } from './daemon'
 import { loadConfig, resolveLocalDaemonIdentity, type CliArgs } from './config'
 import { collectDaemonObservability, formatDoctorReport, formatStatusReport } from './status'
+import { appendWakeRequest, buildWakeQueuePath, type WakeRequest } from './wake-queue'
 import {
   buildCurrentProcessRuntimeRecord,
   buildBackgroundRuntimePaths,
@@ -49,6 +50,25 @@ import {
 type PartialHealthServerConfig = Partial<HealthServerConfig>
 type LocalDaemonIdentityResolver = typeof resolveLocalDaemonIdentity
 const RESTART_BACKGROUND_RUNTIME_STOP_TIMEOUT_MS = 30_000
+
+export interface WakeCommand {
+  kind: 'now' | 'issue' | 'pr'
+  issueNumber?: number
+  prNumber?: number
+}
+
+export interface ExecuteWakeCommandInput {
+  command: WakeCommand
+  repo?: string
+  machineId?: string
+  healthPort: number
+}
+
+export interface ExecuteWakeCommandResult {
+  queuePath: string
+  request: WakeRequest
+  notified: boolean
+}
 
 export interface RestartManagedRuntimeInput {
   discoveredRuntime: BackgroundRuntimeSnapshot | null
@@ -113,6 +133,14 @@ interface RestartManagedRuntimeDependencies {
   launchBackgroundRuntime: typeof launchBackgroundRuntime
 }
 
+interface WakeCommandDependencies {
+  resolveLocalDaemonIdentity: LocalDaemonIdentityResolver
+  buildWakeQueuePath: typeof buildWakeQueuePath
+  appendWakeRequest: typeof appendWakeRequest
+  notifyLocalWake: typeof notifyLocalWake
+  now: () => Date
+}
+
 const DEFAULT_RESTART_DEPENDENCIES: RestartManagedRuntimeDependencies = {
   platform: process.platform,
   resolveLocalDaemonIdentity,
@@ -123,6 +151,14 @@ const DEFAULT_RESTART_DEPENDENCIES: RestartManagedRuntimeDependencies = {
   stopLaunchdService,
   stopBackgroundRuntime,
   launchBackgroundRuntime,
+}
+
+const DEFAULT_WAKE_COMMAND_DEPENDENCIES: WakeCommandDependencies = {
+  resolveLocalDaemonIdentity,
+  buildWakeQueuePath,
+  appendWakeRequest,
+  notifyLocalWake,
+  now: () => new Date(),
 }
 
 async function main() {
@@ -155,6 +191,9 @@ async function main() {
       doctor: { type: 'boolean' },
       'health-host': { type: 'string' },
       'health-port': { type: 'string' },
+      'wake-now': { type: 'boolean' },
+      'wake-issue': { type: 'string' },
+      'wake-pr': { type: 'string' },
       help: { type: 'boolean' },
     },
   })
@@ -169,6 +208,16 @@ async function main() {
   if (args.help) {
     printHelp()
     process.exit(0)
+  }
+
+  const wakeCommand = resolveWakeCommand({
+    'wake-now': args['wake-now'] as boolean | undefined,
+    'wake-issue': args['wake-issue'] as string | undefined,
+    'wake-pr': args['wake-pr'] as string | undefined,
+  })
+
+  if (wakeCommand) {
+    assertWakeCommandCompatible(args)
   }
 
   if (args['repo-cap'] && !args['join-project']) {
@@ -312,6 +361,22 @@ async function main() {
   if (cliArgs.healthPort) healthServerConfig.port = cliArgs.healthPort
 
   try {
+    if (wakeCommand) {
+      const result = await executeWakeCommand({
+        command: wakeCommand,
+        repo: cliArgs.repo,
+        machineId: cliArgs.machineId,
+        healthPort: healthServerConfig.port ?? DEFAULT_HEALTH_SERVER_PORT,
+      })
+      console.log(`[agent-loop] queued wake request at ${result.queuePath}`)
+      console.log(
+        result.notified
+          ? `[agent-loop] local daemon notified via http://${DEFAULT_HEALTH_SERVER_HOST}:${healthServerConfig.port ?? DEFAULT_HEALTH_SERVER_PORT}/wake`
+          : '[agent-loop] wake request persisted; local daemon notify was not confirmed',
+      )
+      process.exit(0)
+    }
+
     if (args.dashboard) {
       const config = loadConfig(cliArgs)
       const server = startDashboardServer({
@@ -535,6 +600,9 @@ agent-loop — Distributed automation daemon
 Usage:
   agent-loop [options]
   agent-loop --join-project [options]
+  agent-loop --wake-now [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
+  agent-loop --wake-issue <number> [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
+  agent-loop --wake-pr <number> [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
   agent-loop --reconcile [--health-port 9310]
   agent-loop --start [--health-port 9310]
   agent-loop --dashboard [--dashboard-port 9388]
@@ -558,6 +626,9 @@ Options:
       --health-host <host>    Health check server host (default: 127.0.0.1)
       --health-port <port>    Health check server port (default: 9310)
       --metrics-port <port>   Prometheus metrics port (default: 9090)
+      --wake-now              Queue an immediate local wake request and best-effort notify the daemon
+      --wake-issue <number>   Queue a targeted issue wake request and best-effort notify the daemon
+      --wake-pr <number>      Queue a targeted PR wake request and best-effort notify the daemon
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -596,6 +667,9 @@ Examples:
   agent-loop --repo owner/repo --concurrency 2
   agent-loop --health-port 8080
   agent-loop --metrics-port 9090
+  agent-loop --wake-now --repo owner/repo
+  agent-loop --wake-issue 374 --repo owner/repo --machine-id macbook-pro-b
+  agent-loop --wake-pr 381 --health-port 9311
   agent-loop --dashboard
   agent-loop --dashboard --dashboard-port 9390
   agent-loop --join-project --machine-id macbook-pro-b --health-port 9312 --metrics-port 9092 --repo-cap 2
@@ -655,6 +729,112 @@ function resolveDiscoveredRuntime(input: {
 function ensureLaunchdSupported(): void {
   if (process.platform !== 'darwin') {
     throw new Error('launchd management is only supported on macOS')
+  }
+}
+
+export function resolveWakeCommand(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+}): WakeCommand | null {
+  const commands: WakeCommand[] = []
+
+  if (args['wake-now']) {
+    commands.push({ kind: 'now' })
+  }
+
+  if (typeof args['wake-issue'] === 'string') {
+    commands.push({
+      kind: 'issue',
+      issueNumber: parseWakeTargetNumber(args['wake-issue'], '--wake-issue'),
+    })
+  }
+
+  if (typeof args['wake-pr'] === 'string') {
+    commands.push({
+      kind: 'pr',
+      prNumber: parseWakeTargetNumber(args['wake-pr'], '--wake-pr'),
+    })
+  }
+
+  if (commands.length > 1) {
+    throw new Error('Only one of --wake-now, --wake-issue, or --wake-pr can be used at a time')
+  }
+
+  return commands[0] ?? null
+}
+
+export function buildWakeRequestFromCli(
+  command: WakeCommand,
+  requestedAt = new Date().toISOString(),
+): WakeRequest {
+  switch (command.kind) {
+    case 'now':
+      return {
+        kind: 'now',
+        reason: 'cli:wake-now',
+        sourceEvent: 'cli',
+        dedupeKey: 'cli:wake-now',
+        requestedAt,
+      }
+    case 'issue':
+      return {
+        kind: 'issue',
+        issueNumber: command.issueNumber!,
+        reason: 'cli:wake-issue',
+        sourceEvent: 'cli',
+        dedupeKey: `cli:wake-issue:${command.issueNumber!}`,
+        requestedAt,
+      }
+    case 'pr':
+      return {
+        kind: 'pr',
+        prNumber: command.prNumber!,
+        reason: 'cli:wake-pr',
+        sourceEvent: 'cli',
+        dedupeKey: `cli:wake-pr:${command.prNumber!}`,
+        requestedAt,
+      }
+  }
+}
+
+export async function executeWakeCommand(
+  input: ExecuteWakeCommandInput,
+  deps: WakeCommandDependencies = DEFAULT_WAKE_COMMAND_DEPENDENCIES,
+): Promise<ExecuteWakeCommandResult> {
+  const identity = deps.resolveLocalDaemonIdentity(
+    {
+      repo: input.repo,
+      machineId: input.machineId,
+    },
+    {
+      persistGeneratedMachineId: false,
+    },
+  )
+  const request = buildWakeRequestFromCli(input.command, deps.now().toISOString())
+  const queuePath = deps.buildWakeQueuePath({
+    repo: identity.repo,
+    machineId: identity.machineId,
+  })
+
+  deps.appendWakeRequest(queuePath, request)
+
+  let notified = false
+
+  try {
+    await deps.notifyLocalWake({
+      healthPort: input.healthPort,
+      request,
+    })
+    notified = true
+  } catch {
+    notified = false
+  }
+
+  return {
+    queuePath,
+    request,
+    notified,
   }
 }
 
@@ -765,6 +945,97 @@ function isManagedRuntimeValueFlag(flag: string): boolean {
 
 function isManagedRuntimeBooleanFlag(flag: string): boolean {
   return flag === '--dry-run' || flag === '--once'
+}
+
+function assertWakeCommandCompatible(args: {
+  pat?: string
+  concurrency?: string
+  'poll-interval'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+}): void {
+  const incompatibleFlags = [
+    typeof args.pat === 'string' ? '--pat' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Wake commands cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function parseWakeTargetNumber(value: string, flag: string): number {
+  const trimmed = value.trim()
+
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`${flag} must be a positive integer`)
+  }
+
+  const parsed = Number.parseInt(trimmed, 10)
+
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`)
+  }
+
+  return parsed
+}
+
+async function notifyLocalWake(input: {
+  healthPort: number
+  request: WakeRequest
+}): Promise<void> {
+  const response = await fetch(`http://${DEFAULT_HEALTH_SERVER_HOST}:${input.healthPort}/wake`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(input.request),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Wake endpoint returned ${response.status}`)
+  }
 }
 
 export function readManagedRuntimeLog(input: {

--- a/apps/agent-daemon/src/presence.test.ts
+++ b/apps/agent-daemon/src/presence.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, test } from 'bun:test'
 import type { AgentConfig, IssueComment } from '@agent/shared'
 import {
   buildManagedDaemonPresenceComment,
+  buildManagedDaemonUpgradeAnnouncementComment,
   extractManagedDaemonPresenceIssueNumber,
   extractManagedDaemonPresenceComment,
+  extractManagedDaemonUpgradeAnnouncementComment,
+  getLatestManagedDaemonUpgradeAnnouncement,
   listActiveManagedDaemonPresenceComments,
   ManagedDaemonPresencePublisher,
   type ManagedDaemonPresence,
@@ -137,6 +140,49 @@ describe('managed daemon presence helpers', () => {
     const body = buildManagedDaemonPresenceComment(presence)
 
     expect(extractManagedDaemonPresenceComment(body)).toEqual(presence)
+  })
+
+  test('round-trips managed daemon upgrade announcement comments and picks the newest one', () => {
+    const older = {
+      repo: TEST_CONFIG.repo,
+      channel: 'master',
+      latestVersion: '0.1.1',
+      latestRevision: '1111111111111111111111111111111111111111',
+      latestCommitAt: '2026-04-11T09:00:00.000Z',
+      announcedAt: '2026-04-11T09:00:10.000Z',
+      announcedByMachineId: 'machine-a',
+      announcedByDaemonInstanceId: 'daemon-a',
+    }
+    const newer = {
+      ...older,
+      latestVersion: '0.1.2',
+      latestRevision: '2222222222222222222222222222222222222222',
+      latestCommitAt: '2026-04-11T09:10:00.000Z',
+      announcedAt: '2026-04-11T09:10:10.000Z',
+      announcedByMachineId: 'machine-b',
+      announcedByDaemonInstanceId: 'daemon-b',
+    }
+
+    expect(extractManagedDaemonUpgradeAnnouncementComment(
+      buildManagedDaemonUpgradeAnnouncementComment(newer),
+    )).toEqual(newer)
+
+    const latest = getLatestManagedDaemonUpgradeAnnouncement([
+      {
+        commentId: 11,
+        body: buildManagedDaemonUpgradeAnnouncementComment(older),
+        createdAt: older.announcedAt,
+        updatedAt: older.announcedAt,
+      },
+      {
+        commentId: 12,
+        body: buildManagedDaemonUpgradeAnnouncementComment(newer),
+        createdAt: newer.announcedAt,
+        updatedAt: newer.announcedAt,
+      },
+    ], TEST_CONFIG.repo)
+
+    expect(latest?.announcement.latestRevision).toBe(newer.latestRevision)
   })
 
   test('filters active managed daemon presence comments by repo and expiry', () => {

--- a/apps/agent-daemon/src/presence.ts
+++ b/apps/agent-daemon/src/presence.ts
@@ -11,6 +11,7 @@ import {
 const MANAGED_DAEMON_PRESENCE_ISSUE_TITLE = 'Agent Loop Presence'
 const MANAGED_DAEMON_PRESENCE_ISSUE_MARKER = '<!-- agent-loop:presence-registry -->'
 const MANAGED_DAEMON_PRESENCE_COMMENT_PREFIX = '<!-- agent-loop:presence '
+const MANAGED_DAEMON_UPGRADE_ANNOUNCEMENT_COMMENT_PREFIX = '<!-- agent-loop:upgrade-announcement '
 const GITHUB_REST_TIMEOUT_MS = 180_000
 
 export type ManagedDaemonPresenceStatus = 'idle' | 'busy' | 'stopped'
@@ -52,6 +53,21 @@ export interface ManagedDaemonPresenceRuntimeState {
   latestVersion: string | null
   latestRevision: string | null
   upgradeCheckedAt: string | null
+}
+
+export interface ManagedDaemonUpgradeAnnouncement {
+  repo: string
+  channel: string | null
+  latestVersion: string | null
+  latestRevision: string | null
+  latestCommitAt: string | null
+  announcedAt: string
+  announcedByMachineId: string
+  announcedByDaemonInstanceId: string
+}
+
+export interface ManagedDaemonUpgradeAnnouncementComment extends IssueComment {
+  announcement: ManagedDaemonUpgradeAnnouncement
 }
 
 export interface PresenceApiAdapter {
@@ -256,6 +272,23 @@ export function buildManagedDaemonPresenceComment(presence: ManagedDaemonPresenc
 - Latest known revision: ${presence.latestRevision ?? 'unknown'}`
 }
 
+export function buildManagedDaemonUpgradeAnnouncementComment(
+  announcement: ManagedDaemonUpgradeAnnouncement,
+): string {
+  return `${MANAGED_DAEMON_UPGRADE_ANNOUNCEMENT_COMMENT_PREFIX}${JSON.stringify(announcement)} -->
+## Agent Loop upgrade announcement
+
+A managed daemon detected a newer agent-loop build and is broadcasting it to other machines.
+
+- Repo: ${announcement.repo}
+- Channel: ${announcement.channel ?? 'default'}
+- Latest version: ${announcement.latestVersion ?? 'unknown'}
+- Latest revision: ${announcement.latestRevision ?? 'unknown'}
+- Latest commit at: ${announcement.latestCommitAt ?? 'unknown'}
+- Announced at: ${announcement.announcedAt}
+- Announced by: ${announcement.announcedByMachineId} (${announcement.announcedByDaemonInstanceId})`
+}
+
 export function extractManagedDaemonPresenceComment(body: string): ManagedDaemonPresence | null {
   const match = body.match(/<!-- agent-loop:presence (\{.*\}) -->/)
   if (!match?.[1]) return null
@@ -326,6 +359,33 @@ export function extractManagedDaemonPresenceComment(body: string): ManagedDaemon
   }
 }
 
+export function extractManagedDaemonUpgradeAnnouncementComment(
+  body: string,
+): ManagedDaemonUpgradeAnnouncement | null {
+  const match = body.match(/<!-- agent-loop:upgrade-announcement (\{.*\}) -->/)
+  if (!match?.[1]) return null
+
+  try {
+    const parsed = JSON.parse(match[1]) as Partial<ManagedDaemonUpgradeAnnouncement>
+    if (!parsed || typeof parsed !== 'object') return null
+    if (typeof parsed.repo !== 'string' || typeof parsed.announcedAt !== 'string') return null
+    if (typeof parsed.announcedByMachineId !== 'string' || typeof parsed.announcedByDaemonInstanceId !== 'string') return null
+
+    return {
+      repo: parsed.repo,
+      channel: typeof parsed.channel === 'string' && parsed.channel.trim().length > 0 ? parsed.channel : null,
+      latestVersion: typeof parsed.latestVersion === 'string' && parsed.latestVersion.trim().length > 0 ? parsed.latestVersion : null,
+      latestRevision: typeof parsed.latestRevision === 'string' && parsed.latestRevision.trim().length > 0 ? parsed.latestRevision : null,
+      latestCommitAt: typeof parsed.latestCommitAt === 'string' && parsed.latestCommitAt.trim().length > 0 ? parsed.latestCommitAt : null,
+      announcedAt: parsed.announcedAt,
+      announcedByMachineId: parsed.announcedByMachineId,
+      announcedByDaemonInstanceId: parsed.announcedByDaemonInstanceId,
+    }
+  } catch {
+    return null
+  }
+}
+
 export function parseManagedDaemonPresenceComments(
   comments: IssueComment[],
 ): ManagedDaemonPresenceComment[] {
@@ -339,6 +399,35 @@ export function parseManagedDaemonPresenceComments(
       } satisfies ManagedDaemonPresenceComment
     })
     .filter((comment): comment is ManagedDaemonPresenceComment => comment !== null)
+}
+
+export function parseManagedDaemonUpgradeAnnouncementComments(
+  comments: IssueComment[],
+): ManagedDaemonUpgradeAnnouncementComment[] {
+  return comments
+    .map((comment) => {
+      const announcement = extractManagedDaemonUpgradeAnnouncementComment(comment.body)
+      if (!announcement) return null
+
+      return {
+        ...comment,
+        announcement,
+      } satisfies ManagedDaemonUpgradeAnnouncementComment
+    })
+    .filter((comment): comment is ManagedDaemonUpgradeAnnouncementComment => comment !== null)
+}
+
+export function getLatestManagedDaemonUpgradeAnnouncement(
+  comments: IssueComment[],
+  repo: string,
+): ManagedDaemonUpgradeAnnouncementComment | null {
+  return parseManagedDaemonUpgradeAnnouncementComments(comments)
+    .filter((comment) => comment.announcement.repo === repo)
+    .sort((left, right) => {
+      const announcedDiff = Date.parse(right.announcement.announcedAt) - Date.parse(left.announcement.announcedAt)
+      if (announcedDiff !== 0) return announcedDiff
+      return right.commentId - left.commentId
+    })[0] ?? null
 }
 
 export function isManagedDaemonPresenceExpired(

--- a/apps/agent-daemon/src/replay-eval.test.ts
+++ b/apps/agent-daemon/src/replay-eval.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
+import {
+  evaluateReplayFixtureDirectory,
+  evaluateReplayFixtures,
+} from './replay-eval'
+
+describe('evaluateReplayFixtures', () => {
+  test('reports fixture cases as passing only when actual summary matches expectation', () => {
+    const report = evaluateReplayFixtures([
+      {
+        name: 'claimability-basic',
+        openIssues: [
+          {
+            number: 91,
+            title: 'ready issue',
+            body: `## 用户故事
+
+作为 开发者，我希望 daemon 能 claim 这个 issue。
+
+## Context
+
+### Dependencies
+\`\`\`json
+{"dependsOn":[]}
+\`\`\`
+
+### AllowedFiles
+- apps/agent-daemon/src/example.ts
+
+### ForbiddenFiles
+- apps/agent-daemon/src/daemon.ts
+
+### MustPreserve
+- ready issue remains ready
+
+### OutOfScope
+- unrelated scheduler changes
+
+### RequiredSemantics
+- issue is claimable
+
+### ReviewHints
+- check contract validity
+
+### Validation
+- \`bun run typecheck\`
+
+## RED 测试
+
+\`\`\`ts
+throw new Error('fixture red test body')
+\`\`\`
+
+## 实现步骤
+1. add test
+
+## 验收
+- [ ] contract valid`,
+            labels: ['agent:ready'],
+            assignees: [],
+            state: 'open',
+            updatedAt: '2026-04-11T09:00:00.000Z',
+          },
+        ],
+        issueComments: [],
+        openPullRequests: [],
+        expected: {
+          claimable: 1,
+          blocked: 0,
+          invalid: 0,
+        },
+      },
+    ])
+
+    expect(report.ok).toBe(true)
+    expect(report.summary).toMatchObject({
+      totalCases: 1,
+      failedCases: 0,
+    })
+  })
+
+  test('marks a case as failed when actual summary differs from expectation', () => {
+    const report = evaluateReplayFixtures([
+      {
+        name: 'mismatch',
+        openIssues: [],
+        issueComments: [],
+        openPullRequests: [],
+        expected: {
+          claimable: 1,
+          blocked: 0,
+          invalid: 0,
+        },
+      },
+    ])
+
+    expect(report.ok).toBe(false)
+    expect(report.cases[0]).toMatchObject({
+      name: 'mismatch',
+      ok: false,
+    })
+    expect(report.cases[0]?.mismatches).toContain('claimable: expected 1, received 0')
+  })
+
+  test('loads repo fixtures from disk and evaluates them deterministically', () => {
+    const report = evaluateReplayFixtureDirectory(join(import.meta.dir, 'fixtures', 'replay'))
+
+    expect(report.ok).toBe(true)
+    expect(report.summary).toMatchObject({
+      totalCases: 2,
+      passedCases: 2,
+      failedCases: 0,
+      claimable: 1,
+      blocked: 1,
+      invalid: 1,
+    })
+  })
+})

--- a/apps/agent-daemon/src/replay-eval.ts
+++ b/apps/agent-daemon/src/replay-eval.ts
@@ -1,0 +1,466 @@
+#!/usr/bin/env bun
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { basename, join, resolve } from 'node:path'
+import {
+  applyDependencyClaimability,
+  deriveIssueStateFromRaw,
+  parseIssueContract,
+  validateIssueContract,
+  type AgentIssue,
+  type IssueComment,
+  type ManagedPullRequest,
+} from '@agent/shared'
+import {
+  getFailedIssueResumeBlock,
+  listBlockedIssueResumeEscalationComments,
+} from './daemon'
+
+export interface ReplayIssueFixture {
+  number: number
+  title: string
+  body: string
+  labels: string[]
+  assignees: string[]
+  state: 'open' | 'closed'
+  updatedAt: string
+}
+
+export interface ReplayIssueCommentFixture {
+  issueNumber: number
+  commentId?: number
+  body: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ReplayPullRequestFixture {
+  number: number
+  title: string
+  labels: string[]
+  isDraft?: boolean
+  headRefName?: string
+  headRefOid?: string | null
+  url?: string
+}
+
+export interface ReplayFixtureSummary {
+  claimable: number
+  blocked: number
+  invalid: number
+}
+
+export interface ReplayFixtureCase {
+  name: string
+  openIssues: ReplayIssueFixture[]
+  issueComments: ReplayIssueCommentFixture[]
+  openPullRequests: ReplayPullRequestFixture[]
+  expected: ReplayFixtureSummary
+}
+
+export interface ReplayFixtureCaseResult {
+  name: string
+  ok: boolean
+  actual: ReplayFixtureSummary
+  expected: ReplayFixtureSummary
+  mismatches: string[]
+}
+
+export interface ReplayFixtureReportSummary extends ReplayFixtureSummary {
+  totalCases: number
+  passedCases: number
+  failedCases: number
+}
+
+export interface ReplayFixtureReport {
+  ok: boolean
+  cases: ReplayFixtureCaseResult[]
+  summary: ReplayFixtureReportSummary
+}
+
+const DEFAULT_FIXTURES_DIR = 'apps/agent-daemon/src/fixtures/replay'
+
+export function evaluateReplayFixtures(fixtures: ReplayFixtureCase[]): ReplayFixtureReport {
+  const caseResults = fixtures.map(evaluateReplayFixtureCase)
+
+  return {
+    ok: caseResults.every((fixture) => fixture.ok),
+    cases: caseResults,
+    summary: {
+      totalCases: caseResults.length,
+      passedCases: caseResults.filter((fixture) => fixture.ok).length,
+      failedCases: caseResults.filter((fixture) => !fixture.ok).length,
+      claimable: caseResults.reduce((total, fixture) => total + fixture.actual.claimable, 0),
+      blocked: caseResults.reduce((total, fixture) => total + fixture.actual.blocked, 0),
+      invalid: caseResults.reduce((total, fixture) => total + fixture.actual.invalid, 0),
+    },
+  }
+}
+
+export function evaluateReplayFixtureDirectory(fixturesDir: string): ReplayFixtureReport {
+  return evaluateReplayFixtures(loadReplayFixtures(fixturesDir))
+}
+
+export function loadReplayFixtures(fixturesDir: string): ReplayFixtureCase[] {
+  const resolvedDir = resolve(fixturesDir)
+  const fixtureFiles = readdirSync(resolvedDir)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort((left, right) => left.localeCompare(right))
+
+  return fixtureFiles.map((entry) => {
+    const filePath = join(resolvedDir, entry)
+    const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as Partial<ReplayFixtureCase>
+    return normalizeReplayFixture(parsed, basename(entry, '.json'))
+  })
+}
+
+export function formatReplayFixtureReport(report: ReplayFixtureReport): string {
+  const lines = ['Replay Eval']
+
+  for (const fixture of report.cases) {
+    const status = fixture.ok ? 'ok' : 'failed'
+    const mismatchSuffix = fixture.mismatches.length > 0
+      ? ` mismatches=${fixture.mismatches.join(' | ')}`
+      : ''
+    lines.push(
+      `${fixture.name}: ${status} actual=${formatReplaySummary(fixture.actual)} expected=${formatReplaySummary(fixture.expected)}${mismatchSuffix}`,
+    )
+  }
+
+  lines.push(
+    `summary: total=${report.summary.totalCases} passed=${report.summary.passedCases} failed=${report.summary.failedCases} actual=${formatReplaySummary(report.summary)}`,
+  )
+
+  return lines.join('\n')
+}
+
+function evaluateReplayFixtureCase(fixture: ReplayFixtureCase): ReplayFixtureCaseResult {
+  const openIssues = applyDependencyClaimability(
+    fixture.openIssues.map(mapReplayIssueFixture),
+  )
+  const invalidIssueNumbers = new Set(
+    openIssues
+      .filter((issue) => issue.state === 'ready' && (!issue.hasExecutableContract || issue.dependencyParseError))
+      .map((issue) => issue.number),
+  )
+  const blockedIssueNumbers = new Set<number>()
+
+  for (const issue of openIssues) {
+    if (issue.state === 'ready' && !issue.isClaimable && !invalidIssueNumbers.has(issue.number)) {
+      blockedIssueNumbers.add(issue.number)
+    }
+  }
+
+  for (const issueNumber of evaluateBlockedResumeIssueNumbers(fixture.openIssues, fixture.issueComments, fixture.openPullRequests)) {
+    blockedIssueNumbers.add(issueNumber)
+  }
+
+  const actual: ReplayFixtureSummary = {
+    claimable: openIssues.filter((issue) => issue.isClaimable).length,
+    blocked: blockedIssueNumbers.size,
+    invalid: invalidIssueNumbers.size,
+  }
+  const mismatches = compareReplaySummary(actual, fixture.expected)
+
+  return {
+    name: fixture.name,
+    ok: mismatches.length === 0,
+    actual,
+    expected: fixture.expected,
+    mismatches,
+  }
+}
+
+function mapReplayIssueFixture(issue: ReplayIssueFixture): AgentIssue {
+  const contract = parseIssueContract(issue.body)
+  const validation = validateIssueContract(contract)
+
+  return {
+    number: issue.number,
+    title: issue.title,
+    body: issue.body,
+    state: deriveIssueStateFromRaw(issue.labels, issue.state),
+    labels: [...issue.labels],
+    assignee: issue.assignees[0] ?? null,
+    isClaimable: false,
+    updatedAt: issue.updatedAt,
+    dependencyIssueNumbers: contract.dependencies,
+    hasDependencyMetadata: contract.hasDependencyMetadata,
+    dependencyParseError: contract.dependencyParseError,
+    claimBlockedBy: [],
+    hasExecutableContract: validation.valid,
+    contractValidationErrors: validation.errors,
+  }
+}
+
+function evaluateBlockedResumeIssueNumbers(
+  openIssues: ReplayIssueFixture[],
+  issueComments: ReplayIssueCommentFixture[],
+  openPullRequests: ReplayPullRequestFixture[],
+): Set<number> {
+  const blockedIssueNumbers = new Set<number>()
+
+  for (const issue of openIssues) {
+    const issueState = deriveIssueStateFromRaw(issue.labels, issue.state)
+    if (issueState !== 'failed') {
+      continue
+    }
+
+    const linkedPr = openPullRequests
+      .map(mapReplayPullRequestFixture)
+      .find((pullRequest) => extractIssueNumberFromPrTitle(pullRequest.title) === issue.number) ?? null
+    const issueScopedComments = issueComments
+      .filter((comment) => comment.issueNumber === issue.number)
+      .map(mapReplayIssueCommentFixture)
+
+    if (
+      listBlockedIssueResumeEscalationComments(
+        issueScopedComments,
+        issue.number,
+        linkedPr?.number ?? null,
+      ).length > 0
+    ) {
+      blockedIssueNumbers.add(issue.number)
+      continue
+    }
+
+    if (getFailedIssueResumeBlock(linkedPr, false) !== null) {
+      blockedIssueNumbers.add(issue.number)
+    }
+  }
+
+  return blockedIssueNumbers
+}
+
+function mapReplayPullRequestFixture(pullRequest: ReplayPullRequestFixture): ManagedPullRequest {
+  return {
+    number: pullRequest.number,
+    title: pullRequest.title,
+    url: pullRequest.url ?? `https://example.invalid/pr/${pullRequest.number}`,
+    headRefName: pullRequest.headRefName ?? `agent/${pullRequest.number}`,
+    headRefOid: pullRequest.headRefOid ?? null,
+    isDraft: pullRequest.isDraft ?? false,
+    labels: [...pullRequest.labels],
+  }
+}
+
+function mapReplayIssueCommentFixture(comment: ReplayIssueCommentFixture, index: number): IssueComment
+function mapReplayIssueCommentFixture(comment: ReplayIssueCommentFixture): IssueComment
+function mapReplayIssueCommentFixture(comment: ReplayIssueCommentFixture, index = 0): IssueComment {
+  return {
+    commentId: comment.commentId ?? index + 1,
+    body: comment.body,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+  }
+}
+
+function compareReplaySummary(actual: ReplayFixtureSummary, expected: ReplayFixtureSummary): string[] {
+  const keys: Array<keyof ReplayFixtureSummary> = ['claimable', 'blocked', 'invalid']
+
+  return keys
+    .filter((key) => actual[key] !== expected[key])
+    .map((key) => `${key}: expected ${expected[key]}, received ${actual[key]}`)
+}
+
+function normalizeReplayFixture(parsed: Partial<ReplayFixtureCase>, fallbackName: string): ReplayFixtureCase {
+  if (typeof parsed.name !== 'string' && parsed.name !== undefined) {
+    throw new Error(`Fixture ${fallbackName} has a non-string name`)
+  }
+
+  return {
+    name: typeof parsed.name === 'string' && parsed.name.trim().length > 0
+      ? parsed.name.trim()
+      : fallbackName,
+    openIssues: normalizeOpenIssues(parsed.openIssues, fallbackName),
+    issueComments: normalizeIssueComments(parsed.issueComments, fallbackName),
+    openPullRequests: normalizePullRequests(parsed.openPullRequests, fallbackName),
+    expected: normalizeExpectedSummary(parsed.expected, fallbackName),
+  }
+}
+
+function normalizeOpenIssues(input: unknown, fixtureName: string): ReplayIssueFixture[] {
+  if (!Array.isArray(input)) {
+    throw new Error(`Fixture ${fixtureName} must define openIssues as an array`)
+  }
+
+  return input.map((issue, index) => {
+    if (!issue || typeof issue !== 'object') {
+      throw new Error(`Fixture ${fixtureName} openIssues[${index}] must be an object`)
+    }
+
+    const candidate = issue as Partial<ReplayIssueFixture>
+    if (
+      !Number.isInteger(candidate.number)
+      || typeof candidate.title !== 'string'
+      || typeof candidate.body !== 'string'
+      || !Array.isArray(candidate.labels)
+      || !Array.isArray(candidate.assignees)
+      || (candidate.state !== 'open' && candidate.state !== 'closed')
+      || typeof candidate.updatedAt !== 'string'
+    ) {
+      throw new Error(`Fixture ${fixtureName} openIssues[${index}] is malformed`)
+    }
+
+    const number = candidate.number as number
+    const title = candidate.title
+    const body = candidate.body
+    const state = candidate.state
+    const updatedAt = candidate.updatedAt
+
+    return {
+      number,
+      title,
+      body,
+      labels: candidate.labels.filter((label): label is string => typeof label === 'string'),
+      assignees: candidate.assignees.filter((assignee): assignee is string => typeof assignee === 'string'),
+      state,
+      updatedAt,
+    }
+  })
+}
+
+function normalizeIssueComments(input: unknown, fixtureName: string): ReplayIssueCommentFixture[] {
+  if (!Array.isArray(input)) {
+    throw new Error(`Fixture ${fixtureName} must define issueComments as an array`)
+  }
+
+  return input.map((comment, index) => {
+    if (!comment || typeof comment !== 'object') {
+      throw new Error(`Fixture ${fixtureName} issueComments[${index}] must be an object`)
+    }
+
+    const candidate = comment as Partial<ReplayIssueCommentFixture>
+    if (
+      !Number.isInteger(candidate.issueNumber)
+      || typeof candidate.body !== 'string'
+      || typeof candidate.createdAt !== 'string'
+      || typeof candidate.updatedAt !== 'string'
+    ) {
+      throw new Error(`Fixture ${fixtureName} issueComments[${index}] is malformed`)
+    }
+
+    const issueNumber = candidate.issueNumber as number
+    const body = candidate.body
+    const createdAt = candidate.createdAt
+    const updatedAt = candidate.updatedAt
+
+    return {
+      issueNumber,
+      commentId: Number.isInteger(candidate.commentId) ? candidate.commentId : undefined,
+      body,
+      createdAt,
+      updatedAt,
+    }
+  })
+}
+
+function normalizePullRequests(input: unknown, fixtureName: string): ReplayPullRequestFixture[] {
+  if (!Array.isArray(input)) {
+    throw new Error(`Fixture ${fixtureName} must define openPullRequests as an array`)
+  }
+
+  return input.map((pullRequest, index) => {
+    if (!pullRequest || typeof pullRequest !== 'object') {
+      throw new Error(`Fixture ${fixtureName} openPullRequests[${index}] must be an object`)
+    }
+
+    const candidate = pullRequest as Partial<ReplayPullRequestFixture>
+    if (
+      !Number.isInteger(candidate.number)
+      || typeof candidate.title !== 'string'
+      || !Array.isArray(candidate.labels)
+    ) {
+      throw new Error(`Fixture ${fixtureName} openPullRequests[${index}] is malformed`)
+    }
+
+    const number = candidate.number as number
+    const title = candidate.title
+
+    return {
+      number,
+      title,
+      labels: candidate.labels.filter((label): label is string => typeof label === 'string'),
+      isDraft: candidate.isDraft,
+      headRefName: candidate.headRefName,
+      headRefOid: candidate.headRefOid,
+      url: candidate.url,
+    }
+  })
+}
+
+function normalizeExpectedSummary(input: unknown, fixtureName: string): ReplayFixtureSummary {
+  if (!input || typeof input !== 'object') {
+    throw new Error(`Fixture ${fixtureName} must define expected summary fields`)
+  }
+
+  const candidate = input as Partial<ReplayFixtureSummary>
+  if (
+    !Number.isInteger(candidate.claimable)
+    || !Number.isInteger(candidate.blocked)
+    || !Number.isInteger(candidate.invalid)
+  ) {
+    throw new Error(`Fixture ${fixtureName} expected summary is malformed`)
+  }
+
+  return {
+    claimable: candidate.claimable as number,
+    blocked: candidate.blocked as number,
+    invalid: candidate.invalid as number,
+  }
+}
+
+function formatReplaySummary(summary: ReplayFixtureSummary): string {
+  return `claimable=${summary.claimable} blocked=${summary.blocked} invalid=${summary.invalid}`
+}
+
+function extractIssueNumberFromPrTitle(title: string): number | null {
+  const match = title.match(/#(\d+)/)
+  if (!match) return null
+
+  const parsed = Number.parseInt(match[1] ?? '', 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseArgs(argv: string[]): {
+  fixturesDir: string
+} {
+  let fixturesDir = DEFAULT_FIXTURES_DIR
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (!token) {
+      continue
+    }
+
+    if (token === '--fixtures-dir') {
+      const nextToken = argv[index + 1]
+      fixturesDir = typeof nextToken === 'string' ? nextToken : fixturesDir
+      index += 1
+      continue
+    }
+
+    if (!token.startsWith('-')) {
+      fixturesDir = token
+    }
+  }
+
+  return {
+    fixturesDir,
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  const report = evaluateReplayFixtureDirectory(args.fixturesDir)
+
+  console.log(formatReplayFixtureReport(report))
+  process.exit(report.ok ? 0 : 1)
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error('[replay-eval] failed:', error)
+    process.exit(1)
+  })
+}

--- a/apps/agent-daemon/src/status.test.ts
+++ b/apps/agent-daemon/src/status.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 import { buildManagedLeaseComment, type DaemonStatus, type ManagedLease } from '@agent/shared'
+import {
+  buildBlockedIssueResumeEscalationComment,
+  buildIssueResumeResolutionComment,
+} from './daemon'
 import { buildPrReviewComment } from './pr-reviewer'
 import {
   collectDaemonObservability,
@@ -894,6 +898,138 @@ describe('status helpers', () => {
     }))
     const blockedCheck = audit.checks.find((check) => check.scope === 'issue-process' && check.targetNumber === 91)
     expect(blockedCheck?.blockedAgeSeconds).toBeGreaterThan(300)
+  })
+
+  test('surfaces valid blocked-issue resolution signals from GitHub state', async () => {
+    const blockedComment = buildPrReviewComment(110, {
+      approved: false,
+      canMerge: false,
+      reason: 'Selection state still breaks the issue contract.',
+      findings: [
+        {
+          severity: 'high',
+          file: 'apps/desktop/src/pages/MainPage.tsx',
+          summary: 'selection mode regressed the required session list behavior',
+          mustFix: ['restore the issue-scoped session list semantics'],
+          mustNotDo: ['do not expand scope beyond issue #91'],
+          validation: ['bun --cwd apps/desktop test src/pages/MainPage.test.tsx'],
+          scopeRationale: 'issue #91 only covers existing session summary and switching',
+        },
+      ],
+    }, 3, 'human-needed')
+
+    const audit = await collectGitHubLeaseAudit({
+      daemonInstanceId: baseHealth.daemonInstanceId,
+      repo: 'JamesWuHK/digital-employee',
+      runtime: {
+        activeLeaseDetails: [],
+      },
+    }, async (args) => {
+      if (args[0] === 'issue' && args[1] === 'list') {
+        return {
+          ok: true,
+          data: [
+            {
+              number: 91,
+              state: 'OPEN',
+              labels: [{ name: 'agent:failed' }],
+            },
+          ],
+          error: null,
+        }
+      }
+
+      if (args[0] === 'pr' && args[1] === 'list') {
+        return {
+          ok: true,
+          data: [
+            {
+              number: 110,
+              state: 'OPEN',
+              headRefName: 'agent/91/codex-dev',
+              labels: [{ name: 'agent:review-failed' }, { name: 'agent:human-needed' }],
+            },
+          ],
+          error: null,
+        }
+      }
+
+      if (args[0] === 'api' && args[1] === 'repos/JamesWuHK/digital-employee/issues/91/comments') {
+        return {
+          ok: true,
+          data: [
+            {
+              id: 201,
+              body: buildBlockedIssueResumeEscalationComment({
+                issueNumber: 91,
+                prNumber: 110,
+                blockedSince: '2026-04-11T08:00:00.000Z',
+                escalatedAt: '2026-04-11T08:10:00.000Z',
+                thresholdSeconds: 300,
+                reason: 'linked PR #110 is in terminal agent:human-needed; automated review has no remaining structured retry path',
+                machineId: 'codex-dev',
+                daemonInstanceId: 'daemon-1',
+              }),
+              created_at: '2026-04-11T08:10:00.000Z',
+              updated_at: '2026-04-11T08:10:00.000Z',
+            },
+            {
+              id: 202,
+              body: buildIssueResumeResolutionComment({
+                issueNumber: 91,
+                prNumber: 110,
+                resolvedAt: '2026-04-11T08:25:00.000Z',
+                resolution: 'human-follow-up-complete',
+              }),
+              created_at: '2026-04-11T08:25:00.000Z',
+              updated_at: '2026-04-11T08:25:00.000Z',
+            },
+          ],
+          error: null,
+        }
+      }
+
+      if (args[0] === 'api' && args[1] === 'repos/JamesWuHK/digital-employee/issues/110/comments') {
+        return {
+          ok: true,
+          data: [
+            {
+              id: 301,
+              body: blockedComment,
+              created_at: '2000-04-05T08:02:00.000Z',
+              updated_at: '2000-04-05T08:02:30.000Z',
+            },
+          ],
+          error: null,
+        }
+      }
+
+      return {
+        ok: false,
+        data: null,
+        error: `unexpected gh invocation: ${args.join(' ')}`,
+      }
+    })
+
+    expect(audit.ok).toBe(true)
+    expect(audit.warnings).toContain('issue-process#91 received a valid resolution signal for linked PR #110 at 2026-04-11T08:25:00.000Z: human-follow-up-complete')
+    expect(audit.warnings).not.toContain('issue-process#91 is blocked by linked PR #110: linked PR #110 is in terminal agent:human-needed; automated review has no remaining structured retry path')
+
+    const report = formatStatusReport({
+      ok: true,
+      healthUrl: 'http://127.0.0.1:9310/health',
+      metricsUrl: null,
+      error: null,
+      diagnosticRepo: baseHealth.repo,
+      localRuntime: baseLocalRuntime,
+      health: baseHealth,
+      metrics: null,
+      metricsError: null,
+      githubAudit: audit,
+      warnings: [],
+    })
+
+    expect(report).toContain('issue-process#91 received a valid resolution signal for linked PR #110 at 2026-04-11T08:25:00.000Z: human-follow-up-complete')
   })
 
   test('collects remote GitHub lease diagnostics even when the local health endpoint is unreachable', async () => {

--- a/apps/agent-daemon/src/status.ts
+++ b/apps/agent-daemon/src/status.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_HEALTH_SERVER_PORT,
   BLOCKED_ISSUE_RESUME_WARNING_AGE_SECONDS,
   HEALTH_PATH,
+  evaluateBlockedIssueResumeResolution,
   getFailedIssueResumeBlock,
 } from './daemon'
 import {
@@ -1493,6 +1494,7 @@ async function collectRemoteGitHubLeaseChecks(
 
   const checks: GitHubLeaseAuditCheck[] = []
   const prBlockers: GitHubPrBlockerSummary[] = []
+  const issueCommentsByNumber = new Map<number, IssueComment[]>()
   const prCommentsByNumber = new Map<number, IssueComment[]>()
   const openIssues = normalizeGitHubIssueList(issueListResult.data)
     .filter((issue) => issue.labels.some((label) => label.startsWith('agent:')))
@@ -1501,26 +1503,24 @@ async function collectRemoteGitHubLeaseChecks(
   const issueBodiesByNumber = new Map(openIssues.map((issue) => [issue.number, issue.body]))
 
   for (const issue of openIssues) {
-    const key = buildLeaseAuditKey('issue-process', issue.number)
-    if (knownKeys.has(key)) continue
-
-    const commentResult = await fetchActiveRemoteManagedLease({
-      repo: health.repo,
-      targetNumber: issue.number,
-      scope: 'issue-process',
-      runner,
-    })
-    if (commentResult.error) {
+    const issueCommentResult = await fetchRemoteManagedLeaseComments(issue.number, runner, health.repo)
+    if (issueCommentResult.error) {
       return {
         checks,
         prBlockers,
-        error: `issue-process#${issue.number}: ${commentResult.error}`,
+        error: `issue-process#${issue.number}: ${issueCommentResult.error}`,
       }
     }
-    if (!commentResult.comment) continue
+    issueCommentsByNumber.set(issue.number, issueCommentResult.comments ?? [])
+
+    const key = buildLeaseAuditKey('issue-process', issue.number)
+    if (knownKeys.has(key)) continue
+
+    const comment = getActiveManagedLease(issueCommentResult.comments ?? [], 'issue-process')
+    if (!comment) continue
 
     checks.push(buildGitHubLeaseAuditCheckFromState(
-      buildLeaseAuditSubjectFromComment(commentResult.comment, issue.number, 'remote', health.daemonInstanceId),
+      buildLeaseAuditSubjectFromComment(comment, issue.number, 'remote', health.daemonInstanceId),
       issue.state,
       issue.labels,
     ))
@@ -1564,7 +1564,7 @@ async function collectRemoteGitHubLeaseChecks(
     }
   }
 
-  checks.push(...collectRemoteBlockedIssueResumeChecks(openIssues, openPrs, prCommentsByNumber))
+  checks.push(...collectRemoteBlockedIssueResumeChecks(openIssues, openPrs, issueCommentsByNumber, prCommentsByNumber))
 
   return {
     checks,
@@ -1733,6 +1733,7 @@ function normalizeGitHubLabels(labels: Array<{ name?: unknown }> | undefined): s
 function collectRemoteBlockedIssueResumeChecks(
   issues: Array<{ number: number; state: string; labels: string[]; updatedAt: string; body: string }>,
   prs: Array<{ number: number; state: string; labels: string[]; headRefName: string; headRefOid: string | null }>,
+  issueCommentsByNumber: Map<number, IssueComment[]>,
   prCommentsByNumber: Map<number, IssueComment[]>,
 ): GitHubLeaseAuditCheck[] {
   const checks: GitHubLeaseAuditCheck[] = []
@@ -1750,7 +1751,9 @@ function collectRemoteBlockedIssueResumeChecks(
     if (linkedPrs.length === 0) continue
 
     let firstBlocked: { prNumber: number; reason: string; blockedAgeSeconds: number | null } | null = null
+    let firstResolutionSignal: { prNumber: number; resolvedAt: string; resolution: string } | null = null
     let hasResumableLinkedPr = false
+    const issueComments = issueCommentsByNumber.get(issue.number) ?? []
 
     for (const pr of linkedPrs) {
       const prComments = prCommentsByNumber.get(pr.number) ?? []
@@ -1772,6 +1775,21 @@ function collectRemoteBlockedIssueResumeChecks(
         break
       }
 
+      const resolution = evaluateBlockedIssueResumeResolution(issueComments, issue.number, pr.number)
+      if (resolution.canResume && resolution.latestResolution) {
+        if (
+          firstResolutionSignal === null
+          || Date.parse(resolution.latestResolution.resolutionComment.resolvedAt) > Date.parse(firstResolutionSignal.resolvedAt)
+        ) {
+          firstResolutionSignal = {
+            prNumber: pr.number,
+            resolvedAt: resolution.latestResolution.resolutionComment.resolvedAt,
+            resolution: resolution.latestResolution.resolutionComment.resolution,
+          }
+        }
+        continue
+      }
+
       const blockedAgeSeconds = getLatestAutomatedPrReviewCommentAgeSeconds(prComments)
       if (
         firstBlocked === null
@@ -1785,7 +1803,21 @@ function collectRemoteBlockedIssueResumeChecks(
       }
     }
 
-    if (hasResumableLinkedPr || firstBlocked === null) continue
+    if (hasResumableLinkedPr) continue
+
+    if (firstBlocked === null && firstResolutionSignal !== null) {
+      checks.push({
+        scope: 'issue-process',
+        targetNumber: issue.number,
+        state: issue.state,
+        labels: issue.labels,
+        warning: `issue-process#${issue.number} received a valid resolution signal for linked PR #${firstResolutionSignal.prNumber} at ${firstResolutionSignal.resolvedAt}: ${firstResolutionSignal.resolution}`,
+        source: 'remote',
+      })
+      continue
+    }
+
+    if (firstBlocked === null) continue
 
     checks.push({
       scope: 'issue-process',

--- a/apps/agent-daemon/src/version.test.ts
+++ b/apps/agent-daemon/src/version.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, test } from 'bun:test'
 import type { AgentConfig, AgentLoopBuildMetadata } from '@agent/shared'
 import {
   abbreviateRevision,
+  applyAgentLoopUpgradeToLocalCheckout,
   checkForAgentLoopUpgrade,
   compareAgentLoopVersions,
   createInitialAgentLoopUpgradeMetadata,
+  listLocalAgentLoopUpgradeDirtyPaths,
+  resolveAgentLoopUpgradePolicy,
 } from './version'
 
 const TEST_CONFIG: AgentConfig = {
@@ -54,6 +57,7 @@ const TEST_CONFIG: AgentConfig = {
     channel: 'master',
     checkIntervalMs: 60_000,
     reminderIntervalMs: 3_600_000,
+    autoApply: false,
   },
 }
 
@@ -96,6 +100,124 @@ describe('createInitialAgentLoopUpgradeMetadata', () => {
 
     expect(metadata.status).toBe('disabled')
     expect(metadata.safeToUpgradeNow).toBe(true)
+  })
+})
+
+describe('resolveAgentLoopUpgradePolicy', () => {
+  test('keeps auto-apply disabled unless explicitly opted in', () => {
+    expect(resolveAgentLoopUpgradePolicy(TEST_CONFIG, LOCAL_BUILD).autoApply).toBe(false)
+    expect(resolveAgentLoopUpgradePolicy({
+      ...TEST_CONFIG,
+      upgrade: {
+        ...TEST_CONFIG.upgrade!,
+        autoApply: true,
+      },
+    }, LOCAL_BUILD).autoApply).toBe(true)
+  })
+})
+
+describe('listLocalAgentLoopUpgradeDirtyPaths', () => {
+  test('ignores local runtime artifacts while preserving real dirty paths', () => {
+    expect(listLocalAgentLoopUpgradeDirtyPaths([
+      '?? .runtime/',
+      ' M README.md',
+      '?? docs/design-notes.md',
+    ].join('\n'))).toEqual([
+      'README.md',
+      'docs/design-notes.md',
+    ])
+  })
+})
+
+describe('applyAgentLoopUpgradeToLocalCheckout', () => {
+  test('pulls the tracked channel and refreshes dependencies for clean matching checkouts', () => {
+    const calls: string[] = []
+
+    const result = applyAgentLoopUpgradeToLocalCheckout({
+      build: LOCAL_BUILD,
+      upgrade: {
+        repo: 'JamesWuHK/agent-loop',
+        channel: 'master',
+      },
+    }, {
+      runCommand: (command, args) => {
+        calls.push(`${command} ${args.join(' ')}`)
+        const rendered = `${command} ${args.join(' ')}`
+        if (rendered === 'git status --porcelain --untracked-files=all') {
+          return { stdout: '?? .runtime/\n', stderr: '' }
+        }
+        if (rendered === 'git branch --show-current') {
+          return { stdout: 'master\n', stderr: '' }
+        }
+        if (rendered === 'git rev-parse HEAD') {
+          return {
+            stdout: calls.filter((value) => value === 'git rev-parse HEAD').length === 1
+              ? '1111111111111111111111111111111111111111\n'
+              : '2222222222222222222222222222222222222222\n',
+            stderr: '',
+          }
+        }
+        if (rendered === 'git pull --ff-only origin master') {
+          return { stdout: 'Updating 1111111..2222222\nFast-forward\n', stderr: '' }
+        }
+        if (command === process.execPath && args.join(' ') === 'install --frozen-lockfile') {
+          return { stdout: 'bun install v1.3.6\n', stderr: '' }
+        }
+        throw new Error(`Unexpected command: ${rendered}`)
+      },
+    })
+
+    expect(result).toEqual({
+      currentBranch: 'master',
+      previousRevision: '1111111111111111111111111111111111111111',
+      nextRevision: '2222222222222222222222222222222222222222',
+      changed: true,
+    })
+    expect(calls).toEqual([
+      'git status --porcelain --untracked-files=all',
+      'git branch --show-current',
+      'git rev-parse HEAD',
+      'git pull --ff-only origin master',
+      `${process.execPath} install --frozen-lockfile`,
+      'git rev-parse HEAD',
+    ])
+  })
+
+  test('refuses to auto-upgrade dirty or branch-mismatched local checkouts', () => {
+    expect(() => applyAgentLoopUpgradeToLocalCheckout({
+      build: LOCAL_BUILD,
+      upgrade: {
+        repo: 'JamesWuHK/agent-loop',
+        channel: 'master',
+      },
+    }, {
+      runCommand: (command, args) => {
+        const rendered = `${command} ${args.join(' ')}`
+        if (rendered === 'git status --porcelain --untracked-files=all') {
+          return { stdout: ' M README.md\n', stderr: '' }
+        }
+        throw new Error(`Unexpected command: ${rendered}`)
+      },
+    })).toThrow('agent-loop checkout has local changes')
+
+    expect(() => applyAgentLoopUpgradeToLocalCheckout({
+      build: LOCAL_BUILD,
+      upgrade: {
+        repo: 'JamesWuHK/agent-loop',
+        channel: 'master',
+      },
+    }, {
+      runCommand: (command, args) => {
+        const rendered = `${command} ${args.join(' ')}`
+        if (rendered === 'git status --porcelain --untracked-files=all') {
+          return { stdout: '', stderr: '' }
+        }
+        if (rendered === 'git branch --show-current') {
+          return { stdout: 'develop\n', stderr: '' }
+        }
+        throw new Error(`Unexpected command: ${rendered}`)
+      },
+    })).toThrow('requires current branch master, found develop')
   })
 })
 

--- a/apps/agent-daemon/src/version.ts
+++ b/apps/agent-daemon/src/version.ts
@@ -13,6 +13,7 @@ export const DEFAULT_AGENT_LOOP_UPGRADE_REMINDER_INTERVAL_MS = 60 * 60 * 1000
 
 const AGENT_LOOP_REPO_ROOT = resolve(import.meta.dir, '../../..')
 const AGENT_LOOP_PACKAGE_JSON_PATH = resolve(AGENT_LOOP_REPO_ROOT, 'package.json')
+const AUTO_UPGRADE_IGNORED_LOCAL_PATH_PREFIXES = ['.runtime/'] as const
 
 interface GitHubRepoRecord {
   default_branch?: unknown
@@ -42,6 +43,25 @@ interface VersionFileRecord {
 interface ResolvedUpgradeTarget {
   repo: string
   channel: string
+}
+
+export interface AgentLoopLocalCommandResult {
+  stdout: string
+  stderr: string
+}
+
+export interface AgentLoopLocalUpgradeDependencies {
+  runCommand: (
+    command: string,
+    args: string[],
+    options?: {
+      cwd?: string
+    },
+  ) => AgentLoopLocalCommandResult
+}
+
+const DEFAULT_AGENT_LOOP_LOCAL_UPGRADE_DEPENDENCIES: AgentLoopLocalUpgradeDependencies = {
+  runCommand: runLocalCommand,
 }
 
 export function resolveAgentLoopBuildMetadata(): AgentLoopBuildMetadata {
@@ -132,6 +152,7 @@ export function resolveAgentLoopUpgradePolicy(
   channel: string | null
   checkIntervalMs: number
   reminderIntervalMs: number
+  autoApply: boolean
 } {
   return {
     enabled: config.upgrade?.enabled !== false,
@@ -145,6 +166,92 @@ export function resolveAgentLoopUpgradePolicy(
       config.upgrade?.reminderIntervalMs,
       DEFAULT_AGENT_LOOP_UPGRADE_REMINDER_INTERVAL_MS,
     ),
+    autoApply: config.upgrade?.autoApply === true,
+  }
+}
+
+export function listLocalAgentLoopUpgradeDirtyPaths(
+  porcelainStatusOutput: string,
+): string[] {
+  return porcelainStatusOutput
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length >= 4)
+    .flatMap((line) => {
+      const pathSpec = line.slice(3).trim()
+      return pathSpec.includes(' -> ')
+        ? pathSpec.split(' -> ').map((part) => part.trim()).filter(Boolean)
+        : [pathSpec]
+    })
+    .filter((path) => !isIgnoredAutoUpgradeDirtyPath(path))
+}
+
+export function applyAgentLoopUpgradeToLocalCheckout(
+  input: {
+    build: AgentLoopBuildMetadata
+    upgrade: Pick<AgentLoopUpgradeMetadata, 'channel' | 'repo'>
+  },
+  deps: AgentLoopLocalUpgradeDependencies = DEFAULT_AGENT_LOOP_LOCAL_UPGRADE_DEPENDENCIES,
+): {
+  currentBranch: string
+  previousRevision: string | null
+  nextRevision: string | null
+  changed: boolean
+} {
+  if (!input.build.repo || !input.upgrade.repo || input.build.repo !== input.upgrade.repo) {
+    throw new Error(
+      `local agent-loop origin ${input.build.repo ?? 'unknown'} does not match upgrade repo ${input.upgrade.repo ?? 'unknown'}`,
+    )
+  }
+
+  const channel = normalizeOptionalString(input.upgrade.channel)
+  if (!channel) {
+    throw new Error('agent-loop auto-upgrade requires a resolved channel name')
+  }
+
+  const dirtyPaths = listLocalAgentLoopUpgradeDirtyPaths(
+    deps.runCommand('git', ['status', '--porcelain', '--untracked-files=all'], {
+      cwd: AGENT_LOOP_REPO_ROOT,
+    }).stdout,
+  )
+  if (dirtyPaths.length > 0) {
+    throw new Error(`agent-loop checkout has local changes: ${dirtyPaths.join(', ')}`)
+  }
+
+  const currentBranch = deps.runCommand('git', ['branch', '--show-current'], {
+    cwd: AGENT_LOOP_REPO_ROOT,
+  }).stdout.trim()
+  if (!currentBranch) {
+    throw new Error('agent-loop auto-upgrade requires a checked-out local branch')
+  }
+  if (currentBranch !== channel) {
+    throw new Error(`agent-loop auto-upgrade requires current branch ${channel}, found ${currentBranch}`)
+  }
+
+  const previousRevision = normalizeOptionalString(
+    deps.runCommand('git', ['rev-parse', 'HEAD'], {
+      cwd: AGENT_LOOP_REPO_ROOT,
+    }).stdout,
+  )
+
+  deps.runCommand('git', ['pull', '--ff-only', 'origin', channel], {
+    cwd: AGENT_LOOP_REPO_ROOT,
+  })
+  deps.runCommand(process.execPath, ['install', '--frozen-lockfile'], {
+    cwd: AGENT_LOOP_REPO_ROOT,
+  })
+
+  const nextRevision = normalizeOptionalString(
+    deps.runCommand('git', ['rev-parse', 'HEAD'], {
+      cwd: AGENT_LOOP_REPO_ROOT,
+    }).stdout,
+  )
+
+  return {
+    currentBranch,
+    previousRevision,
+    nextRevision,
+    changed: previousRevision !== nextRevision,
   }
 }
 
@@ -349,6 +456,40 @@ function parseGitHubErrorMessage(body: string): string {
   }
 
   return trimmed
+}
+
+function isIgnoredAutoUpgradeDirtyPath(path: string): boolean {
+  const normalized = path.replace(/\\/g, '/').replace(/^"\.\//, '').replace(/^\.\//, '')
+  return AUTO_UPGRADE_IGNORED_LOCAL_PATH_PREFIXES.some((prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix))
+}
+
+function runLocalCommand(
+  command: string,
+  args: string[],
+  options: {
+    cwd?: string
+  } = {},
+): AgentLoopLocalCommandResult {
+  try {
+    return {
+      stdout: execFileSync(command, args, {
+        cwd: options.cwd,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+      stderr: '',
+    }
+  } catch (error) {
+    const stdout = error instanceof Error && 'stdout' in error && typeof error.stdout === 'string'
+      ? error.stdout
+      : ''
+    const stderr = error instanceof Error && 'stderr' in error && typeof error.stderr === 'string'
+      ? error.stderr
+      : error instanceof Error
+        ? error.message
+        : String(error)
+    throw new Error(`${command} ${args.join(' ')} failed: ${(stderr || stdout).trim() || 'unknown command failure'}`)
+  }
 }
 
 function parseVersionParts(version: string): number[] {

--- a/apps/agent-daemon/src/version.ts
+++ b/apps/agent-daemon/src/version.ts
@@ -531,3 +531,37 @@ function normalizePositiveInteger(value: number | undefined, fallback: number): 
     ? value
     : fallback
 }
+
+function isIgnoredAutoUpgradeDirtyPath(path: string): boolean {
+  const normalized = path.replace(/\\/g, '/').replace(/^"\.\//, '').replace(/^\.\//, '')
+  return AUTO_UPGRADE_IGNORED_LOCAL_PATH_PREFIXES.some((prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix))
+}
+
+function runLocalCommand(
+  command: string,
+  args: string[],
+  options: {
+    cwd?: string
+  } = {},
+): AgentLoopLocalCommandResult {
+  try {
+    return {
+      stdout: execFileSync(command, args, {
+        cwd: options.cwd,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+      stderr: '',
+    }
+  } catch (error) {
+    const stdout = typeof error === 'object' && error !== null && 'stdout' in error && typeof error.stdout === 'string'
+      ? error.stdout
+      : ''
+    const stderr = typeof error === 'object' && error !== null && 'stderr' in error && typeof error.stderr === 'string'
+      ? error.stderr
+      : error instanceof Error
+        ? error.message
+        : String(error)
+    throw new Error(`${command} ${args.join(' ')} failed: ${(stderr || stdout).trim() || 'unknown command failure'}`)
+  }
+}

--- a/apps/agent-daemon/src/version.ts
+++ b/apps/agent-daemon/src/version.ts
@@ -458,40 +458,6 @@ function parseGitHubErrorMessage(body: string): string {
   return trimmed
 }
 
-function isIgnoredAutoUpgradeDirtyPath(path: string): boolean {
-  const normalized = path.replace(/\\/g, '/').replace(/^"\.\//, '').replace(/^\.\//, '')
-  return AUTO_UPGRADE_IGNORED_LOCAL_PATH_PREFIXES.some((prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix))
-}
-
-function runLocalCommand(
-  command: string,
-  args: string[],
-  options: {
-    cwd?: string
-  } = {},
-): AgentLoopLocalCommandResult {
-  try {
-    return {
-      stdout: execFileSync(command, args, {
-        cwd: options.cwd,
-        encoding: 'utf-8',
-        stdio: ['ignore', 'pipe', 'pipe'],
-      }),
-      stderr: '',
-    }
-  } catch (error) {
-    const stdout = error instanceof Error && 'stdout' in error && typeof error.stdout === 'string'
-      ? error.stdout
-      : ''
-    const stderr = error instanceof Error && 'stderr' in error && typeof error.stderr === 'string'
-      ? error.stderr
-      : error instanceof Error
-        ? error.message
-        : String(error)
-    throw new Error(`${command} ${args.join(' ')} failed: ${(stderr || stdout).trim() || 'unknown command failure'}`)
-  }
-}
-
 function parseVersionParts(version: string): number[] {
   const [core] = version.trim().split('-')
   return (core ?? version)

--- a/apps/agent-daemon/src/wake-queue.test.ts
+++ b/apps/agent-daemon/src/wake-queue.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  appendWakeRequest,
+  buildWakeQueuePath,
+  drainWakeQueue,
+  hasPendingWakeRequests,
+  resolveWakeQueueHomeDirFromWorktreesBase,
+} from './wake-queue'
+
+describe('wake queue helpers', () => {
+  test('builds queue paths under the repo and machine specific wake queue directory', () => {
+    expect(buildWakeQueuePath({
+      repo: 'JamesWuHK/agent-loop',
+      machineId: 'codex-dev',
+      homeDir: '/tmp/agent-loop-home',
+    })).toBe('/tmp/agent-loop-home/.agent-loop/wake-queue/JamesWuHK-agent-loop/codex-dev.jsonl')
+  })
+
+  test('appends wake requests as newline-delimited JSON records', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'agent-loop-wake-queue-test-'))
+    const queuePath = buildWakeQueuePath({
+      repo: 'JamesWuHK/agent-loop',
+      machineId: 'codex-dev',
+      homeDir,
+    })
+
+    appendWakeRequest(queuePath, {
+      kind: 'issue',
+      issueNumber: 42,
+      reason: 'cli:wake-issue',
+      sourceEvent: 'cli',
+      dedupeKey: 'cli:wake-issue:42',
+      requestedAt: '2026-04-11T09:00:00.000Z',
+    })
+
+    appendWakeRequest(queuePath, {
+      kind: 'now',
+      reason: 'cli:wake-now',
+      sourceEvent: 'cli',
+      dedupeKey: 'cli:wake-now',
+      requestedAt: '2026-04-11T09:01:00.000Z',
+    })
+
+    expect(existsSync(queuePath)).toBe(true)
+    expect(readFileSync(queuePath, 'utf-8')).toBe([
+      '{"kind":"issue","issueNumber":42,"reason":"cli:wake-issue","sourceEvent":"cli","dedupeKey":"cli:wake-issue:42","requestedAt":"2026-04-11T09:00:00.000Z"}',
+      '{"kind":"now","reason":"cli:wake-now","sourceEvent":"cli","dedupeKey":"cli:wake-now","requestedAt":"2026-04-11T09:01:00.000Z"}',
+      '',
+    ].join('\n'))
+  })
+
+  test('drains queued wake requests once and removes the consumed queue file', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'agent-loop-wake-drain-test-'))
+    const queuePath = buildWakeQueuePath({
+      repo: 'JamesWuHK/agent-loop',
+      machineId: 'codex-dev',
+      homeDir,
+    })
+
+    appendWakeRequest(queuePath, {
+      kind: 'pr',
+      prNumber: 381,
+      reason: 'cli:wake-pr',
+      sourceEvent: 'cli',
+      dedupeKey: 'cli:wake-pr:381',
+      requestedAt: '2026-04-11T09:05:00.000Z',
+    })
+
+    expect(hasPendingWakeRequests(queuePath)).toBe(true)
+
+    expect(drainWakeQueue(queuePath)).toEqual({
+      requests: [{
+        kind: 'pr',
+        prNumber: 381,
+        reason: 'cli:wake-pr',
+        sourceEvent: 'cli',
+        dedupeKey: 'cli:wake-pr:381',
+        requestedAt: '2026-04-11T09:05:00.000Z',
+      }],
+      invalidEntries: [],
+    })
+
+    expect(hasPendingWakeRequests(queuePath)).toBe(false)
+    expect(existsSync(queuePath)).toBe(false)
+  })
+
+  test('drain skips malformed entries while preserving valid wake requests', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'agent-loop-wake-invalid-test-'))
+    const queuePath = buildWakeQueuePath({
+      repo: 'JamesWuHK/agent-loop',
+      machineId: 'codex-dev',
+      homeDir,
+    })
+
+    appendWakeRequest(queuePath, {
+      kind: 'issue',
+      issueNumber: 42,
+      reason: 'workflow',
+      sourceEvent: 'issues.labeled',
+      dedupeKey: 'issue:42',
+      requestedAt: '2026-04-11T09:10:00.000Z',
+    })
+
+    writeFileSync(queuePath, [
+      '{"kind":"issue","issueNumber":42,"reason":"workflow","sourceEvent":"issues.labeled","dedupeKey":"issue:42","requestedAt":"2026-04-11T09:10:00.000Z"}',
+      '{"kind":"issue","issueNumber":"oops"}',
+      'not-json',
+      '',
+    ].join('\n'))
+
+    const result = drainWakeQueue(queuePath)
+
+    expect(result.requests).toEqual([{
+      kind: 'issue',
+      issueNumber: 42,
+      reason: 'workflow',
+      sourceEvent: 'issues.labeled',
+      dedupeKey: 'issue:42',
+      requestedAt: '2026-04-11T09:10:00.000Z',
+    }])
+    expect(result.invalidEntries).toHaveLength(2)
+    expect(result.invalidEntries[0]?.lineNumber).toBe(2)
+    expect(result.invalidEntries[1]?.lineNumber).toBe(3)
+    expect(existsSync(queuePath)).toBe(false)
+  })
+
+  test('derives the wake queue home dir from supported worktree layouts', () => {
+    expect(resolveWakeQueueHomeDirFromWorktreesBase('/tmp/agent-loop-home/worktrees')).toBe('/tmp/agent-loop-home')
+    expect(resolveWakeQueueHomeDirFromWorktreesBase('/Users/wujames/.agent-worktrees/JamesWuHK-agent-loop')).toBe('/Users/wujames')
+    expect(resolveWakeQueueHomeDirFromWorktreesBase('/tmp/custom-layout')).toBeUndefined()
+  })
+})

--- a/apps/agent-daemon/src/wake-queue.ts
+++ b/apps/agent-daemon/src/wake-queue.ts
@@ -1,0 +1,219 @@
+import { appendFileSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { basename, dirname, resolve } from 'node:path'
+
+export type WakeRequest =
+  | {
+      kind: 'now'
+      reason: string
+      sourceEvent: string
+      dedupeKey: string
+      requestedAt: string
+    }
+  | {
+      kind: 'issue'
+      issueNumber: number
+      reason: string
+      sourceEvent: string
+      dedupeKey: string
+      requestedAt: string
+    }
+  | {
+      kind: 'pr'
+      prNumber: number
+      reason: string
+      sourceEvent: string
+      dedupeKey: string
+      requestedAt: string
+    }
+
+export interface InvalidWakeQueueEntry {
+  lineNumber: number
+  line: string
+  error: string
+}
+
+export interface DrainWakeQueueResult {
+  requests: WakeRequest[]
+  invalidEntries: InvalidWakeQueueEntry[]
+}
+
+export function formatWakeQueueRepoSlug(repo: string): string {
+  return repo.replaceAll('/', '-')
+}
+
+export function resolveWakeQueueHomeDirFromWorktreesBase(worktreesBase: string): string | undefined {
+  const resolved = resolve(worktreesBase)
+  const parentDir = dirname(resolved)
+
+  if (basename(resolved) === 'worktrees') {
+    return parentDir
+  }
+
+  if (basename(parentDir) === '.agent-worktrees') {
+    return dirname(parentDir)
+  }
+
+  return undefined
+}
+
+export function buildWakeQueuePath(input: {
+  repo: string
+  machineId: string
+  homeDir?: string
+}): string {
+  return resolve(
+    input.homeDir ?? homedir(),
+    '.agent-loop',
+    'wake-queue',
+    formatWakeQueueRepoSlug(input.repo),
+    `${input.machineId}.jsonl`,
+  )
+}
+
+export function appendWakeRequest(queuePath: string, request: WakeRequest): void {
+  mkdirSync(dirname(queuePath), { recursive: true })
+  appendFileSync(queuePath, `${JSON.stringify(request)}\n`, 'utf-8')
+}
+
+export function hasPendingWakeRequests(queuePath: string): boolean {
+  try {
+    return statSync(queuePath).size > 0
+  } catch {
+    return false
+  }
+}
+
+export function drainWakeQueue(queuePath: string): DrainWakeQueueResult {
+  const drainingPath = beginWakeQueueDrain(queuePath)
+  if (drainingPath === null) {
+    return {
+      requests: [],
+      invalidEntries: [],
+    }
+  }
+
+  let content: string
+  try {
+    content = readFileSync(drainingPath, 'utf-8')
+  } catch (error) {
+    try {
+      renameSync(drainingPath, queuePath)
+    } catch {
+      // Keep the original read error as the main signal; restore is best-effort.
+    }
+    throw error
+  }
+
+  try {
+    return parseWakeQueueContent(content)
+  } finally {
+    unlinkSync(drainingPath)
+  }
+}
+
+function beginWakeQueueDrain(queuePath: string): string | null {
+  if (!hasPendingWakeRequests(queuePath)) {
+    return null
+  }
+
+  const drainingPath = `${queuePath}.draining-${process.pid}-${Date.now()}-${crypto.randomUUID()}`
+
+  try {
+    renameSync(queuePath, drainingPath)
+    return drainingPath
+  } catch {
+    return null
+  }
+}
+
+function parseWakeQueueContent(content: string): DrainWakeQueueResult {
+  const requests: WakeRequest[] = []
+  const invalidEntries: InvalidWakeQueueEntry[] = []
+
+  const lines = content.split('\n')
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]?.trim() ?? ''
+    if (line.length === 0) {
+      continue
+    }
+
+    try {
+      requests.push(parseWakeRequest(line))
+    } catch (error) {
+      invalidEntries.push({
+        lineNumber: index + 1,
+        line,
+        error: error instanceof Error ? error.message : 'Unknown wake queue parse error',
+      })
+    }
+  }
+
+  return {
+    requests,
+    invalidEntries,
+  }
+}
+
+function parseWakeRequest(line: string): WakeRequest {
+  const parsed = JSON.parse(line) as Record<string, unknown> | null
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Wake request must be a JSON object')
+  }
+
+  const kind = parsed.kind
+  const reason = parsed.reason
+  const sourceEvent = parsed.sourceEvent
+  const dedupeKey = parsed.dedupeKey
+  const requestedAt = parsed.requestedAt
+
+  if (kind !== 'now' && kind !== 'issue' && kind !== 'pr') {
+    throw new Error('Wake request kind must be one of now, issue, or pr')
+  }
+
+  if (
+    typeof reason !== 'string'
+    || typeof sourceEvent !== 'string'
+    || typeof dedupeKey !== 'string'
+    || typeof requestedAt !== 'string'
+  ) {
+    throw new Error('Wake request is missing required string fields')
+  }
+
+  if (kind === 'now') {
+    return {
+      kind,
+      reason,
+      sourceEvent,
+      dedupeKey,
+      requestedAt,
+    }
+  }
+
+  const targetField = kind === 'issue' ? parsed.issueNumber : parsed.prNumber
+  if (!Number.isSafeInteger(targetField) || (targetField as number) <= 0) {
+    throw new Error(`Wake request ${kind} target must be a positive integer`)
+  }
+
+  if (kind === 'issue') {
+    return {
+      kind,
+      issueNumber: targetField as number,
+      reason,
+      sourceEvent,
+      dedupeKey,
+      requestedAt,
+    }
+  }
+
+  return {
+    kind,
+    prNumber: targetField as number,
+    reason,
+    sourceEvent,
+    dedupeKey,
+    requestedAt,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "agent:issues:audit": "bun apps/agent-daemon/src/audit-issue-contracts.ts",
     "agent:issues:enforce-ready": "bun apps/agent-daemon/src/ready-gate.ts",
     "agent:join-project": "bun apps/agent-daemon/src/index.ts --join-project",
+    "agent:replay:eval": "bun apps/agent-daemon/src/replay-eval.ts",
     "agent:version:bump": "bun scripts/bump-version.ts",
     "start": "bun run apps/agent-daemon/src/index.ts",
     "dev": "bun --watch run apps/agent-daemon/src/index.ts",

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -23,9 +23,10 @@ import {
   parseGhApiErrorMessage,
   parseMergePrResponse,
   qualifyGhApiArgs,
+  sortClaimableIssuesForScheduling,
   shouldClearIssueAssigneesForStateLabel,
 } from './github-api'
-import { ISSUE_LABELS } from './types'
+import { ISSUE_LABELS, ISSUE_PRIORITY_LABELS, type AgentIssue } from './types'
 
 describe('buildGhEnv', () => {
   test('removes proxy variables and injects GitHub auth tokens', () => {
@@ -384,6 +385,58 @@ describe('applyDependencyClaimability', () => {
 
     expect(issue?.isClaimable).toBe(true)
     expect(issue?.claimBlockedBy).toEqual([])
+  })
+})
+
+describe('sortClaimableIssuesForScheduling', () => {
+  function buildIssue(input: Partial<AgentIssue> & Pick<AgentIssue, 'number'>): AgentIssue {
+    const { number, ...rest } = input
+
+    return {
+      number,
+      title: `issue-${number}`,
+      body: '',
+      state: 'ready',
+      labels: [ISSUE_LABELS.READY],
+      assignee: null,
+      isClaimable: true,
+      updatedAt: '2026-04-11T08:00:00.000Z',
+      dependencyIssueNumbers: [],
+      hasDependencyMetadata: true,
+      dependencyParseError: false,
+      claimBlockedBy: [],
+      hasExecutableContract: true,
+      contractValidationErrors: [],
+      ...rest,
+    }
+  }
+
+  test('orders high before default before low and keeps ties deterministic', () => {
+    const ordered = sortClaimableIssuesForScheduling([
+      buildIssue({ number: 14 }),
+      buildIssue({ number: 13, labels: [ISSUE_LABELS.READY, ISSUE_PRIORITY_LABELS.LOW] }),
+      buildIssue({
+        number: 12,
+        labels: [ISSUE_LABELS.READY, ISSUE_PRIORITY_LABELS.HIGH],
+        updatedAt: '2026-04-11T08:05:00.000Z',
+      }),
+      buildIssue({
+        number: 11,
+        labels: [ISSUE_LABELS.READY, ISSUE_PRIORITY_LABELS.HIGH],
+        updatedAt: '2026-04-11T08:01:00.000Z',
+      }),
+      buildIssue({
+        number: 10,
+        labels: [ISSUE_LABELS.READY, 'agent:custom-priority'],
+        updatedAt: '2026-04-11T07:55:00.000Z',
+      }),
+      buildIssue({
+        number: 9,
+        updatedAt: '2026-04-11T07:55:00.000Z',
+      }),
+    ])
+
+    expect(ordered.map((issue) => issue.number)).toEqual([11, 12, 9, 10, 14, 13])
   })
 })
 

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -12,7 +12,7 @@ import type {
   ManagedLeaseScope,
   ManagedPullRequest,
 } from './types'
-import { ISSUE_LABELS, PR_REVIEW_LABELS } from './types'
+import { ISSUE_LABELS, ISSUE_PRIORITY_LABELS, PR_REVIEW_LABELS } from './types'
 import {
   inferState,
   buildEventComment,
@@ -796,6 +796,24 @@ export function applyDependencyClaimability(
       isClaimable: issue.state === 'ready' && issue.assignee === null && blockedBy.length === 0,
       claimBlockedBy: blockedBy,
     }
+  })
+}
+
+function getClaimSchedulingPriorityRank(issue: Pick<AgentIssue, 'labels'>): number {
+  if (issue.labels.includes(ISSUE_PRIORITY_LABELS.HIGH)) return 0
+  if (issue.labels.includes(ISSUE_PRIORITY_LABELS.LOW)) return 2
+  return 1
+}
+
+export function sortClaimableIssuesForScheduling(issues: AgentIssue[]): AgentIssue[] {
+  return [...issues].sort((left, right) => {
+    const priorityDiff = getClaimSchedulingPriorityRank(left) - getClaimSchedulingPriorityRank(right)
+    if (priorityDiff !== 0) return priorityDiff
+
+    const updatedAtDiff = left.updatedAt.localeCompare(right.updatedAt)
+    if (updatedAtDiff !== 0) return updatedAtDiff
+
+    return left.number - right.number
   })
 }
 

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -9,6 +9,11 @@ export const ISSUE_LABELS = {
   STALE: 'agent:stale',
 } as const
 
+export const ISSUE_PRIORITY_LABELS = {
+  HIGH: 'agent:priority-high',
+  LOW: 'agent:priority-low',
+} as const
+
 export const PR_REVIEW_LABELS = {
   APPROVED: 'agent:review-approved',
   FAILED: 'agent:review-failed',
@@ -17,6 +22,7 @@ export const PR_REVIEW_LABELS = {
 } as const
 
 export type IssueLabel = (typeof ISSUE_LABELS)[keyof typeof ISSUE_LABELS]
+export type IssuePriorityLabel = (typeof ISSUE_PRIORITY_LABELS)[keyof typeof ISSUE_PRIORITY_LABELS]
 
 export type IssueState =
   | 'ready'

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -143,6 +143,7 @@ export interface AgentLoopUpgradeConfig {
   channel: string | null
   checkIntervalMs: number
   reminderIntervalMs: number
+  autoApply: boolean
 }
 
 export interface AgentLoopBuildMetadata {


### PR DESCRIPTION
## Summary

This PR stabilizes Agent Loop for single-repo, multi-machine autonomous development.

It adds:
- explicit claim priority scheduling with `agent:priority-high` and `agent:priority-low`
- a durable local wake queue plus `--wake-now`, `--wake-issue`, and `--wake-pr`
- daemon wake consumption and immediate reconcile via `/wake`
- a fixture-driven replay/eval harness for offline behavior checks
- structured resolution comments for retrying blocked failed issues after human intervention
- managed-daemon self-upgrade with `upgrade.autoApply` when the machine is idle and the poll cycle did not start new work
- shared presence-registry upgrade announcements so one machine finding a newer Agent Loop build prompts all other machines to refresh upgrade status on the next heartbeat instead of waiting for their normal upgrade check interval
- README updates for the new multi-machine workflow, upgrade coordination, and opt-in auto-apply behavior

## Validation

- `bun test apps/agent-daemon/src/presence.test.ts apps/agent-daemon/src/config.test.ts apps/agent-daemon/src/version.test.ts apps/agent-daemon/src/daemon.test.ts`
- `bun run typecheck`

## Issues

Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15