### PR TITLE
feat(wake): wire GitHub events into local daemon wakeups

### DIFF
--- a/.github/workflows/agent-daemon-wake.yml
+++ b/.github/workflows/agent-daemon-wake.yml
@@ -1,0 +1,64 @@
+name: Agent Daemon Wake
+
+on:
+  issues:
+    types:
+      - edited
+      - reopened
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+      - labeled
+      - unlabeled
+  issue_comment:
+    types:
+      - created
+      - edited
+  workflow_dispatch:
+    inputs:
+      wake_target:
+        description: Target to wake. `auto` uses issue/pr inputs when present, otherwise falls back to `now`.
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - now
+          - issue
+          - pr
+      issue_number:
+        description: Optional issue number for manual targeted wake
+        required: false
+        type: string
+      pr_number:
+        description: Optional PR number for manual targeted wake
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  wake-daemon:
+    if: ${{ github.event_name != 'issues' || (github.event.issue.pull_request == null && !contains(github.event.issue.labels.*.name, 'agent:ready')) }}
+    runs-on:
+      - self-hosted
+      - agent-loop
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.6
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Translate GitHub event into a local wake request
+        run: bun apps/agent-daemon/src/index.ts --wake-from-github-event --repo "${{ github.repository }}"

--- a/.github/workflows/agent-ready-gate.yml
+++ b/.github/workflows/agent-ready-gate.yml
@@ -31,3 +31,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run agent:issues:enforce-ready --issue "${{ github.event.issue.number }}" --repo "${{ github.repository }}"
+
+  wake-ready-issue:
+    if: ${{ github.event.issue.pull_request == null && (github.event.label.name == 'agent:ready' || contains(github.event.issue.labels.*.name, 'agent:ready')) }}
+    needs:
+      - enforce-ready-contract
+    runs-on:
+      - self-hosted
+      - agent-loop
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.6
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Wake local daemon after ready-gate passes
+        run: bun apps/agent-daemon/src/index.ts --wake-from-github-event --repo "${{ github.repository }}"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ agent-loop --wake-pr 456
 ~/.agent-loop/wake-queue/{owner-repo}/{machineId}.jsonl
 ```
 
+如果你已经在目标开发机上装了 GitHub self-hosted runner，现在仓库里的 [`agent-daemon-wake.yml`](.github/workflows/agent-daemon-wake.yml) 和 [`agent-ready-gate.yml`](.github/workflows/agent-ready-gate.yml) 会把 issue / PR / manual dispatch 事件翻译成这类本地 wake request：
+
+- `agent:ready` 的 issue 会先过 ready-gate，再 wake 本机 daemon，避免校验和认领抢跑
+- PR 的 `opened / reopened / ready_for_review / synchronize / review label changes` 会直接 wake
+- `workflow_dispatch` 支持手工发 `now / issue / pr` 三类 wake
+
+接线方式很简单：
+
+1. 在目标机器上把这个仓库注册成 GitHub self-hosted runner，并带上 `agent-loop` label
+2. 确保这台机器已经通过 `agent-loop --join-project` 或 `--start` 跑着本地 daemon
+3. workflow 会在 runner 上执行 `bun apps/agent-daemon/src/index.ts --wake-from-github-event --repo <owner/repo>`，把 GitHub 事件落成 durable wake queue，再 best-effort 通知本地 daemon
+
 - 离线回放评估：daemon 行为变更可以用 fixture 目录做 replay/eval，而不是只靠手工盯日志。
 
 ```bash

