### PR TITLE
feat(wake): add wake observability metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ agent-loop --wake-pr 456
 - `--wake-issue` / `--wake-pr`：优先只检查这个 issue / PR 对应的调度路径，不先做全仓库 discovery
 - `--wake-now`：显式允许这轮 wake 继续回退到普通全量扫描，适合手工兜底
 
+现在 `agent-loop --status` / `agent-loop --doctor` 和 `/metrics` 也会把 wake 队列观测带出来，方便你判断“事件有没有进来、有没有被消费、是不是经常 miss target 后回退到全量扫描”。
+
 如果你已经在目标开发机上装了 GitHub self-hosted runner，现在仓库里的 [`agent-daemon-wake.yml`](.github/workflows/agent-daemon-wake.yml) 和 [`agent-ready-gate.yml`](.github/workflows/agent-ready-gate.yml) 会把 issue / PR / manual dispatch 事件翻译成这类本地 wake request：
 
 - `agent:ready` 的 issue 会先过 ready-gate，再 wake 本机 daemon，避免校验和认领抢跑
@@ -407,6 +409,9 @@ agent-loop --doctor
 - `agent_loop_review_auto_fixes_total`
 - `agent_loop_pr_merge_recovery_total`
 - `agent_loop_polls_total`
+- `agent_loop_wake_requests_total`
+- `agent_loop_pending_wake_requests`
+- `agent_loop_wake_request_age_seconds`
 
 职责边界建议：
 

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -47,6 +47,7 @@ import {
 } from './daemon'
 import { ISSUE_LABELS, PR_REVIEW_LABELS } from '@agent/shared'
 import { buildManagedDaemonUpgradeAnnouncementComment } from './presence'
