### PR TITLE
fix: preserve issue state on intentional upgrade restarts

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -293,6 +293,29 @@ describe('agent-loop upgrade coordination', () => {
     expect(immediateReason as string | null).toBe('agent-loop-upgrade')
   })
 
+  test('preserves active issue state markers across intentional upgrade restarts', async () => {
+    const daemon = createTestDaemon()
+
+    ;(daemon as any).running = true
+    ;(daemon as any).activeWorktrees.set(321, {
+      path: '/tmp/worktrees/issue-321-codex-dev',
+      issueNumber: 321,
+      machineId: 'codex-dev',
+      branch: 'agent/321/codex-dev',
+      state: 'active',
+      createdAt: '2026-04-11T11:30:00.000Z',
+    })
+
+    await daemon.stop({
+      preserveActiveIssueStates: true,
+      reason: 'agent-loop-auto-upgrade',
+    })
+
+    expect((daemon as any).running).toBe(false)
+    expect((daemon as any).shutdownRequested).toBe(true)
+    expect((daemon as any).activeWorktrees.has(321)).toBe(true)
+  })
+
   test('attempts automatic self-upgrade after an idle no-issues poll when enabled', async () => {
     const daemon = createTestDaemon({
       upgrade: {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -95,6 +95,11 @@ export interface HealthServerConfig {
   port: number
 }
 
+export interface StopDaemonOptions {
+  preserveActiveIssueStates?: boolean
+  reason?: string
+}
+
 export const HEALTH_PATH = '/health'
 export const WAKE_PATH = '/wake'
 export const DEFAULT_HEALTH_SERVER_PORT = 9310
@@ -822,8 +827,10 @@ export class AgentDaemon {
     this.logger.log(`[daemon] health server listening on http://${host}:${port} (pid: ${process.pid})`)
   }
 
-  async stop(): Promise<void> {
-    this.logger.log(`[daemon] shutting down...`)
+  async stop(options: StopDaemonOptions = {}): Promise<void> {
+    const shutdownReason = options.reason?.trim() ?? ''
+    const shutdownContext = shutdownReason.length > 0 ? ` (${shutdownReason})` : ''
+    this.logger.log(`[daemon] shutting down${shutdownContext}...`)
     this.shutdownRequested = true
 
     if (this.pollTimeoutId !== null) {
@@ -867,24 +874,32 @@ export class AgentDaemon {
       }
     }
 
-    // Mark all active worktrees as stale
-    for (const [issueNumber] of this.activeWorktrees) {
-      try {
-        await transitionIssueState(
-          issueNumber,
-          ISSUE_LABELS.STALE,
-          ISSUE_LABELS.WORKING,
-          {
-            event: 'stale',
-            machine: this.config.machineId,
-            ts: new Date().toISOString(),
-            reason: 'daemon-shutdown',
-          },
-          this.config,
+    if (options.preserveActiveIssueStates) {
+      if (this.activeWorktrees.size > 0) {
+        this.logger.log(
+          `[daemon] preserving ${this.activeWorktrees.size} active issue state(s) across intentional restart${shutdownContext}`,
         )
-        this.logger.log(`[daemon] marked issue #${issueNumber} as stale`)
-      } catch (err) {
-        this.logger.error(`[daemon] failed to mark #${issueNumber} as stale:`, err)
+      }
+    } else {
+      // Mark all active worktrees as stale
+      for (const [issueNumber] of this.activeWorktrees) {
+        try {
+          await transitionIssueState(
+            issueNumber,
+            ISSUE_LABELS.STALE,
+            ISSUE_LABELS.WORKING,
+            {
+              event: 'stale',
+              machine: this.config.machineId,
+              ts: new Date().toISOString(),
+              reason: 'daemon-shutdown',
+            },
+            this.config,
+          )
+          this.logger.log(`[daemon] marked issue #${issueNumber} as stale`)
+        } catch (err) {
+          this.logger.error(`[daemon] failed to mark #${issueNumber} as stale:`, err)
+        }
       }
     }
 
@@ -3279,7 +3294,10 @@ export class AgentDaemon {
       `[daemon] upgraded local agent-loop checkout on ${result.currentBranch}: v${this.agentLoopBuild.version}@${fromRevision} -> v${upgrade.latestVersion ?? this.agentLoopBuild.version}@${toRevision}`,
     )
 
-    await this.stop()
+    await this.stop({
+      preserveActiveIssueStates: true,
+      reason: 'agent-loop-auto-upgrade',
+    })
 
     if (supervisor === 'detached') {
       const pid = this.spawnDetachedUpgradeSuccessor()


### PR DESCRIPTION
## Summary

This follow-up hardens the multi-machine auto-upgrade flow.

It changes daemon shutdown semantics so intentional upgrade restarts preserve local active issue state instead of eagerly marking active worktrees as `agent:stale`.

It adds:
- a `stop()` option for intentional restarts that preserves active issue state markers
- auto-upgrade shutdowns wired to use that intentional-restart path
- a regression test covering preserved active worktree state during `agent-loop-auto-upgrade`

## Why

The current auto-upgrade path only runs when the daemon is idle, but making intentional restart semantics explicit keeps restart behavior safe if state races appear around upgrade boundaries and makes future recovery changes less brittle.

## Validation

- `bun test apps/agent-daemon/src/daemon.test.ts`
- `bun run typecheck`