### PR TITLE
fix: prefer direct GitHub API calls when PAT is configured

### DIFF
--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -23,10 +23,11 @@ import {
   parseGhApiErrorMessage,
   parseMergePrResponse,
   qualifyGhApiArgs,
+  ghApiRaw,
   sortClaimableIssuesForScheduling,
   shouldClearIssueAssigneesForStateLabel,
 } from './github-api'
-import { ISSUE_LABELS, ISSUE_PRIORITY_LABELS, type AgentIssue } from './types'
+import { ISSUE_LABELS, ISSUE_PRIORITY_LABELS, type AgentConfig, type AgentIssue } from './types'
 
 describe('buildGhEnv', () => {
   test('removes proxy variables and injects GitHub auth tokens', () => {
@@ -130,6 +131,77 @@ describe('buildDirectGitHubApiRequest', () => {
     expect(JSON.parse(request.body ?? '{}')).toEqual({
       labels: ['agent:ready', 'agent:claimed'],
     })
+  })
+
+  test('rejects unsupported gh api flags so callers can fall back to gh', () => {
+    expect(() => buildDirectGitHubApiRequest(
+      [
+        'repos/JamesWuHK/digital-employee/issues/334',
+        '--cache',
+        '1h',
+      ],
+      { repo: 'JamesWuHK/digital-employee' },
+    )).toThrow('unsupported gh api option for direct mode: --cache')
+  })
+})
+
+describe('ghApiRaw', () => {
+  test('uses direct fetch for PAT-backed paginated REST requests', async () => {
+    const originalFetch = globalThis.fetch
+    const seen: string[] = []
+    const config = {
+      repo: 'JamesWuHK/digital-employee',
+      pat: 'ghp_test',
+    } as AgentConfig
+
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+      seen.push(url)
+
+      if (seen.length === 1) {
+        expect(init?.headers).toMatchObject({
+          Authorization: 'token ghp_test',
+          Accept: 'application/vnd.github+json',
+        })
+        return new Response(
+          JSON.stringify([{ id: 11, body: 'page-1', created_at: '2026-04-11T10:00:00.000Z', updated_at: '2026-04-11T10:00:00.000Z' }]),
+          {
+            status: 200,
+            headers: {
+              link: '<https://api.github.com/repos/JamesWuHK/digital-employee/issues/334/comments?page=2>; rel="next"',
+            },
+          },
+        )
+      }
+
+      return new Response(
+        JSON.stringify([{ id: 12, body: 'page-2', created_at: '2026-04-11T10:00:01.000Z', updated_at: '2026-04-11T10:00:01.000Z' }]),
+        { status: 200 },
+      )
+    }) as typeof fetch
+
+    try {
+      const result = await ghApiRaw(
+        ['repos/JamesWuHK/digital-employee/issues/334/comments', '--paginate'],
+        config,
+      )
+
+      expect(result.exitCode).toBe(0)
+      expect(seen).toEqual([
+        'https://api.github.com/repos/JamesWuHK/digital-employee/issues/334/comments',
+        'https://api.github.com/repos/JamesWuHK/digital-employee/issues/334/comments?page=2',
+      ])
+      expect(JSON.parse(result.stdout)).toEqual([
+        { id: 11, body: 'page-1', created_at: '2026-04-11T10:00:00.000Z', updated_at: '2026-04-11T10:00:00.000Z' },
+        { id: 12, body: 'page-2', created_at: '2026-04-11T10:00:01.000Z', updated_at: '2026-04-11T10:00:01.000Z' },
+      ])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 })
 

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -216,11 +216,19 @@ async function ghRaw(
   return { stdout, stderr, exitCode }
 }
 
-async function ghApiRaw(
+export async function ghApiRaw(
   args: string[],
   config: AgentConfig,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const qualifiedArgs = qualifyGhApiArgs(args, config)
+  if (config.pat) {
+    try {
+      buildDirectGitHubApiRequest(qualifiedArgs, config)
+      return await runDirectGitHubApi(qualifiedArgs, config)
+    } catch {
+      // Fall back to gh api for argument shapes that direct mode does not support yet.
+    }
+  }
   return runBoundedGhCommand(['api', ...qualifiedArgs], config)
 }
 
@@ -336,6 +344,11 @@ export function buildDirectGitHubApiRequest(
 
     if (token === '--paginate') {
       paginate = true
+      continue
+    }
+
+    if (typeof token === 'string' && token.startsWith('-')) {
+      throw new Error(`unsupported gh api option for direct mode: ${token}`)
     }
   }
 


### PR DESCRIPTION
## Summary

This follow-up improves agent-loop GitHub runtime reliability when a PAT is configured.

It changes `ghApiRaw()` to prefer direct HTTPS calls to GitHub when `config.pat` is available, while still falling back to `gh api` for unsupported argument shapes.

It adds:
- direct-request routing for PAT-backed `ghApiRaw()` calls
- stricter direct-mode option parsing so unsupported flags fall back cleanly
- regression tests for unsupported-option fallback signaling and PAT-backed paginated REST requests

## Why

The current code already has a direct GitHub API implementation, but `ghApiRaw()` was still unconditionally routing through `gh api`. Wiring the direct path reduces subprocess overhead and removes one more source of CLI/runtime flakiness in the daemon control plane.

## Validation

- `bun test packages/agent-shared/src/github-api.test.ts`
- `bun run --cwd packages/agent-shared typecheck`
- `bun run typecheck`