### PR TITLE
feat(metrics): add github api observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ agent-loop --wake-pr 456
 - `--wake-now`：显式允许这轮 wake 继续回退到普通全量扫描，适合手工兜底
 
 现在 `agent-loop --status` / `agent-loop --doctor` 和 `/metrics` 也会把 wake 队列观测带出来，方便你判断“事件有没有进来、有没有被消费、是不是经常 miss target 后回退到全量扫描”。
+现在它们也会显示 GitHub API 读写观测，能直接区分 `graphql` / `rest`、`direct` / `gh_cli`，以及 `success` / `error` / `timeout` / `rate_limited`。
 
 一旦这台机器已经收到过 wake 流量，daemon 在“空闲且没有发现任何 work”的周期里会自动切到更慢的 idle safety-net polling；但只要新的 wake request 到来，还是会立刻把下一轮 reconcile 拉到 0ms，不会因为慢轮询拖慢响应。
 
@@ -419,6 +420,8 @@ agent-loop --doctor
 - `agent_loop_review_auto_fixes_total`
 - `agent_loop_pr_merge_recovery_total`
 - `agent_loop_polls_total`
+- `agent_loop_github_api_requests_total`
+- `agent_loop_github_api_request_duration_seconds`
 - `agent_loop_wake_requests_total`
 - `agent_loop_pending_wake_requests`
 - `agent_loop_wake_request_age_seconds`

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -20,7 +20,7 @@ import type {
   StalledWorkerRuntimeDetail,
   WorktreeInfo,
 } from '@agent/shared'
-import { ISSUE_LABELS, PR_REVIEW_LABELS, canDaemonAdoptManagedLease, getActiveManagedLease, getLatestManagedLease, listOpenAgentIssues, listOpenAgentPullRequests, transitionIssueState, commentOnIssue, commentOnPr, setManagedPrReviewLabels, mergePullRequest, checkPrExists, listIssueComments, resolveActiveClaimMachine, getAgentIssueByNumber, getManagedPullRequestByNumber } from '@agent/shared'
+import { ISSUE_LABELS, PR_REVIEW_LABELS, canDaemonAdoptManagedLease, getActiveManagedLease, getLatestManagedLease, listOpenAgentIssues, listOpenAgentPullRequests, transitionIssueState, commentOnIssue, commentOnPr, setManagedPrReviewLabels, mergePullRequest, checkPrExists, listIssueComments, resolveActiveClaimMachine, getAgentIssueByNumber, getManagedPullRequestByNumber, setGitHubApiRequestObserver } from '@agent/shared'
 import { claimSpecificIssue, pollAndClaim } from './claimer'
 import { createWorktree, removeWorktree, cleanupOrphanedWorktrees, hasWorktreeForIssue } from './worktree-manager'
 import { runIssueBranchPreflight, runSubtaskExecutor, runReviewAutoFix, runIssueRecovery } from './subtask-executor'