--- a/apps/agent-daemon/src/github-event-wake.test.ts
+++ b/apps/agent-daemon/src/github-event-wake.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from 'bun:test'
+import { buildWakeRequestFromGitHubEvent, readWakeRequestFromGitHubEventContext } from './github-event-wake'
+
+describe('github event wake parser', () => {
+  test('builds an issue wake when agent:ready is labeled', () => {
+    expect(buildWakeRequestFromGitHubEvent({
+      eventName: 'issues',
+      requestedAt: '2026-04-11T10:00:00.000Z',
+      event: {
+        action: 'labeled',
+        label: {
+          name: 'agent:ready',
+        },
+        issue: {
+          number: 374,
+          labels: [{ name: 'agent:ready' }],
+          updated_at: '2026-04-11T09:59:59.000Z',
+        },
+      },
+    })).toEqual({
+      kind: 'issue',
+      issueNumber: 374,
+      reason: 'issues.labeled:agent:ready',
+      sourceEvent: 'issues.labeled',
+      dedupeKey: 'issues:labeled:374:agent:ready',
+      requestedAt: '2026-04-11T10:00:00.000Z',
+    })
+  })
+
+  test('wakes non-ready actionable issues when they are edited', () => {
+    expect(buildWakeRequestFromGitHubEvent({
+      eventName: 'issues',
+      requestedAt: '2026-04-11T10:05:00.000Z',
+      event: {
+        action: 'edited',
+        issue: {
+          number: 88,
+          labels: [{ name: 'agent:failed' }],
+          updated_at: '2026-04-11T10:04:30.000Z',
+        },
+      },
+    })).toEqual({
+      kind: 'issue',
+      issueNumber: 88,
+      reason: 'issues.edited',
+      sourceEvent: 'issues.edited',
+      dedupeKey: 'issues:edited:88:2026-04-11T10:04:30.000Z',
+      requestedAt: '2026-04-11T10:05:00.000Z',
+    })
+  })
+
+  test('ignores draft pull requests until they are ready for review', () => {
+    expect(buildWakeRequestFromGitHubEvent({
+      eventName: 'pull_request',
+      requestedAt: '2026-04-11T10:10:00.000Z',
+      event: {
+        action: 'opened',
+        pull_request: {
+          number: 205,
+          draft: true,
+          head: {
+            sha: 'abc123',
+          },
+        },
+      },
+    })).toBeNull()
+  })
+
+  test('builds a pr wake on synchronize using the new head sha as dedupe key', () => {
+    expect(buildWakeRequestFromGitHubEvent({
+      eventName: 'pull_request',
+      requestedAt: '2026-04-11T10:12:00.000Z',
+      event: {
+        action: 'synchronize',
+        pull_request: {
+          number: 205,
+          draft: false,
+          head: {
+            sha: 'def456',
+          },
+        },
+      },
+    })).toEqual({
+      kind: 'pr',
+      prNumber: 205,
+      reason: 'pull_request.synchronize',
+      sourceEvent: 'pull_request.synchronize',
+      dedupeKey: 'pull_request:synchronize:205:def456',
+      requestedAt: '2026-04-11T10:12:00.000Z',
+    })
+  })
+
+  test('builds a pr wake when review labels change', () => {
+    expect(buildWakeRequestFromGitHubEvent({
+      eventName: 'pull_request',
+      requestedAt: '2026-04-11T10:15:00.000Z',
+      event: {
+        action: 'labeled',
+        label: {
+          name: 'agent:review-approved',
+        },
+        pull_request: {
+          number: 205,
+          draft: false,
+          head: {
+            sha: 'def456',
+          },
+        },
+      },
+    })).toEqual({
+      kind: 'pr',
+      prNumber: 205,
+      reason: 'pull_request.labeled:agent:review-approved',
+      sourceEvent: 'pull_request.labeled',
+      dedupeKey: 'pull_request:labeled:205:agent:review-approved',
+      requestedAt: '2026-04-11T10:15:00.000Z',
+    })
+  })
+
+  test('wakes an issue when a structured resolution comment is posted', () => {
+    expect(buildWakeRequestFromGitHubEvent({
+      eventName: 'issue_comment',
+      requestedAt: '2026-04-11T10:20:00.000Z',
+      event: {
+        action: 'created',
+        issue: {
+          number: 104,
+          labels: [{ name: 'agent:failed' }],
+        },
+        comment: {
+          id: 9001,
+          body: '<!-- agent-loop:issue-resume-resolved {"issueNumber":104,"prNumber":205} -->\nresolved',
+        },
+      },
+    })).toEqual({
+      kind: 'issue',
+      issueNumber: 104,
+      reason: 'issue_comment.issue-resume-resolved',
+      sourceEvent: 'issue_comment.created',
+      dedupeKey: 'issue_comment:9001:issue-resume-resolved',
+      requestedAt: '2026-04-11T10:20:00.000Z',
+    })
+  })
+
+  test('supports workflow_dispatch issue and fallback wake-now inputs', () => {
+    expect(buildWakeRequestFromGitHubEvent({
+      eventName: 'workflow_dispatch',
+      requestedAt: '2026-04-11T10:25:00.000Z',
+      event: {
+        inputs: {
+          wake_target: 'issue',
+          issue_number: '42',
+        },
+      },
+    })).toEqual({
+      kind: 'issue',
+      issueNumber: 42,
+      reason: 'workflow_dispatch:issue',
+      sourceEvent: 'workflow_dispatch',
+      dedupeKey: 'workflow_dispatch:issue:42',
+      requestedAt: '2026-04-11T10:25:00.000Z',
+    })
+
+    expect(buildWakeRequestFromGitHubEvent({
+      eventName: 'workflow_dispatch',
+      requestedAt: '2026-04-11T10:26:00.000Z',
+      event: {
+        inputs: {
+          wake_target: 'auto',
+        },
+      },
+    })).toEqual({
+      kind: 'now',
+      reason: 'workflow_dispatch',
+      sourceEvent: 'workflow_dispatch',
+      dedupeKey: 'workflow_dispatch:now',
+      requestedAt: '2026-04-11T10:26:00.000Z',
+    })
+  })
+
+  test('loads github event context from the actions environment', () => {
+    const request = readWakeRequestFromGitHubEventContext({}, {
+      GITHUB_EVENT_NAME: 'pull_request',
+      GITHUB_EVENT_PATH: '/tmp/github-event.json',
+    }, () => JSON.stringify({
+      action: 'ready_for_review',
+      pull_request: {
+        number: 205,
+        draft: false,
+        head: {
+          sha: 'fedcba',
+        },
+      },
+    }))
+
+    expect(request).toEqual({
+      kind: 'pr',
+      prNumber: 205,
+      reason: 'pull_request.ready_for_review',
+      sourceEvent: 'pull_request.ready_for_review',
+      dedupeKey: 'pull_request:ready_for_review:205:fedcba',
+      requestedAt: expect.any(String),
+    })
+  })
+})