+import { getMetrics, registry } from './metrics'
 import { appendWakeRequest, buildWakeQueuePath } from './wake-queue'
 
 function createTestDaemon(
@@ -322,6 +323,52 @@ describe('wake queue integration', () => {
 
     expect(untargetedResumeAttempts).toBe(1)
     expect(scheduleCount).toBe(1)
+  })
+
+  test('publishes wake queue metrics when requests are queued and consumed', async () => {
+    registry.resetMetrics()
+
+    try {
+      const homeDir = mkdtempSync(join(tmpdir(), 'agent-loop-daemon-wake-metrics-'))
+      const queuePath = buildWakeQueuePath({
+        homeDir,
+        repo: 'JamesWuHK/agent-loop',
+        machineId: 'codex-dev',
+      })
+
+      appendWakeRequest(queuePath, {
+        kind: 'issue',
+        issueNumber: 374,
+        reason: 'issues.labeled:agent:ready',
+        sourceEvent: 'issues.labeled',
+        dedupeKey: 'issues:labeled:374:agent:ready',
+        requestedAt: '2026-04-11T09:12:00.000Z',
+      })
+
+      const daemon = createTestDaemon({
+        repo: 'JamesWuHK/agent-loop',
+        machineId: 'codex-dev',
+        worktreesBase: join(homeDir, 'worktrees'),
+      })
+
+      await daemon.drainWakeQueueOnce({
+        scheduleImmediate: false,
+      })
+
+      let metrics = await getMetrics()
+      expect(metrics).toContain('agent_loop_wake_requests_total{kind="issue",outcome="queued"} 1')
+      expect(metrics).toContain('agent_loop_pending_wake_requests 1')
+
+      ;(daemon as any).maybeStartTargetedIssueWake = async () => true
+      await (daemon as any).maybeStartQueuedWakeRequest()
+
+      metrics = await getMetrics()
+      expect(metrics).toContain('agent_loop_wake_requests_total{kind="issue",outcome="started_work"} 1')
+      expect(metrics).toContain('agent_loop_pending_wake_requests 0')
+      expect(metrics).toContain('agent_loop_wake_request_age_seconds_count{kind="issue",outcome="started_work"} 1')
+    } finally {
+      registry.resetMetrics()
+    }
   })
 })
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -53,12 +53,15 @@ import {
   recordRecoveryAction,
   recordTransientLoopError,
   recordWorkerIdleTimeout,
+  recordQueuedWakeRequest,
+  recordHandledWakeRequest,
   setStalledWorkers,
   setBlockedIssueResumes,
   setBlockedIssueResumeAgeSeconds,
   setBlockedIssueResumeEscalations,
   setBlockedIssueResumeEscalationAgeSeconds,
   setLastTransientLoopErrorAgeSeconds,
+  setPendingWakeRequests,
   setStartupRecoveryPending,
   startMetricsServer,
   METRICS_PORT_DEFAULT,
@@ -599,6 +602,10 @@ export class AgentDaemon {
       return
     }
 
+    for (const request of requests) {
+      recordQueuedWakeRequest(request.kind)
+    }
+
     const deduped = new Map<string, WakeRequest>()
     for (const request of [...this.pendingWakeRequests, ...requests]) {
       if (deduped.has(request.dedupeKey)) {
@@ -608,6 +615,7 @@ export class AgentDaemon {
     }
 
     this.pendingWakeRequests = Array.from(deduped.values())
+    this.syncRuntimeMetrics()
   }
 
   private maybeRequestQueuedWakeReconcile(): void {
@@ -642,7 +650,10 @@ export class AgentDaemon {
       }
     }
 
+    this.syncRuntimeMetrics()
+
     if (request.kind === 'now') {
+      recordHandledWakeRequest(request.kind, 'allow_fallback', request.requestedAt)
       return {
         handled: true,
         startedWork: false,
@@ -651,16 +662,20 @@ export class AgentDaemon {
     }
 
     if (request.kind === 'issue') {
+      const startedWork = await this.maybeStartTargetedIssueWake(request.issueNumber)
+      recordHandledWakeRequest(request.kind, startedWork ? 'started_work' : 'no_match', request.requestedAt)
       return {
         handled: true,
-        startedWork: await this.maybeStartTargetedIssueWake(request.issueNumber),
+        startedWork,
         allowUntargetedFallback: false,
       }
     }
 
+    const startedWork = await this.maybeStartTargetedPrWake(request.prNumber)
+    recordHandledWakeRequest(request.kind, startedWork ? 'started_work' : 'no_match', request.requestedAt)
     return {
       handled: true,
-      startedWork: await this.maybeStartTargetedPrWake(request.prNumber),
+      startedWork,
       allowUntargetedFallback: false,
     }
   }
@@ -3802,6 +3817,7 @@ export class AgentDaemon {
     setBlockedIssueResumeAgeSeconds(runtime.oldestBlockedIssueResumeAgeSeconds)
     setBlockedIssueResumeEscalations(runtime.blockedIssueResumeEscalationCount)
     setBlockedIssueResumeEscalationAgeSeconds(runtime.oldestBlockedIssueResumeEscalationAgeSeconds)
+    setPendingWakeRequests(this.pendingWakeRequests.length)
   }
 
   private getOldestLeaseHeartbeatAgeSeconds(): number {

--- a/apps/agent-daemon/src/metrics.test.ts
+++ b/apps/agent-daemon/src/metrics.test.ts
@@ -11,6 +11,8 @@ import {
   recordRecoveryAction,
   recordTransientLoopError,
   recordWorkerIdleTimeout,
+  recordQueuedWakeRequest,
+  recordHandledWakeRequest,
   recordPrCreated,
   setActiveWorktrees,
   setActivePrReviews,
@@ -21,6 +23,7 @@ import {
   setBlockedIssueResumeEscalationAgeSeconds,
   setLastTransientLoopErrorAgeSeconds,
   setNextPollDelaySeconds,
+  setPendingWakeRequests,
   setInFlightIssueProcesses,
   setInFlightPrReviews,
   setLeaseHeartbeatAgeSeconds,
@@ -182,6 +185,21 @@ describe('metrics', () => {
       expect(metrics).toContain('agent_loop_worker_idle_timeouts_total')
       expect(metrics).toContain('scope="pr-review"')
     })
+
+    test('tracks wake queue and handling outcomes', async () => {
+      recordQueuedWakeRequest('issue')
+      recordHandledWakeRequest('issue', 'started_work', '2026-04-11T09:10:00.000Z', Date.parse('2026-04-11T09:10:05.000Z'))
+      recordHandledWakeRequest('now', 'allow_fallback', '2026-04-11T09:11:00.000Z', Date.parse('2026-04-11T09:11:01.000Z'))
+
+      const metrics = await getMetrics()
+      expect(metrics).toContain('agent_loop_wake_requests_total')
+      expect(metrics).toContain('kind="issue"')
+      expect(metrics).toContain('kind="now"')
+      expect(metrics).toContain('outcome="queued"')
+      expect(metrics).toContain('outcome="started_work"')
+      expect(metrics).toContain('outcome="allow_fallback"')
+      expect(metrics).toContain('agent_loop_wake_request_age_seconds')
+    })
   })
 
   describe('recordPrCreated', () => {
@@ -212,6 +230,7 @@ describe('metrics', () => {
       setBlockedIssueResumeEscalationAgeSeconds(15)
       setLastTransientLoopErrorAgeSeconds(12)
       setNextPollDelaySeconds(5)
+      setPendingWakeRequests(2)
       setInFlightIssueProcesses(true)
       setInFlightPrReviews(false)
       setStartupRecoveryPending(true)
@@ -228,6 +247,7 @@ describe('metrics', () => {
       expect(metrics).toContain('agent_loop_blocked_issue_resume_escalation_age_seconds')
       expect(metrics).toContain('agent_loop_last_transient_loop_error_age_seconds')
       expect(metrics).toContain('agent_loop_next_poll_delay_seconds')
+      expect(metrics).toContain('agent_loop_pending_wake_requests')
       expect(metrics).toContain('agent_loop_inflight_issue_processes')
       expect(metrics).toContain('agent_loop_inflight_pr_reviews')
       expect(metrics).toContain('agent_loop_startup_recovery_pending')

--- a/apps/agent-daemon/src/metrics.ts
+++ b/apps/agent-daemon/src/metrics.ts
@@ -24,12 +24,15 @@
  * - agent_loop_lease_heartbeat_age_seconds: Gauge of oldest held lease heartbeat age
  * - agent_loop_stalled_workers: Gauge of stalled workers tracked by the daemon
  * - agent_loop_transient_loop_errors_total: Counter of transient loop-level GitHub/network errors
+ * - agent_loop_wake_requests_total: Counter of wake requests queued/handled (labels: kind, outcome)
  * - agent_loop_last_transient_loop_error_age_seconds: Gauge of the most recent transient loop error age
+ * - agent_loop_pending_wake_requests: Gauge of queued wake requests waiting in memory
  * - agent_loop_blocked_issue_resumes: Gauge of failed issue resumes currently blocked by linked PR state
  * - agent_loop_blocked_issue_resume_age_seconds: Gauge of the oldest blocked failed-issue resume age
  * - agent_loop_poll_duration_seconds: Histogram of poll cycle durations
  * - agent_loop_issue_processing_duration_seconds: Histogram of issue processing durations
  * - agent_loop_agent_execution_duration_seconds: Histogram of agent execution durations
+ * - agent_loop_wake_request_age_seconds: Histogram of wake request queue age when handled
  */
 
 import {
@@ -103,6 +106,8 @@ export const agentExecutionsTotal = new Counter({
 
 export type PrReviewStage = 'initial' | 'post_fix' | 'merge_refresh'
 export type PrReviewOutcome = 'approved' | 'rejected' | 'invalid_output' | 'execution_failed'
+export type WakeRequestKind = 'now' | 'issue' | 'pr'
+export type WakeRequestOutcome = 'queued' | 'started_work' | 'no_match' | 'allow_fallback'
 
 /**
  * Total number of automated PR reviews performed by the daemon.
@@ -221,6 +226,19 @@ export const transientLoopErrorsTotal = new Counter({
   name: 'agent_loop_transient_loop_errors_total',
   help: 'Total number of transient loop-level GitHub or network errors that were deferred for retry',
   labelNames: ['kind'] as const,
+  registers: [registry],
+})
+
+/**
+ * Total number of wake requests queued and handled.
+ * Labels:
+ *   - kind: "now" | "issue" | "pr"
+ *   - outcome: "queued" | "started_work" | "no_match" | "allow_fallback"
+ */
+export const wakeRequestsTotal = new Counter({
+  name: 'agent_loop_wake_requests_total',
+  help: 'Total number of wake requests queued and handled by the daemon',
+  labelNames: ['kind', 'outcome'] as const,
   registers: [registry],
 })
 
@@ -399,6 +417,15 @@ export const lastTransientLoopErrorAgeSeconds = new Gauge({
   registers: [registry],
 })
 
+/**
+ * Current number of pending wake requests held in memory.
+ */
+export const pendingWakeRequests = new Gauge({
+  name: 'agent_loop_pending_wake_requests',
+  help: 'Current number of pending wake requests held in the daemon in-memory queue',
+  registers: [registry],
+})
+
 // ─── Histograms ────────────────────────────────────────────────────────────────
 
 /**
@@ -438,6 +465,17 @@ export const worktreeCreationDurationSeconds = new Histogram({
   name: 'agent_loop_worktree_creation_duration_seconds',
   help: 'Duration of worktree creation in seconds',
   buckets: [0.1, 0.5, 1, 2, 5, 10],
+  registers: [registry],
+})
+
+/**
+ * Age of wake requests in seconds when they are handled.
+ */
+export const wakeRequestAgeSeconds = new Histogram({
+  name: 'agent_loop_wake_request_age_seconds',
+  help: 'Age of wake requests in seconds when the daemon handles them',
+  labelNames: ['kind', 'outcome'] as const,
+  buckets: [0.01, 0.1, 0.5, 1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600],
   registers: [registry],
 })
 
@@ -563,6 +601,35 @@ export function recordTransientLoopError(
   kind: 'startup-recovery' | 'poll-cycle',
 ): void {
   transientLoopErrorsTotal.inc({ kind })
+}
+
+/**
+ * Record a wake request entering the daemon queue.
+ */
+export function recordQueuedWakeRequest(kind: WakeRequestKind): void {
+  wakeRequestsTotal.inc({ kind, outcome: 'queued' })
+}
+
+/**
+ * Record a handled wake request and its time spent queued.
+ */
+export function recordHandledWakeRequest(
+  kind: WakeRequestKind,
+  outcome: Exclude<WakeRequestOutcome, 'queued'>,
+  requestedAt: string,
+  nowMs: number = Date.now(),
+): void {
+  wakeRequestsTotal.inc({ kind, outcome })
+
+  const requestedAtMs = Date.parse(requestedAt)
+  if (!Number.isFinite(requestedAtMs)) {
+    return
+  }
+
+  wakeRequestAgeSeconds.observe(
+    { kind, outcome },
+    Math.max(0, (nowMs - requestedAtMs) / 1000),
+  )
 }
 
 /**
@@ -725,6 +792,13 @@ export function setBlockedIssueResumeEscalationAgeSeconds(ageSeconds: number): v
  */
 export function setLastTransientLoopErrorAgeSeconds(ageSeconds: number): void {
   lastTransientLoopErrorAgeSeconds.set(ageSeconds)
+}
+
+/**
+ * Update the in-memory pending wake request gauge.
+ */
+export function setPendingWakeRequests(count: number): void {
+  pendingWakeRequests.set(count)
 }
 
 /**

--- a/apps/agent-daemon/src/status.test.ts
+++ b/apps/agent-daemon/src/status.test.ts
@@ -213,6 +213,10 @@ agent_loop_polls_total{result="success"} 12
 agent_loop_polls_total{result="skipped_concurrency"} 3
 agent_loop_polls_total{result="no_issues"} 4
 agent_loop_polls_total{result="error"} 1
+agent_loop_wake_requests_total{kind="issue",outcome="queued"} 2
+agent_loop_wake_requests_total{kind="issue",outcome="started_work"} 1
+agent_loop_wake_requests_total{kind="pr",outcome="no_match"} 1
+agent_loop_wake_requests_total{kind="now",outcome="allow_fallback"} 1
 agent_loop_pr_reviews_total{stage="initial",outcome="approved"} 2
 agent_loop_pr_reviews_total{stage="post_fix",outcome="rejected"} 1
 agent_loop_pr_reviews_total{stage="merge_refresh",outcome="execution_failed"} 1
@@ -225,6 +229,7 @@ agent_loop_transient_loop_errors_total{kind="startup-recovery"} 1
 agent_loop_transient_loop_errors_total{kind="poll-cycle"} 1
 agent_loop_last_transient_loop_error_age_seconds 15
 agent_loop_next_poll_delay_seconds 5
+agent_loop_pending_wake_requests 2
 agent_loop_worker_idle_timeouts_total{scope="issue-process"} 2
 agent_loop_active_leases 2
 agent_loop_lease_heartbeat_age_seconds 75
@@ -308,6 +313,18 @@ describe('status helpers', () => {
         no_issues: 4,
         error: 1,
       },
+      wakeRequests: {
+        issue: {
+          queued: 2,
+          started_work: 1,
+        },
+        pr: {
+          no_match: 1,
+        },
+        now: {
+          allow_fallback: 1,
+        },
+      },
       prReviews: {
         initial: {
           approved: 2,
@@ -341,6 +358,7 @@ describe('status helpers', () => {
       },
       lastTransientLoopErrorAgeSeconds: 15,
       nextPollDelaySeconds: 5,
+      pendingWakeRequests: 2,
       activeLeases: 2,
       leaseHeartbeatAgeSeconds: 75,
       stalledWorkers: 1,
@@ -402,7 +420,8 @@ describe('status helpers', () => {
     expect(report).toContain('blocked resumes: issue#91<-pr#110 45s esc=1/15s')
     expect(report).toContain('launchd: loaded yes | state running | runs 2 | last signal Terminated: 15')
     expect(report).toContain('runtime files: record /Users/wujames/.agent-loop/runtime/jameswuhk-digital-employee__codex-dev__9310.json | log /Users/wujames/.agent-loop/runtime/jameswuhk-digital-employee__codex-dev__9310.log')
-    expect(report).toContain('outcomes: polls success=12, skipped_concurrency=3, no_issues=4, error=1')
+    expect(report).toContain('outcomes: polls success=12, skipped_concurrency=3, no_issues=4, error=1 | wake queued=2, started_work=1, no_match=1, allow_fallback=1')
+    expect(report).toContain('wake: pending 2 | now[queued=0, started_work=0, no_match=0, allow_fallback=1], issue[queued=2, started_work=1, no_match=0, allow_fallback=0], pr[queued=0, started_work=0, no_match=1, allow_fallback=0]')
     expect(report).toContain('pr blockers: pr#239<-issue#105 attempt 5 @ 2026-04-06T01:23:45.000Z: The PR breaks the existing approval-bar flow')
     expect(report).toContain('warnings: startup recovery is still pending')
   })
@@ -482,6 +501,8 @@ describe('status helpers', () => {
     expect(report).toContain('GitHub Audit')
     expect(report).toContain('issue-process#77 | state=open | labels=agent:stale | warning=issue-process#77 has an active lease but issue state is stale (expected working)')
     expect(report).toContain('merge-recovery: merged_initial=1')
+    expect(report).toContain('pending-wake-requests: 2')
+    expect(report).toContain('wake-requests: now[queued=0, started_work=0, no_match=0, allow_fallback=1], issue[queued=2, started_work=1, no_match=0, allow_fallback=0], pr[queued=0, started_work=0, no_match=1, allow_fallback=0]')
     expect(report).toContain('worker-idle-timeouts: issue-process=2')
     expect(report).toContain('blocked-issue-resumes: 1')
     expect(report).toContain('blocked-issue-resume-age-seconds: 45')

--- a/apps/agent-daemon/src/status.ts
+++ b/apps/agent-daemon/src/status.ts
@@ -42,6 +42,8 @@ const MERGE_RECOVERY_OUTCOME_ORDER = [
   'retry_merge_failed',
 ] as const
 const POLL_OUTCOME_ORDER = ['success', 'skipped_concurrency', 'no_issues', 'error'] as const
+const WAKE_KIND_ORDER = ['now', 'issue', 'pr'] as const
+const WAKE_OUTCOME_ORDER = ['queued', 'started_work', 'no_match', 'allow_fallback'] as const
 const GITHUB_AUDIT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS = 3
 const RECENT_TRANSIENT_LOOP_ERROR_WARNING_AGE_SECONDS = 5 * 60
 export interface DaemonHealthPayload extends DaemonStatus {
@@ -52,6 +54,7 @@ export interface DaemonHealthPayload extends DaemonStatus {
 
 export interface DaemonMetricSummary {
   polls: Record<string, number>
+  wakeRequests: Record<string, Record<string, number>>
   prReviews: Record<string, Record<string, number>>
   autoFixes: Record<string, number>
   mergeRecovery: Record<string, number>
@@ -60,6 +63,7 @@ export interface DaemonMetricSummary {
   workerIdleTimeouts: Record<string, number>
   lastTransientLoopErrorAgeSeconds: number | null
   nextPollDelaySeconds: number | null
+  pendingWakeRequests: number | null
   activeLeases: number | null
   leaseHeartbeatAgeSeconds: number | null
   stalledWorkers: number | null
@@ -447,7 +451,10 @@ export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): strin
   if (snapshot.metrics) {
     const reviewTotals = summarizeReviewOutcomes(snapshot.metrics.prReviews)
     lines.push(
-      `outcomes: polls ${formatOrderedMap(snapshot.metrics.polls, POLL_OUTCOME_ORDER)} | reviews ${formatOrderedMap(reviewTotals, REVIEW_OUTCOME_ORDER)} | auto-fix ${formatOrderedMap(snapshot.metrics.autoFixes, AUTO_FIX_OUTCOME_ORDER)} | merge ${formatOrderedMap(snapshot.metrics.mergeRecovery, MERGE_RECOVERY_OUTCOME_ORDER)}`,
+      `outcomes: polls ${formatOrderedMap(snapshot.metrics.polls, POLL_OUTCOME_ORDER)} | wake ${formatOrderedMap(summarizeWakeOutcomes(snapshot.metrics.wakeRequests), WAKE_OUTCOME_ORDER)} | reviews ${formatOrderedMap(reviewTotals, REVIEW_OUTCOME_ORDER)} | auto-fix ${formatOrderedMap(snapshot.metrics.autoFixes, AUTO_FIX_OUTCOME_ORDER)} | merge ${formatOrderedMap(snapshot.metrics.mergeRecovery, MERGE_RECOVERY_OUTCOME_ORDER)}`,
+    )
+    lines.push(
+      `wake: pending ${snapshot.metrics.pendingWakeRequests ?? 0} | ${formatWakeRequestSummary(snapshot.metrics.wakeRequests)}`,
     )
   } else if (snapshot.metricsError) {
     lines.push(`metrics: unavailable (${snapshot.metricsError})`)
@@ -558,6 +565,8 @@ export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): strin
         `transient-loop-errors: ${formatInlineKeyValue(snapshot.metrics.transientLoopErrors) || 'none'}`,
         `last-transient-loop-error-age-seconds: ${snapshot.metrics.lastTransientLoopErrorAgeSeconds ?? 0}`,
         `next-poll-delay-seconds: ${snapshot.metrics.nextPollDelaySeconds ?? 0}`,
+        `pending-wake-requests: ${snapshot.metrics.pendingWakeRequests ?? 0}`,
+        `wake-requests: ${formatWakeRequestSummary(snapshot.metrics.wakeRequests)}`,
         `lease-conflicts: ${snapshot.metrics.leaseConflicts}`,
         `worker-idle-timeouts: ${formatInlineKeyValue(snapshot.metrics.workerIdleTimeouts) || 'none'}`,
         `blocked-issue-resumes: ${snapshot.metrics.blockedIssueResumes ?? 0}`,
@@ -774,6 +783,7 @@ function parsePortFromUrl(url: string): number | null {
 export function summarizeDaemonMetrics(metricsText: string): DaemonMetricSummary {
   const summary: DaemonMetricSummary = {
     polls: {},
+    wakeRequests: {},
     prReviews: {},
     autoFixes: {},
     mergeRecovery: {},
@@ -782,6 +792,7 @@ export function summarizeDaemonMetrics(metricsText: string): DaemonMetricSummary
     workerIdleTimeouts: {},
     lastTransientLoopErrorAgeSeconds: null,
     nextPollDelaySeconds: null,
+    pendingWakeRequests: null,
     activeLeases: null,
     leaseHeartbeatAgeSeconds: null,
     stalledWorkers: null,
@@ -797,6 +808,11 @@ export function summarizeDaemonMetrics(metricsText: string): DaemonMetricSummary
     switch (sample.name) {
       case 'agent_loop_polls_total':
         if (sample.labels.result) summary.polls[sample.labels.result] = sample.value
+        break
+      case 'agent_loop_wake_requests_total':
+        if (!sample.labels.kind || !sample.labels.outcome) break
+        summary.wakeRequests[sample.labels.kind] ??= {}
+        summary.wakeRequests[sample.labels.kind]![sample.labels.outcome] = sample.value
         break
       case 'agent_loop_pr_reviews_total':
         if (!sample.labels.stage || !sample.labels.outcome) break
@@ -825,6 +841,9 @@ export function summarizeDaemonMetrics(metricsText: string): DaemonMetricSummary
         break
       case 'agent_loop_next_poll_delay_seconds':
         summary.nextPollDelaySeconds = sample.value
+        break
+      case 'agent_loop_pending_wake_requests':
+        summary.pendingWakeRequests = sample.value
         break
       case 'agent_loop_active_leases':
         summary.activeLeases = sample.value
@@ -1116,6 +1135,20 @@ function summarizeReviewOutcomes(
   return totals
 }
 
+function summarizeWakeOutcomes(
+  wakeRequests: Record<string, Record<string, number>>,
+): Record<string, number> {
+  const totals: Record<string, number> = {}
+
+  for (const outcomeMap of Object.values(wakeRequests)) {
+    for (const [outcome, value] of Object.entries(outcomeMap)) {
+      totals[outcome] = (totals[outcome] ?? 0) + value
+    }
+  }
+
+  return totals
+}
+
 function buildEndpointUrl(host: string, port: number, path: string): string {
   return `http://${host}:${port}${path}`
 }
@@ -1189,6 +1222,14 @@ function formatRecoveryActionSummary(values: Record<string, Record<string, numbe
   const parts = Object.entries(values).flatMap(([kind, outcomes]) => {
     return Object.entries(outcomes).map(([outcome, count]) => `${kind}/${outcome}=${count}`)
   })
+
+  return parts.join(', ') || 'none'
+}
+
+function formatWakeRequestSummary(values: Record<string, Record<string, number>>): string {
+  const parts = WAKE_KIND_ORDER
+    .filter((kind) => values[kind] !== undefined)
+    .map((kind) => `${kind}[${formatOrderedMap(values[kind] ?? {}, WAKE_OUTCOME_ORDER)}]`)
 
   return parts.join(', ') || 'none'
 }

--- a/docs/agent-loop-event-wake-spec.md
+++ b/docs/agent-loop-event-wake-spec.md
@@ -2,7 +2,7 @@
 
 - Status: partially implemented
 - Owner: engineering
-- Last updated: 2026-04-10
+- Last updated: 2026-04-11
 - Related: `docs/issue-writing.md`, `.github/workflows/agent-ready-gate.yml`
 
 ## Summary
@@ -21,11 +21,12 @@ Phase 1 local wake delivery is now implemented in this repo:
 - CLI wake commands and a durable local wake queue
 - loopback wake endpoint in the daemon
 - GitHub Actions workflows that translate GitHub events into local wake requests on `self-hosted` runners
+- wake queue observability in Prometheus metrics plus `agent-loop --status` / `--doctor`
 
 What is still pending from this spec:
 
 - slower idle safety-net polling after wake delivery proves stable
-- explicit wake-latency / missed-event measurement
+- end-to-end wake-latency / missed-event measurement beyond local queue handling metrics
 
 ## Goals
 
@@ -172,7 +173,7 @@ In practice, this should help with rate limits, but it is not a full replacement
 2. Done: add a loopback wake endpoint in the daemon.
 3. Done: add GitHub Actions workflows that route events to self-hosted runners.
 4. Pending: reduce idle poll frequency after wake delivery is stable.
-5. Pending: measure wake latency, missed-event recovery, and GraphQL consumption.
+5. Pending: add end-to-end wake latency, missed-event recovery, and GraphQL consumption measurement.
 
 ## Acceptance
 


### PR DESCRIPTION
## Summary
- add Prometheus counters, gauge, and age histogram for queued and handled wake requests
- surface wake queue state and outcomes in daemon status/doctor summaries
- cover helper, daemon, and status flows with targeted tests

## Testing
- bun test apps/agent-daemon/src/metrics.test.ts apps/agent-daemon/src/status.test.ts apps/agent-daemon/src/daemon.test.ts
- bun run typecheck