@@ -39,6 +39,7 @@ import {
   recordPrCreated,
   setActiveWorktrees,
   setActivePrReviews,
+  recordGitHubApiRequest,
   setConcurrencyLimit,
   setConcurrencyPolicy,
   setDaemonUptime,
@@ -780,6 +781,14 @@ export class AgentDaemon {
   }
 
   async start(): Promise<void> {
+    setGitHubApiRequestObserver((observation) => {
+      recordGitHubApiRequest(
+        observation.transport,
+        observation.mode,
+        observation.outcome,
+        observation.durationMs,
+      )
+    })
     this.logger.log(`[daemon] starting agent-loop v${this.agentLoopBuild.version} (${abbreviateRevision(this.agentLoopBuild.revision)})`)
     this.logger.log(`[daemon] machineId: ${this.config.machineId}`)
     this.logger.log(`[daemon] repo: ${this.config.repo}`)
@@ -1006,6 +1015,7 @@ export class AgentDaemon {
 
     this.running = false
     this.syncRuntimeMetrics()
+    setGitHubApiRequestObserver(null)
     this.logger.log(`[daemon] stopped. Worktrees preserved for debugging.`)
   }
 

--- a/apps/agent-daemon/src/metrics.test.ts
+++ b/apps/agent-daemon/src/metrics.test.ts
@@ -10,6 +10,7 @@ import {
   recordLeaseConflict,
   recordRecoveryAction,
   recordTransientLoopError,
+  recordGitHubApiRequest,
   recordWorkerIdleTimeout,
   recordQueuedWakeRequest,
   recordHandledWakeRequest,
@@ -184,6 +185,21 @@ describe('metrics', () => {
       expect(metrics).toContain('kind="startup-recovery"')
       expect(metrics).toContain('agent_loop_worker_idle_timeouts_total')
       expect(metrics).toContain('scope="pr-review"')
+    })
+
+    test('tracks github api request outcomes and durations', async () => {
+      recordGitHubApiRequest('graphql', 'direct', 'success', 250)
+      recordGitHubApiRequest('rest', 'gh_cli', 'rate_limited', 500)
+
+      const metrics = await getMetrics()
+      expect(metrics).toContain('agent_loop_github_api_requests_total')
+      expect(metrics).toContain('transport="graphql"')
+      expect(metrics).toContain('transport="rest"')
+      expect(metrics).toContain('mode="direct"')
+      expect(metrics).toContain('mode="gh_cli"')
+      expect(metrics).toContain('outcome="success"')
+      expect(metrics).toContain('outcome="rate_limited"')
+      expect(metrics).toContain('agent_loop_github_api_request_duration_seconds')
     })
 
     test('tracks wake queue and handling outcomes', async () => {

--- a/apps/agent-daemon/src/metrics.ts
+++ b/apps/agent-daemon/src/metrics.ts
@@ -24,6 +24,7 @@
  * - agent_loop_lease_heartbeat_age_seconds: Gauge of oldest held lease heartbeat age
  * - agent_loop_stalled_workers: Gauge of stalled workers tracked by the daemon
  * - agent_loop_transient_loop_errors_total: Counter of transient loop-level GitHub/network errors
+ * - agent_loop_github_api_requests_total: Counter of GitHub API requests (labels: transport, mode, outcome)
  * - agent_loop_wake_requests_total: Counter of wake requests queued/handled (labels: kind, outcome)
  * - agent_loop_last_transient_loop_error_age_seconds: Gauge of the most recent transient loop error age
  * - agent_loop_pending_wake_requests: Gauge of queued wake requests waiting in memory
@@ -32,6 +33,7 @@
  * - agent_loop_poll_duration_seconds: Histogram of poll cycle durations
  * - agent_loop_issue_processing_duration_seconds: Histogram of issue processing durations
  * - agent_loop_agent_execution_duration_seconds: Histogram of agent execution durations
+ * - agent_loop_github_api_request_duration_seconds: Histogram of GitHub API request durations
  * - agent_loop_wake_request_age_seconds: Histogram of wake request queue age when handled
  */
 
@@ -42,7 +44,12 @@ import {
   Registry,
   collectDefaultMetrics,
 } from 'prom-client'
-import type { ConcurrencyPolicy } from '@agent/shared'
+import type {
+  ConcurrencyPolicy,
+  GitHubApiMode,
+  GitHubApiOutcome,
+  GitHubApiTransport,
+} from '@agent/shared'
 
 export const METRICS_PORT_DEFAULT = 9090
 export const METRICS_PATH = '/metrics'
@@ -226,6 +233,20 @@ export const transientLoopErrorsTotal = new Counter({
   name: 'agent_loop_transient_loop_errors_total',
   help: 'Total number of transient loop-level GitHub or network errors that were deferred for retry',
   labelNames: ['kind'] as const,
+  registers: [registry],
+})
+
+/**
+ * Total number of GitHub API requests issued by the daemon.
+ * Labels:
+ *   - transport: "graphql" | "rest"
+ *   - mode: "direct" | "gh_cli"
+ *   - outcome: "success" | "error" | "timeout" | "rate_limited"
+ */
+export const githubApiRequestsTotal = new Counter({
+  name: 'agent_loop_github_api_requests_total',
+  help: 'Total number of GitHub API requests issued by the daemon',
+  labelNames: ['transport', 'mode', 'outcome'] as const,
   registers: [registry],
 })
 
@@ -469,6 +490,17 @@ export const worktreeCreationDurationSeconds = new Histogram({
 })
 
 /**
+ * Duration of GitHub API requests in seconds.
+ */
+export const githubApiRequestDurationSeconds = new Histogram({
+  name: 'agent_loop_github_api_request_duration_seconds',
+  help: 'Duration of GitHub API requests in seconds',
+  labelNames: ['transport', 'mode', 'outcome'] as const,
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60],
+  registers: [registry],
+})
+
+/**
  * Age of wake requests in seconds when they are handled.
  */
 export const wakeRequestAgeSeconds = new Histogram({
@@ -601,6 +633,19 @@ export function recordTransientLoopError(
   kind: 'startup-recovery' | 'poll-cycle',
 ): void {
   transientLoopErrorsTotal.inc({ kind })
+}
+
+/**
+ * Record a GitHub API request outcome and duration.
+ */
+export function recordGitHubApiRequest(
+  transport: GitHubApiTransport,
+  mode: GitHubApiMode,
+  outcome: GitHubApiOutcome,
+  durationMs: number,
+): void {
+  githubApiRequestsTotal.inc({ transport, mode, outcome })
+  githubApiRequestDurationSeconds.observe({ transport, mode, outcome }, durationMs / 1000)
 }
 
 /**

--- a/apps/agent-daemon/src/presence.ts
+++ b/apps/agent-daemon/src/presence.ts
@@ -4,9 +4,11 @@ import { join } from 'node:path'
 import {
   runBoundedGhCommand,
   type AgentConfig,
+  type GitHubApiOutcome,
   type AgentLoopUpgradeStatusKind,
   type IssueComment,
 } from '@agent/shared'
+import { recordGitHubApiRequest } from './metrics'
 
 const MANAGED_DAEMON_PRESENCE_ISSUE_TITLE = 'Agent Loop Presence'
 const MANAGED_DAEMON_PRESENCE_ISSUE_MARKER = '<!-- agent-loop:presence-registry -->'
@@ -123,9 +125,9 @@ function withTempJsonFile<T>(
 async function runGhCommand(
   args: string[],
   config: AgentConfig,
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const { stdout, stderr, exitCode } = await runBoundedGhCommand(args, config)
-  return { stdout, stderr, exitCode }
+): Promise<{ stdout: string; stderr: string; exitCode: number; timedOut: boolean }> {
+  const { stdout, stderr, exitCode, timedOut } = await runBoundedGhCommand(args, config)
+  return { stdout, stderr, exitCode, timedOut }
 }
 
 async function runGitHubRestRequest(
@@ -138,6 +140,7 @@ async function runGitHubRestRequest(
 ): Promise<string> {
   const normalizedPath = path.replace(/^\/+/, '')
   const method = options.method ?? 'GET'
+  const startedAt = Date.now()
 
   if (!config.pat) {
     const args = ['api', normalizedPath]
@@ -150,6 +153,12 @@ async function runGitHubRestRequest(
         options.body,
         async (payloadPath) => {
           const response = await runGhCommand([...args, '--input', payloadPath], config)
+          recordGitHubApiRequest(
+            'rest',
+            'gh_cli',
+            classifyGitHubApiOutcome(response.stderr, response.exitCode, response.timedOut),
+            Date.now() - startedAt,
+          )
           if (response.exitCode !== 0) {
             throw new Error(`gh api ${normalizedPath} failed (exit ${response.exitCode}): ${response.stderr}`)
           }
@@ -159,26 +168,45 @@ async function runGitHubRestRequest(
     }
 
     const response = await runGhCommand(args, config)
+    recordGitHubApiRequest(
+      'rest',
+      'gh_cli',
+      classifyGitHubApiOutcome(response.stderr, response.exitCode, response.timedOut),
+      Date.now() - startedAt,
+    )
     if (response.exitCode !== 0) {
       throw new Error(`gh api ${normalizedPath} failed (exit ${response.exitCode}): ${response.stderr}`)
     }
     return response.stdout
   }
 
-  const response = await fetchWithTimeout(`https://api.github.com/${normalizedPath}`, {
-    method,
-    headers: {
-      Authorization: `token ${config.pat}`,
-      Accept: 'application/vnd.github+json',
-      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
-    },
-    body: options.body ? JSON.stringify(options.body) : undefined,
-  })
-  const text = await response.text()
-  if (!response.ok) {
-    throw new Error(`GitHub REST ${method} ${normalizedPath} failed (HTTP ${response.status}): ${parseGitHubRestErrorMessage(text)}`)
+  try {
+    const response = await fetchWithTimeout(`https://api.github.com/${normalizedPath}`, {
+      method,
+      headers: {
+        Authorization: `token ${config.pat}`,
+        Accept: 'application/vnd.github+json',
+        ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    })
+    const text = await response.text()
+    recordGitHubApiRequest(
+      'rest',
+      'direct',
+      classifyGitHubApiOutcome(parseGitHubRestErrorMessage(text), response.ok ? 0 : 1, false),
+      Date.now() - startedAt,
+    )
+    if (!response.ok) {
+      throw new Error(`GitHub REST ${method} ${normalizedPath} failed (HTTP ${response.status}): ${parseGitHubRestErrorMessage(text)}`)
+    }
+    return text
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('timed out')) {
+      recordGitHubApiRequest('rest', 'direct', 'timeout', Date.now() - startedAt)
+    }
+    throw error
   }
-  return text
 }
 
 async function fetchWithTimeout(
@@ -220,6 +248,30 @@ function parseGitHubRestErrorMessage(body: string): string {
   }
 
   return trimmed
+}
+
+function classifyGitHubApiOutcome(
+  message: string,
+  exitCode: number,
+  timedOut: boolean,
+): GitHubApiOutcome {
+  if (timedOut || message.toLowerCase().includes('timed out')) {
+    return 'timeout'
+  }
+  if (exitCode === 0) {
+    return 'success'
+  }
+
+  const normalized = message.toLowerCase()
+  if (
+    normalized.includes('api rate limit')
+    || normalized.includes('secondary rate limit')
+    || normalized.includes('rate limit exceeded')
+  ) {
+    return 'rate_limited'
+  }
+
+  return 'error'
 }
 
 function mapIssueCommentRecord(

--- a/apps/agent-daemon/src/status.test.ts
+++ b/apps/agent-daemon/src/status.test.ts
@@ -214,6 +214,10 @@ agent_loop_polls_total{result="success"} 12
 agent_loop_polls_total{result="skipped_concurrency"} 3
 agent_loop_polls_total{result="no_issues"} 4
 agent_loop_polls_total{result="error"} 1
+agent_loop_github_api_requests_total{transport="graphql",mode="direct",outcome="success"} 8
+agent_loop_github_api_requests_total{transport="graphql",mode="direct",outcome="rate_limited"} 1
+agent_loop_github_api_requests_total{transport="rest",mode="gh_cli",outcome="success"} 5
+agent_loop_github_api_requests_total{transport="rest",mode="gh_cli",outcome="error"} 1
 agent_loop_wake_requests_total{kind="issue",outcome="queued"} 2
 agent_loop_wake_requests_total{kind="issue",outcome="started_work"} 1
 agent_loop_wake_requests_total{kind="pr",outcome="no_match"} 1
@@ -313,6 +317,16 @@ describe('status helpers', () => {
         skipped_concurrency: 3,
         no_issues: 4,
         error: 1,
+      },
+      githubApiRequests: {
+        'graphql/direct': {
+          success: 8,
+          rate_limited: 1,
+        },
+        'rest/gh_cli': {
+          success: 5,
+          error: 1,
+        },
       },
       wakeRequests: {
         issue: {
@@ -423,9 +437,11 @@ describe('status helpers', () => {
     expect(report).toContain('launchd: loaded yes | state running | runs 2 | last signal Terminated: 15')
     expect(report).toContain('runtime files: record /Users/wujames/.agent-loop/runtime/jameswuhk-digital-employee__codex-dev__9310.json | log /Users/wujames/.agent-loop/runtime/jameswuhk-digital-employee__codex-dev__9310.log')
     expect(report).toContain('outcomes: polls success=12, skipped_concurrency=3, no_issues=4, error=1 | wake queued=2, started_work=1, no_match=1, allow_fallback=1')
+    expect(report).toContain('github api: graphql/direct[success=8, error=0, timeout=0, rate_limited=1], rest/gh_cli[success=5, error=1, timeout=0, rate_limited=0]')
     expect(report).toContain('wake: pending 2 | now[queued=0, started_work=0, no_match=0, allow_fallback=1], issue[queued=2, started_work=1, no_match=0, allow_fallback=0], pr[queued=0, started_work=0, no_match=1, allow_fallback=0]')
     expect(report).toContain('pr blockers: pr#239<-issue#105 attempt 5 @ 2026-04-06T01:23:45.000Z: The PR breaks the existing approval-bar flow')
     expect(report).toContain('warnings: startup recovery is still pending')
+    expect(report).toContain('github api rate limits observed: graphql/direct[success=0, error=0, timeout=0, rate_limited=1]')
   })
 
   test('formats a doctor report with worktrees and metrics warnings', () => {
@@ -503,6 +519,7 @@ describe('status helpers', () => {
     expect(report).toContain('reason=The PR breaks the existing approval-bar flow that this issue explicitly had to preserve while adding execution-status logging.')
     expect(report).toContain('GitHub Audit')
     expect(report).toContain('issue-process#77 | state=open | labels=agent:stale | warning=issue-process#77 has an active lease but issue state is stale (expected working)')
+    expect(report).toContain('github-api-requests: graphql/direct[success=8, error=0, timeout=0, rate_limited=1], rest/gh_cli[success=5, error=1, timeout=0, rate_limited=0]')
     expect(report).toContain('merge-recovery: merged_initial=1')
     expect(report).toContain('pending-wake-requests: 2')
     expect(report).toContain('wake-requests: now[queued=0, started_work=0, no_match=0, allow_fallback=1], issue[queued=2, started_work=1, no_match=0, allow_fallback=0], pr[queued=0, started_work=0, no_match=1, allow_fallback=0]')
@@ -512,6 +529,7 @@ describe('status helpers', () => {
     expect(report).toContain('oldest blocked issue resume age: 45s')
     expect(report).toContain('- agent-loop upgrade available; defer restart until the daemon is idle to avoid interrupting active work')
     expect(report).toContain('- open PR review blockers: pr#239')
+    expect(report).toContain('- github api rate limits observed: graphql/direct[success=0, error=0, timeout=0, rate_limited=1]')
     expect(report).toContain('- review auto-fix push failures observed: 1')
   })
 

--- a/apps/agent-daemon/src/status.ts
+++ b/apps/agent-daemon/src/status.ts
@@ -44,6 +44,8 @@ const MERGE_RECOVERY_OUTCOME_ORDER = [
 const POLL_OUTCOME_ORDER = ['success', 'skipped_concurrency', 'no_issues', 'error'] as const
 const WAKE_KIND_ORDER = ['now', 'issue', 'pr'] as const
 const WAKE_OUTCOME_ORDER = ['queued', 'started_work', 'no_match', 'allow_fallback'] as const
+const GITHUB_API_REQUEST_KEY_ORDER = ['graphql/direct', 'graphql/gh_cli', 'rest/direct', 'rest/gh_cli'] as const
+const GITHUB_API_OUTCOME_ORDER = ['success', 'error', 'timeout', 'rate_limited'] as const
 const GITHUB_AUDIT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS = 3
 const RECENT_TRANSIENT_LOOP_ERROR_WARNING_AGE_SECONDS = 5 * 60
 export interface DaemonHealthPayload extends DaemonStatus {
@@ -54,6 +56,7 @@ export interface DaemonHealthPayload extends DaemonStatus {
 
 export interface DaemonMetricSummary {
   polls: Record<string, number>
+  githubApiRequests: Record<string, Record<string, number>>
   wakeRequests: Record<string, Record<string, number>>
   prReviews: Record<string, Record<string, number>>
   autoFixes: Record<string, number>
@@ -454,6 +457,7 @@ export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): strin
     lines.push(
       `outcomes: polls ${formatOrderedMap(snapshot.metrics.polls, POLL_OUTCOME_ORDER)} | wake ${formatOrderedMap(summarizeWakeOutcomes(snapshot.metrics.wakeRequests), WAKE_OUTCOME_ORDER)} | reviews ${formatOrderedMap(reviewTotals, REVIEW_OUTCOME_ORDER)} | auto-fix ${formatOrderedMap(snapshot.metrics.autoFixes, AUTO_FIX_OUTCOME_ORDER)} | merge ${formatOrderedMap(snapshot.metrics.mergeRecovery, MERGE_RECOVERY_OUTCOME_ORDER)}`,
     )
+    lines.push(`github api: ${formatGitHubApiRequestSummary(snapshot.metrics.githubApiRequests)}`)
     lines.push(
       `wake: pending ${snapshot.metrics.pendingWakeRequests ?? 0} | ${formatWakeRequestSummary(snapshot.metrics.wakeRequests)}`,
     )
@@ -560,6 +564,7 @@ export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): strin
   const outcomeLines = snapshot.metrics
     ? [
         `polls: ${formatOrderedMap(snapshot.metrics.polls, POLL_OUTCOME_ORDER)}`,
+        `github-api-requests: ${formatGitHubApiRequestSummary(snapshot.metrics.githubApiRequests)}`,
         ...REVIEW_STAGE_ORDER.map((stage) => `reviews.${stage}: ${formatOrderedMap(snapshot.metrics?.prReviews[stage] ?? {}, REVIEW_OUTCOME_ORDER)}`),
         `auto-fix: ${formatOrderedMap(snapshot.metrics.autoFixes, AUTO_FIX_OUTCOME_ORDER)}`,
         `merge-recovery: ${formatOrderedMap(snapshot.metrics.mergeRecovery, MERGE_RECOVERY_OUTCOME_ORDER)}`,
@@ -785,6 +790,7 @@ function parsePortFromUrl(url: string): number | null {
 export function summarizeDaemonMetrics(metricsText: string): DaemonMetricSummary {
   const summary: DaemonMetricSummary = {
     polls: {},
+    githubApiRequests: {},
     wakeRequests: {},
     prReviews: {},
     autoFixes: {},
@@ -810,6 +816,11 @@ export function summarizeDaemonMetrics(metricsText: string): DaemonMetricSummary
     switch (sample.name) {
       case 'agent_loop_polls_total':
         if (sample.labels.result) summary.polls[sample.labels.result] = sample.value
+        break
+      case 'agent_loop_github_api_requests_total':
+        if (!sample.labels.transport || !sample.labels.mode || !sample.labels.outcome) break
+        summary.githubApiRequests[formatGitHubApiRequestKey(sample.labels.transport, sample.labels.mode)] ??= {}
+        summary.githubApiRequests[formatGitHubApiRequestKey(sample.labels.transport, sample.labels.mode)]![sample.labels.outcome] = sample.value
         break
       case 'agent_loop_wake_requests_total':
         if (!sample.labels.kind || !sample.labels.outcome) break
@@ -1023,6 +1034,9 @@ function buildDoctorWarnings(snapshot: DaemonObservabilitySnapshot): string[] {
   if ((snapshot.metrics?.leaseConflicts ?? 0) > 0) {
     warnings.push(`managed lease conflicts observed: ${snapshot.metrics?.leaseConflicts}`)
   }
+  if (countGitHubApiOutcomes(snapshot.metrics?.githubApiRequests ?? {}, 'rate_limited') > 0) {
+    warnings.push(`github api rate limits observed: ${formatGitHubApiRequestSummary(filterGitHubApiOutcome(snapshot.metrics?.githubApiRequests ?? {}, 'rate_limited'))}`)
+  }
   if (Object.values(snapshot.metrics?.workerIdleTimeouts ?? {}).reduce((sum, value) => sum + value, 0) > 0) {
     warnings.push(`worker idle timeouts observed: ${formatInlineKeyValue(snapshot.metrics?.workerIdleTimeouts ?? {})}`)
   }
@@ -1151,6 +1165,10 @@ function summarizeWakeOutcomes(
   return totals
 }
 
+function formatGitHubApiRequestKey(transport: string, mode: string): string {
+  return `${transport}/${mode}`
+}
+
 function buildEndpointUrl(host: string, port: number, path: string): string {
   return `http://${host}:${port}${path}`
 }
@@ -1234,6 +1252,35 @@ function formatWakeRequestSummary(values: Record<string, Record<string, number>>
     .map((kind) => `${kind}[${formatOrderedMap(values[kind] ?? {}, WAKE_OUTCOME_ORDER)}]`)
 
   return parts.join(', ') || 'none'
+}
+
+function formatGitHubApiRequestSummary(values: Record<string, Record<string, number>>): string {
+  const parts = GITHUB_API_REQUEST_KEY_ORDER
+    .filter((key) => values[key] !== undefined)
+    .map((key) => `${key}[${formatOrderedMap(values[key] ?? {}, GITHUB_API_OUTCOME_ORDER)}]`)
+
+  return parts.join(', ') || 'none'
+}
+
+function countGitHubApiOutcomes(
+  values: Record<string, Record<string, number>>,
+  outcome: string,
+): number {
+  return Object.values(values).reduce((sum, counts) => sum + (counts[outcome] ?? 0), 0)
+}
+
+function filterGitHubApiOutcome(
+  values: Record<string, Record<string, number>>,
+  outcome: string,
+): Record<string, Record<string, number>> {
+  const filtered: Record<string, Record<string, number>> = {}
+
+  for (const [key, counts] of Object.entries(values)) {
+    if ((counts[outcome] ?? 0) <= 0) continue
+    filtered[key] = { [outcome]: counts[outcome] ?? 0 }
+  }
+
+  return filtered
 }
 
 function formatActiveLeaseInlineSummary(details: DaemonHealthPayload['runtime']['activeLeaseDetails']): string {

--- a/docs/agent-loop-event-wake-spec.md
+++ b/docs/agent-loop-event-wake-spec.md
@@ -164,6 +164,8 @@ Recommended behavior:
 
 This design should materially reduce GraphQL pressure because idle discovery moves from periodic full scans to targeted wakeups. It does not remove GraphQL usage completely, because startup recovery, fallback polling, and some coordination flows still need GitHub reads.
 
+This repo now exposes GitHub API request metrics that separate `graphql` vs `rest`, `direct` vs `gh_cli`, plus `success/error/timeout/rate_limited` outcomes, so the effect of wake delivery and slower idle polling can be measured directly.
+
 In practice, this should help with rate limits, but it is not a full replacement for timeout handling, REST fallbacks, and scoped recovery reads.
 
 ## Rollout
@@ -172,7 +174,7 @@ In practice, this should help with rate limits, but it is not a full replacement
 2. Done: add a loopback wake endpoint in the daemon.
 3. Done: add GitHub Actions workflows that route events to self-hosted runners.
 4. Done: reduce idle poll frequency after wake delivery is stable on a machine, while preserving immediate wake-triggered reconcile.
-5. Pending: add end-to-end wake latency, missed-event recovery, and GraphQL consumption measurement.
+5. Pending: add end-to-end wake latency and missed-event recovery measurement on top of the existing GitHub API consumption metrics.
 
 ## Acceptance
 

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -25,6 +25,7 @@ import {
   parseMergePrResponse,
   qualifyGhApiArgs,
   ghApiRaw,
+  setGitHubApiRequestObserver,
   sortClaimableIssuesForScheduling,
   shouldClearIssueAssigneesForStateLabel,
 } from './github-api'
@@ -147,9 +148,15 @@ describe('buildDirectGitHubApiRequest', () => {
 })
 
 describe('ghApiRaw', () => {
-  test('uses direct fetch for PAT-backed paginated REST requests', async () => {
+  test('uses direct fetch for PAT-backed paginated REST requests and emits request observations', async () => {
     const originalFetch = globalThis.fetch
     const seen: string[] = []
+    const observations: Array<{
+      transport: string
+      mode: string
+      outcome: string
+      durationMs: number
+    }> = []
     const config = {
       repo: 'JamesWuHK/digital-employee',
       pat: 'ghp_test',
@@ -186,6 +193,9 @@ describe('ghApiRaw', () => {
     }) as typeof fetch
 
     try {
+      setGitHubApiRequestObserver((observation) => {
+        observations.push(observation)
+      })
       const result = await ghApiRaw(
         ['repos/JamesWuHK/digital-employee/issues/334/comments', '--paginate'],
         config,
@@ -200,7 +210,15 @@ describe('ghApiRaw', () => {
         { id: 11, body: 'page-1', created_at: '2026-04-11T10:00:00.000Z', updated_at: '2026-04-11T10:00:00.000Z' },
         { id: 12, body: 'page-2', created_at: '2026-04-11T10:00:01.000Z', updated_at: '2026-04-11T10:00:01.000Z' },
       ])
+      expect(observations).toHaveLength(1)
+      expect(observations[0]).toMatchObject({
+        transport: 'rest',
+        mode: 'direct',
+        outcome: 'success',
+      })
+      expect((observations[0]?.durationMs ?? 0) >= 0).toBe(true)
     } finally {
+      setGitHubApiRequestObserver(null)
       globalThis.fetch = originalFetch
     }
   })

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -36,6 +36,33 @@ const GH_PROXY_ENV_KEYS = [
   'http_proxy',
 ] as const
 
+export type GitHubApiTransport = 'graphql' | 'rest'
+export type GitHubApiMode = 'direct' | 'gh_cli'
+export type GitHubApiOutcome = 'success' | 'error' | 'timeout' | 'rate_limited'
+
+export interface GitHubApiRequestObservation {
+  transport: GitHubApiTransport
+  mode: GitHubApiMode
+  outcome: GitHubApiOutcome
+  durationMs: number
+}
+
+let githubApiRequestObserver: ((observation: GitHubApiRequestObservation) => void) | null = null
+
+export function setGitHubApiRequestObserver(
+  observer: ((observation: GitHubApiRequestObservation) => void) | null,
+): void {
+  githubApiRequestObserver = observer
+}
+
+function observeGitHubApiRequest(observation: GitHubApiRequestObservation): void {
+  try {
+    githubApiRequestObserver?.(observation)
+  } catch {
+    // Metrics hooks must never break GitHub API callers.
+  }
+}
+
 // ─── gh CLI wrapper ───────────────────────────────────────────────────────────
 
 export function buildGhEnv(config: Pick<AgentConfig, 'pat'>): Record<string, string> {
@@ -221,15 +248,46 @@ export async function ghApiRaw(
   config: AgentConfig,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const qualifiedArgs = qualifyGhApiArgs(args, config)
+  const transport = inferGitHubApiTransportFromArgs(qualifiedArgs)
   if (config.pat) {
     try {
       buildDirectGitHubApiRequest(qualifiedArgs, config)
-      return await runDirectGitHubApi(qualifiedArgs, config)
+      const startedAt = Date.now()
+      const result = await runDirectGitHubApi(qualifiedArgs, config)
+      observeGitHubApiRequest({
+        transport,
+        mode: 'direct',
+        outcome: inferGitHubApiOutcome({
+          transport,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+        }),
+        durationMs: Date.now() - startedAt,
+      })
+      return result
     } catch {
       // Fall back to gh api for argument shapes that direct mode does not support yet.
     }
   }
-  return runBoundedGhCommand(['api', ...qualifiedArgs], config)
+
+  const startedAt = Date.now()
+  const result = await runBoundedGhCommand(['api', ...qualifiedArgs], config)
+  observeGitHubApiRequest({
+    transport,
+    mode: 'gh_cli',
+    outcome: inferGitHubApiOutcome({
+      transport,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+      timedOut: result.timedOut,
+    }),
+    durationMs: Date.now() - startedAt,
+  })
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exitCode: result.exitCode,
+  }
 }
 
 interface DirectGitHubApiRequest {
@@ -607,6 +665,44 @@ export function qualifyGhApiArgs(
 
   const normalizedEndpoint = endpoint.replace(/^\/+/, '')
   return [`repos/${config.repo}/${normalizedEndpoint}`, ...rest]
+}
+
+function inferGitHubApiTransportFromArgs(args: string[]): GitHubApiTransport {
+  return args[0]?.trim() === 'graphql' ? 'graphql' : 'rest'
+}
+
+function inferGitHubApiOutcome(input: {
+  transport: GitHubApiTransport
+  stderr: string
+  exitCode: number
+  timedOut?: boolean
+}): GitHubApiOutcome {
+  if (input.timedOut || input.stderr.toLowerCase().includes('timed out')) {
+    return 'timeout'
+  }
+  if (input.exitCode === 0) {
+    return 'success'
+  }
+  if (isGitHubApiRateLimitErrorMessage(input.transport, input.stderr)) {
+    return 'rate_limited'
+  }
+  return 'error'
+}
+
+function isGitHubApiRateLimitErrorMessage(
+  transport: GitHubApiTransport,
+  message: string,
+): boolean {
+  if (transport === 'graphql') {
+    return isGraphQlRateLimitErrorMessage(message)
+  }
+
+  const normalized = message.toLowerCase()
+  return (
+    normalized.includes('api rate limit')
+    || normalized.includes('secondary rate limit')
+    || normalized.includes('rate limit exceeded')
+  )
 }
 
 function shouldQualifyGhApiEndpoint(endpoint: string): boolean {


### PR DESCRIPTION
## Summary
- add GitHub API request counters and latency histograms for graphql/rest and gh_cli/direct modes
- wire daemon and presence polling into the new observability hooks
- surface GitHub API usage and rate-limit warnings in status/doctor output

## Testing
- bun test packages/agent-shared/src/github-api.test.ts apps/agent-daemon/src/metrics.test.ts apps/agent-daemon/src/status.test.ts apps/agent-daemon/src/presence.test.ts
- bun run typecheck