--- a/apps/agent-daemon/src/github-event-wake.ts
+++ b/apps/agent-daemon/src/github-event-wake.ts
@@ -1,0 +1,326 @@
+import { readFileSync } from 'node:fs'
+import { ISSUE_LABELS, PR_REVIEW_LABELS } from '@agent/shared'
+import type { WakeRequest } from './wake-queue'
+
+const ACTIONABLE_ISSUE_LABELS = new Set<string>([
+  ISSUE_LABELS.READY,
+  ISSUE_LABELS.CLAIMED,
+  ISSUE_LABELS.WORKING,
+  ISSUE_LABELS.FAILED,
+  ISSUE_LABELS.STALE,
+])
+
+const ACTIONABLE_PR_LABELS = new Set<string>(Object.values(PR_REVIEW_LABELS))
+const ISSUE_RESUME_RESOLUTION_COMMENT_PREFIX = '<!-- agent-loop:issue-resume-resolved '
+
+export interface GitHubEventWakeInput {
+  eventName: string
+  event: unknown
+  requestedAt?: string
+}
+
+export interface GitHubEventWakeContextInput {
+  eventName?: string
+  eventPath?: string
+  requestedAt?: string
+}
+
+export function readWakeRequestFromGitHubEventContext(
+  input: GitHubEventWakeContextInput = {},
+  env: NodeJS.ProcessEnv = process.env,
+  readText: (path: string) => string = (path) => readFileSync(path, 'utf-8'),
+): WakeRequest | null {
+  const eventName = normalizeNonEmptyString(input.eventName ?? env.GITHUB_EVENT_NAME)
+  if (!eventName) {
+    throw new Error('No GitHub event name available. Pass --github-event-name or run inside GitHub Actions.')
+  }
+
+  const eventPath = normalizeNonEmptyString(input.eventPath ?? env.GITHUB_EVENT_PATH)
+  if (!eventPath) {
+    throw new Error('No GitHub event payload path available. Pass --github-event-path or run inside GitHub Actions.')
+  }
+
+  return buildWakeRequestFromGitHubEvent({
+    eventName,
+    event: JSON.parse(readText(eventPath)),
+    requestedAt: input.requestedAt,
+  })
+}
+
+export function buildWakeRequestFromGitHubEvent(
+  input: GitHubEventWakeInput,
+): WakeRequest | null {
+  const requestedAt = input.requestedAt ?? new Date().toISOString()
+  const payload = asRecord(input.event)
+  if (!payload) return null
+
+  switch (input.eventName) {
+    case 'issues':
+      return buildWakeRequestFromIssuesEvent(payload, requestedAt)
+    case 'pull_request':
+      return buildWakeRequestFromPullRequestEvent(payload, requestedAt)
+    case 'issue_comment':
+      return buildWakeRequestFromIssueCommentEvent(payload, requestedAt)
+    case 'workflow_dispatch':
+      return buildWakeRequestFromWorkflowDispatchEvent(payload, requestedAt)
+    default:
+      return null
+  }
+}
+
+function buildWakeRequestFromIssuesEvent(
+  payload: Record<string, unknown>,
+  requestedAt: string,
+): WakeRequest | null {
+  const action = normalizeNonEmptyString(payload.action)
+  const issue = readIssueLike(payload.issue)
+  if (!action || !issue || issue.isPullRequest) return null
+
+  if (action === 'labeled') {
+    const labelName = readLabelName(payload.label)
+    if (labelName !== ISSUE_LABELS.READY) return null
+
+    return {
+      kind: 'issue',
+      issueNumber: issue.number,
+      reason: 'issues.labeled:agent:ready',
+      sourceEvent: 'issues.labeled',
+      dedupeKey: `issues:labeled:${issue.number}:${labelName}`,
+      requestedAt,
+    }
+  }
+
+  if ((action === 'edited' || action === 'reopened') && hasAnyLabel(issue.labels, ACTIONABLE_ISSUE_LABELS)) {
+    return {
+      kind: 'issue',
+      issueNumber: issue.number,
+      reason: `issues.${action}`,
+      sourceEvent: `issues.${action}`,
+      dedupeKey: `issues:${action}:${issue.number}:${issue.updatedAt ?? requestedAt}`,
+      requestedAt,
+    }
+  }
+
+  return null
+}
+
+function buildWakeRequestFromPullRequestEvent(
+  payload: Record<string, unknown>,
+  requestedAt: string,
+): WakeRequest | null {
+  const action = normalizeNonEmptyString(payload.action)
+  const pullRequest = readPullRequestLike(payload.pull_request)
+  if (!action || !pullRequest) return null
+
+  if (
+    (action === 'opened' || action === 'reopened' || action === 'synchronize')
+    && pullRequest.isDraft
+  ) {
+    return null
+  }
+
+  if (
+    action === 'opened'
+    || action === 'reopened'
+    || action === 'ready_for_review'
+    || action === 'synchronize'
+  ) {
+    return {
+      kind: 'pr',
+      prNumber: pullRequest.number,
+      reason: `pull_request.${action}`,
+      sourceEvent: `pull_request.${action}`,
+      dedupeKey: `pull_request:${action}:${pullRequest.number}:${pullRequest.headSha ?? requestedAt}`,
+      requestedAt,
+    }
+  }
+
+  if (action === 'labeled' || action === 'unlabeled') {
+    const labelName = readLabelName(payload.label)
+    if (!labelName || !ACTIONABLE_PR_LABELS.has(labelName)) return null
+
+    return {
+      kind: 'pr',
+      prNumber: pullRequest.number,
+      reason: `pull_request.${action}:${labelName}`,
+      sourceEvent: `pull_request.${action}`,
+      dedupeKey: `pull_request:${action}:${pullRequest.number}:${labelName}`,
+      requestedAt,
+    }
+  }
+
+  return null
+}
+
+function buildWakeRequestFromIssueCommentEvent(
+  payload: Record<string, unknown>,
+  requestedAt: string,
+): WakeRequest | null {
+  const action = normalizeNonEmptyString(payload.action) ?? 'created'
+  const issue = readIssueLike(payload.issue)
+  const comment = readCommentLike(payload.comment)
+  if (!issue || !comment || issue.isPullRequest) return null
+  if (!comment.body.includes(ISSUE_RESUME_RESOLUTION_COMMENT_PREFIX)) return null
+
+  return {
+    kind: 'issue',
+    issueNumber: issue.number,
+    reason: 'issue_comment.issue-resume-resolved',
+    sourceEvent: `issue_comment.${action}`,
+    dedupeKey: `issue_comment:${comment.id}:issue-resume-resolved`,
+    requestedAt,
+  }
+}
+
+function buildWakeRequestFromWorkflowDispatchEvent(
+  payload: Record<string, unknown>,
+  requestedAt: string,
+): WakeRequest | null {
+  const inputs = asRecord(payload.inputs)
+  const wakeTarget = normalizeNonEmptyString(inputs?.wake_target) ?? 'auto'
+  const issueNumber = readPositiveInteger(inputs?.issue_number)
+  const prNumber = readPositiveInteger(inputs?.pr_number)
+
+  if (wakeTarget === 'issue') {
+    if (!issueNumber) {
+      throw new Error('workflow_dispatch input wake_target=issue requires a positive issue_number')
+    }
+
+    return {
+      kind: 'issue',
+      issueNumber,
+      reason: 'workflow_dispatch:issue',
+      sourceEvent: 'workflow_dispatch',
+      dedupeKey: `workflow_dispatch:issue:${issueNumber}`,
+      requestedAt,
+    }
+  }
+
+  if (wakeTarget === 'pr') {
+    if (!prNumber) {
+      throw new Error('workflow_dispatch input wake_target=pr requires a positive pr_number')
+    }
+
+    return {
+      kind: 'pr',
+      prNumber,
+      reason: 'workflow_dispatch:pr',
+      sourceEvent: 'workflow_dispatch',
+      dedupeKey: `workflow_dispatch:pr:${prNumber}`,
+      requestedAt,
+    }
+  }
+
+  if (wakeTarget === 'auto') {
+    if (issueNumber && !prNumber) {
+      return {
+        kind: 'issue',
+        issueNumber,
+        reason: 'workflow_dispatch:issue',
+        sourceEvent: 'workflow_dispatch',
+        dedupeKey: `workflow_dispatch:issue:${issueNumber}`,
+        requestedAt,
+      }
+    }
+
+    if (prNumber && !issueNumber) {
+      return {
+        kind: 'pr',
+        prNumber,
+        reason: 'workflow_dispatch:pr',
+        sourceEvent: 'workflow_dispatch',
+        dedupeKey: `workflow_dispatch:pr:${prNumber}`,
+        requestedAt,
+      }
+    }
+  }
+
+  return {
+    kind: 'now',
+    reason: 'workflow_dispatch',
+    sourceEvent: 'workflow_dispatch',
+    dedupeKey: 'workflow_dispatch:now',
+    requestedAt,
+  }
+}
+
+function readIssueLike(
+  value: unknown,
+): { number: number; labels: string[]; updatedAt: string | null; isPullRequest: boolean } | null {
+  const record = asRecord(value)
+  const number = readPositiveInteger(record?.number)
+  if (!number) return null
+
+  return {
+    number,
+    labels: readLabelNames(record?.labels),
+    updatedAt: normalizeNonEmptyString(record?.updated_at) ?? null,
+    isPullRequest: !!asRecord(record?.pull_request),
+  }
+}
+
+function readPullRequestLike(
+  value: unknown,
+): { number: number; isDraft: boolean; headSha: string | null } | null {
+  const record = asRecord(value)
+  const number = readPositiveInteger(record?.number)
+  if (!number) return null
+
+  return {
+    number,
+    isDraft: record?.draft === true,
+    headSha: normalizeNonEmptyString(asRecord(record?.head)?.sha) ?? null,
+  }
+}
+
+function readCommentLike(
+  value: unknown,
+): { id: number; body: string } | null {
+  const record = asRecord(value)
+  const id = readPositiveInteger(record?.id)
+  const body = normalizeNonEmptyString(record?.body)
+  if (!id || !body) return null
+
+  return {
+    id,
+    body,
+  }
+}
+
+function readLabelName(value: unknown): string | null {
+  return normalizeNonEmptyString(asRecord(value)?.name)
+}
+
+function readLabelNames(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => readLabelName(item))
+    .filter((label): label is string => !!label)
+}
+
+function hasAnyLabel(labels: string[], allowed: ReadonlySet<string>): boolean {
+  return labels.some((label) => allowed.has(label))
+}
+
+function readPositiveInteger(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value > 0 ? value : null
+  }
+
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    const parsed = Number.parseInt(value, 10)
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
+  }
+
+  return null
+}
+
+function normalizeNonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
   executeWakeCommand,
+  executeWakeRequest,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
   resolveWakeCommand,
@@ -125,6 +126,51 @@ describe('index helpers', () => {
     expect(readFileSync(queuePath, 'utf-8')).toBe(
       '{"kind":"pr","prNumber":381,"reason":"cli:wake-pr","sourceEvent":"cli","dedupeKey":"cli:wake-pr:381","requestedAt":"2026-04-11T09:40:00.000Z"}\n',
     )
+  })
+
+  test('persists prebuilt github-event wake requests through the shared wake execution path', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'agent-loop-wake-request-test-'))
+
+    const result = await executeWakeRequest({
+      request: {
+        kind: 'issue',
+        issueNumber: 374,
+        reason: 'issues.labeled:agent:ready',
+        sourceEvent: 'issues.labeled',
+        dedupeKey: 'issues:labeled:374:agent:ready',
+        requestedAt: '2026-04-11T09:41:00.000Z',
+      },
+      healthPort: 9311,
+    }, {
+      resolveLocalDaemonIdentity: () => ({
+        repo: 'JamesWuHK/agent-loop',
+        machineId: 'macbook-pro-b',
+      }),
+      buildWakeQueuePath: (input) => buildWakeQueuePath({
+        ...input,
+        homeDir,
+      }),
+      appendWakeRequest,
+      notifyLocalWake: async () => undefined,
+      now: () => new Date('2026-04-11T09:41:00.000Z'),
+    })
+
+    expect(result).toEqual({
+      queuePath: buildWakeQueuePath({
+        repo: 'JamesWuHK/agent-loop',
+        machineId: 'macbook-pro-b',
+        homeDir,
+      }),
+      request: {
+        kind: 'issue',
+        issueNumber: 374,
+        reason: 'issues.labeled:agent:ready',
+        sourceEvent: 'issues.labeled',
+        dedupeKey: 'issues:labeled:374:agent:ready',
+        requestedAt: '2026-04-11T09:41:00.000Z',
+      },
+      notified: true,
+    })
   })
 
   test('preserves existing managed runtime launch args and replaces explicit overrides', () => {

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -15,6 +15,7 @@ import { AgentDaemon, DEFAULT_HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_HOST, ty
 import { loadConfig, resolveLocalDaemonIdentity, type CliArgs } from './config'
 import { collectDaemonObservability, formatDoctorReport, formatStatusReport } from './status'
 import { appendWakeRequest, buildWakeQueuePath, type WakeRequest } from './wake-queue'
+import { readWakeRequestFromGitHubEventContext } from './github-event-wake'
 import {
   buildCurrentProcessRuntimeRecord,
   buildBackgroundRuntimePaths,
@@ -59,6 +60,13 @@ export interface WakeCommand {
 
 export interface ExecuteWakeCommandInput {
   command: WakeCommand
+  repo?: string
+  machineId?: string
+  healthPort: number
+}
+
+export interface ExecuteWakeRequestInput {
+  request: WakeRequest
   repo?: string
   machineId?: string
   healthPort: number
@@ -194,6 +202,9 @@ async function main() {
       'wake-now': { type: 'boolean' },
       'wake-issue': { type: 'string' },
       'wake-pr': { type: 'string' },
+      'wake-from-github-event': { type: 'boolean' },
+      'github-event-name': { type: 'string' },
+      'github-event-path': { type: 'string' },
       help: { type: 'boolean' },
     },
   })
@@ -217,6 +228,13 @@ async function main() {
   })
 
   if (wakeCommand) {
+    assertWakeCommandCompatible(args)
+  }
+
+  if (args['wake-from-github-event']) {
+    if (wakeCommand) {
+      throw new Error('--wake-from-github-event cannot be combined with --wake-now, --wake-issue, or --wake-pr')
+    }
     assertWakeCommandCompatible(args)
   }
 
@@ -368,6 +386,32 @@ async function main() {
         machineId: cliArgs.machineId,
         healthPort: healthServerConfig.port ?? DEFAULT_HEALTH_SERVER_PORT,
       })
+      console.log(`[agent-loop] queued wake request at ${result.queuePath}`)
+      console.log(
+        result.notified
+          ? `[agent-loop] local daemon notified via http://${DEFAULT_HEALTH_SERVER_HOST}:${healthServerConfig.port ?? DEFAULT_HEALTH_SERVER_PORT}/wake`
+          : '[agent-loop] wake request persisted; local daemon notify was not confirmed',
+      )
+      process.exit(0)
+    }
+
+    if (args['wake-from-github-event']) {
+      const request = readWakeRequestFromGitHubEventContext({
+        eventName: args['github-event-name'] as string | undefined,
+        eventPath: args['github-event-path'] as string | undefined,
+      })
+      if (!request) {
+        console.log('[agent-loop] github event did not require a wake request')
+        process.exit(0)
+      }
+
+      const result = await executeWakeRequest({
+        request,
+        repo: cliArgs.repo,
+        machineId: cliArgs.machineId,
+        healthPort: healthServerConfig.port ?? DEFAULT_HEALTH_SERVER_PORT,
+      })
+      console.log(`[agent-loop] resolved ${result.request.kind} wake request from ${result.request.sourceEvent}`)
       console.log(`[agent-loop] queued wake request at ${result.queuePath}`)
       console.log(
         result.notified
@@ -603,6 +647,7 @@ Usage:
   agent-loop --wake-now [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
   agent-loop --wake-issue <number> [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
   agent-loop --wake-pr <number> [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
+  agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
   agent-loop --reconcile [--health-port 9310]
   agent-loop --start [--health-port 9310]
   agent-loop --dashboard [--dashboard-port 9388]
@@ -629,6 +674,10 @@ Options:
       --wake-now              Queue an immediate local wake request and best-effort notify the daemon
       --wake-issue <number>   Queue a targeted issue wake request and best-effort notify the daemon
       --wake-pr <number>      Queue a targeted PR wake request and best-effort notify the daemon
+      --wake-from-github-event
+                              Translate the current GitHub Actions event into a local wake request
+      --github-event-name     Override the GitHub event name used by --wake-from-github-event
+      --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -802,6 +851,18 @@ export async function executeWakeCommand(
   input: ExecuteWakeCommandInput,
   deps: WakeCommandDependencies = DEFAULT_WAKE_COMMAND_DEPENDENCIES,
 ): Promise<ExecuteWakeCommandResult> {
+  return executeWakeRequest({
+    request: buildWakeRequestFromCli(input.command, deps.now().toISOString()),
+    repo: input.repo,
+    machineId: input.machineId,
+    healthPort: input.healthPort,
+  }, deps)
+}
+
+export async function executeWakeRequest(
+  input: ExecuteWakeRequestInput,
+  deps: WakeCommandDependencies = DEFAULT_WAKE_COMMAND_DEPENDENCIES,
+): Promise<ExecuteWakeCommandResult> {
   const identity = deps.resolveLocalDaemonIdentity(
     {
       repo: input.repo,
@@ -811,20 +872,19 @@ export async function executeWakeCommand(
       persistGeneratedMachineId: false,
     },
   )
-  const request = buildWakeRequestFromCli(input.command, deps.now().toISOString())
   const queuePath = deps.buildWakeQueuePath({
     repo: identity.repo,
     machineId: identity.machineId,
   })
 
-  deps.appendWakeRequest(queuePath, request)
+  deps.appendWakeRequest(queuePath, input.request)
 
   let notified = false
 
   try {
     await deps.notifyLocalWake({
       healthPort: input.healthPort,
-      request,
+      request: input.request,
     })
     notified = true
   } catch {
@@ -833,7 +893,7 @@ export async function executeWakeCommand(
 
   return {
     queuePath,
-    request,
+    request: input.request,
     notified,
   }
 }

--- a/apps/agent-daemon/src/wake-queue.test.ts
+++ b/apps/agent-daemon/src/wake-queue.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import {
   appendWakeRequest,
   buildWakeQueuePath,
+  coalesceWakeRequests,
   drainWakeQueue,
   hasPendingWakeRequests,
   resolveWakeQueueHomeDirFromWorktreesBase,
@@ -125,6 +126,50 @@ describe('wake queue helpers', () => {
     expect(result.invalidEntries[0]?.lineNumber).toBe(2)
     expect(result.invalidEntries[1]?.lineNumber).toBe(3)
     expect(existsSync(queuePath)).toBe(false)
+  })
+
+  test('coalesces duplicate wake requests by dedupe key while preserving the latest payload', () => {
+    expect(coalesceWakeRequests([
+      {
+        kind: 'issue',
+        issueNumber: 42,
+        reason: 'issues.edited',
+        sourceEvent: 'issues.edited',
+        dedupeKey: 'issues:edited:42',
+        requestedAt: '2026-04-11T10:00:00.000Z',
+      },
+      {
+        kind: 'now',
+        reason: 'workflow_dispatch',
+        sourceEvent: 'workflow_dispatch',
+        dedupeKey: 'workflow_dispatch:now',
+        requestedAt: '2026-04-11T10:01:00.000Z',
+      },
+      {
+        kind: 'issue',
+        issueNumber: 42,
+        reason: 'issues.edited',
+        sourceEvent: 'issues.edited',
+        dedupeKey: 'issues:edited:42',
+        requestedAt: '2026-04-11T10:02:00.000Z',
+      },
+    ])).toEqual([
+      {
+        kind: 'now',
+        reason: 'workflow_dispatch',
+        sourceEvent: 'workflow_dispatch',
+        dedupeKey: 'workflow_dispatch:now',
+        requestedAt: '2026-04-11T10:01:00.000Z',
+      },
+      {
+        kind: 'issue',
+        issueNumber: 42,
+        reason: 'issues.edited',
+        sourceEvent: 'issues.edited',
+        dedupeKey: 'issues:edited:42',
+        requestedAt: '2026-04-11T10:02:00.000Z',
+      },
+    ])
   })
 
   test('derives the wake queue home dir from supported worktree layouts', () => {

--- a/apps/agent-daemon/src/wake-queue.ts
+++ b/apps/agent-daemon/src/wake-queue.ts
@@ -106,10 +106,27 @@ export function drainWakeQueue(queuePath: string): DrainWakeQueueResult {
   }
 
   try {
-    return parseWakeQueueContent(content)
+    const parsed = parseWakeQueueContent(content)
+    return {
+      ...parsed,
+      requests: coalesceWakeRequests(parsed.requests),
+    }
   } finally {
     unlinkSync(drainingPath)
   }
+}
+
+export function coalesceWakeRequests(requests: WakeRequest[]): WakeRequest[] {
+  const deduped = new Map<string, WakeRequest>()
+
+  for (const request of requests) {
+    if (deduped.has(request.dedupeKey)) {
+      deduped.delete(request.dedupeKey)
+    }
+    deduped.set(request.dedupeKey, request)
+  }
+
+  return Array.from(deduped.values())
 }
 
 function beginWakeQueueDrain(queuePath: string): string | null {

--- a/docs/agent-loop-event-wake-spec.md
+++ b/docs/agent-loop-event-wake-spec.md
@@ -1,6 +1,6 @@
 # Agent Loop Event Wake Spec
 
-- Status: draft
+- Status: partially implemented
 - Owner: engineering
 - Last updated: 2026-04-10
 - Related: `docs/issue-writing.md`, `.github/workflows/agent-ready-gate.yml`
@@ -16,7 +16,17 @@ This document proposes a hybrid model:
 - the local daemon performs a targeted reconcile
 - low-frequency polling remains as a safety net
 
-This is a design draft only. It does not change the current daemon behavior by itself.
+Phase 1 local wake delivery is now implemented in this repo:
+
+- CLI wake commands and a durable local wake queue
+- loopback wake endpoint in the daemon
+- GitHub Actions workflows that translate GitHub events into local wake requests on `self-hosted` runners
+
+What is still pending from this spec:
+
+- targeted reconcile after a wake instead of immediate full discovery
+- slower idle safety-net polling after wake delivery proves stable
+- explicit wake-latency / missed-event measurement
 
 ## Goals
 
@@ -159,11 +169,11 @@ In practice, this should help with rate limits, but it is not a full replacement
 
 ## Rollout
 
-1. Add CLI wake commands and a durable local wake queue.
-2. Add a loopback wake endpoint in the daemon.
-3. Add a GitHub Actions workflow that routes events to self-hosted runners.
-4. Reduce idle poll frequency after wake delivery is stable.
-5. Measure wake latency, missed-event recovery, and GraphQL consumption.
+1. Done: add CLI wake commands and a durable local wake queue.
+2. Done: add a loopback wake endpoint in the daemon.
+3. Done: add GitHub Actions workflows that route events to self-hosted runners.
+4. Pending: reduce idle poll frequency after wake delivery is stable.
+5. Pending: measure wake latency, missed-event recovery, and GraphQL consumption.
 
 ## Acceptance
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions event -> local wake parser and CLI entrypoint via `--wake-from-github-event`
- add self-hosted runner wake workflows, with ready-gate waking only after contract enforcement passes
- coalesce duplicate wake requests by `dedupeKey` and document the new event-driven wake path

## Testing
- bun test apps/agent-daemon/src/github-event-wake.test.ts apps/agent-daemon/src/wake-queue.test.ts apps/agent-daemon/src/index.test.ts apps/agent-daemon/src/daemon.test.ts
- bun run --cwd apps/agent-daemon typecheck
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/agent-daemon-wake.yml"); YAML.load_file(".github/workflows/agent-ready-gate.yml"); puts "yaml ok"'