### PR TITLE
feat(dashboard): summarize upgrade rollout state

### DIFF
--- a/apps/agent-daemon/src/dashboard.test.ts
+++ b/apps/agent-daemon/src/dashboard.test.ts
@@ -249,11 +249,16 @@ describe('dashboard machine aggregation', () => {
     expect(buildDashboardSummary(machines, issues, prs)).toEqual({
       machineCount: 1,
       localRuntimeCount: 1,
+      managedPresenceCount: 0,
       activeLeaseCount: 2,
       readyIssueCount: 1,
       workingIssueCount: 1,
       failedIssueCount: 1,
       openPrCount: 1,
+      upgradePendingMachineCount: 0,
+      upgradeReadyMachineCount: 0,
+      upgradeBlockedMachineCount: 0,
+      upgradeErrorMachineCount: 0,
     })
   })
 
@@ -274,6 +279,65 @@ describe('dashboard machine aggregation', () => {
     expect(remoteMachine?.presence?.status).toBe('idle')
     expect(remoteMachine?.daemonInstanceIds).toEqual(['daemon-remote-1'])
   })
+
+  test('summarizes upgrade rollout state from managed machine presence', () => {
+    const machines = buildDashboardMachineCards(
+      [buildLocalSnapshot()],
+      [],
+      [
+        buildPresence({
+          machineId: 'machine-ready',
+          daemonInstanceId: 'daemon-ready',
+          upgradeStatus: 'upgrade-available',
+          safeToUpgradeNow: true,
+          latestVersion: '0.1.2',
+        }),
+        buildPresence({
+          machineId: 'machine-busy',
+          daemonInstanceId: 'daemon-busy',
+          status: 'busy',
+          effectiveActiveTasks: 2,
+          activeLeaseCount: 1,
+          activeWorktreeCount: 1,
+          upgradeStatus: 'upgrade-available',
+          safeToUpgradeNow: false,
+          latestVersion: '0.1.2',
+        }),
+        buildPresence({
+          machineId: 'machine-error',
+          daemonInstanceId: 'daemon-error',
+          upgradeStatus: 'error',
+          safeToUpgradeNow: false,
+          latestVersion: null,
+        }),
+      ],
+    )
+
+    expect(buildDashboardSummary(machines, [], [])).toEqual({
+      machineCount: 4,
+      localRuntimeCount: 1,
+      managedPresenceCount: 3,
+      activeLeaseCount: 1,
+      readyIssueCount: 0,
+      workingIssueCount: 0,
+      failedIssueCount: 0,
+      openPrCount: 0,
+      upgradePendingMachineCount: 2,
+      upgradeReadyMachineCount: 1,
+      upgradeBlockedMachineCount: 1,
+      upgradeErrorMachineCount: 1,
+    })
+
+    expect(machines.find((machine) => machine.machineId === 'machine-ready')?.warnings).toContain(
+      'agent-loop upgrade available on machine-ready; this machine is idle enough to upgrade now',
+    )
+    expect(machines.find((machine) => machine.machineId === 'machine-busy')?.warnings).toContain(
+      'agent-loop upgrade available on machine-busy; wait for the machine to go idle before restarting',
+    )
+    expect(machines.find((machine) => machine.machineId === 'machine-error')?.warnings).toContain(
+      'agent-loop upgrade check is failing on machine-error; inspect this daemon before relying on auto-upgrade',
+    )
+  })
 })
 
 describe('dashboard localization', () => {
@@ -291,6 +355,8 @@ describe('dashboard localization', () => {
     expect(script).toContain('仪表盘快照加载失败')
     expect(script).toContain('未发现本仓库的本地受管 daemon 运行时。')
     expect(script).toContain('机器数')
+    expect(script).toContain('待升级机器')
+    expect(script).toContain('可立刻升级')
     expect(script).toContain('本地运行时')
     expect(script).toContain('可认领')
     expect(script).toContain('阻塞原因')

--- a/apps/agent-daemon/src/dashboard.ts
+++ b/apps/agent-daemon/src/dashboard.ts
@@ -40,11 +40,16 @@ type DashboardLeaseSource = 'local' | 'github'
 export interface DashboardSummary {
   machineCount: number
   localRuntimeCount: number
+  managedPresenceCount: number
   activeLeaseCount: number
   readyIssueCount: number
   workingIssueCount: number
   failedIssueCount: number
   openPrCount: number
+  upgradePendingMachineCount: number
+  upgradeReadyMachineCount: number
+  upgradeBlockedMachineCount: number
+  upgradeErrorMachineCount: number
 }
 
 export interface DashboardLeaseView {
@@ -341,6 +346,8 @@ export function buildDashboardMachineCards(
         ? 'local'
         : 'github'
 
+    mergeDashboardWarnings(machine, buildPresenceUpgradeWarnings(machine))
+
     if (machine.localRuntimes.length > 1) {
       mergeDashboardWarnings(machine, [
         `multiple local runtimes detected (${machine.localRuntimes.length})`,
@@ -366,22 +373,47 @@ export function buildDashboardSummary(
 ): DashboardSummary {
   const activeLeaseKeys = new Set<string>()
   let localRuntimeCount = 0
+  let managedPresenceCount = 0
+  let upgradePendingMachineCount = 0
+  let upgradeReadyMachineCount = 0
+  let upgradeBlockedMachineCount = 0
+  let upgradeErrorMachineCount = 0
 
   for (const machine of machines) {
     localRuntimeCount += machine.localRuntimes.length
     for (const lease of machine.activeLeases) {
       activeLeaseKeys.add(buildLeaseKey(lease))
     }
+
+    if (machine.presence) {
+      managedPresenceCount += 1
+      if (machine.presence.upgradeStatus === 'upgrade-available') {
+        upgradePendingMachineCount += 1
+        if (machine.presence.safeToUpgradeNow) {
+          upgradeReadyMachineCount += 1
+        } else {
+          upgradeBlockedMachineCount += 1
+        }
+      }
+      if (machine.presence.upgradeStatus === 'error') {
+        upgradeErrorMachineCount += 1
+      }
+    }
   }
 
   return {
     machineCount: machines.length,
     localRuntimeCount,
+    managedPresenceCount,
     activeLeaseCount: activeLeaseKeys.size,
     readyIssueCount: issues.filter((issue) => issue.state === 'ready').length,
     workingIssueCount: issues.filter((issue) => issue.state === 'working').length,
     failedIssueCount: issues.filter((issue) => issue.state === 'failed').length,
     openPrCount: prs.length,
+    upgradePendingMachineCount,
+    upgradeReadyMachineCount,
+    upgradeBlockedMachineCount,
+    upgradeErrorMachineCount,
   }
 }
 
@@ -829,13 +861,6 @@ function mergeDashboardLease(machine: DashboardMachineCard, lease: DashboardLeas
 function mergeDashboardPresence(machine: DashboardMachineCard, presence: DashboardPresenceView): void {
   if (!machine.presence) {
     machine.presence = presence
-    if (presence.upgradeStatus === 'upgrade-available') {
-      mergeDashboardWarnings(machine, [
-        presence.safeToUpgradeNow
-          ? `agent-loop upgrade available on ${presence.machineId}; this machine is idle enough to upgrade now`
-          : `agent-loop upgrade available on ${presence.machineId}; wait for the machine to go idle before restarting`,
-      ])
-    }
     return
   }
 
@@ -844,6 +869,33 @@ function mergeDashboardPresence(machine: DashboardMachineCard, presence: Dashboa
   if (candidateHeartbeat <= currentHeartbeat) {
     machine.presence = presence
   }
+}
+
+function buildPresenceUpgradeWarnings(machine: DashboardMachineCard): string[] {
+  if (!machine.presence) {
+    return []
+  }
+
+  const presence = machine.presence
+  if (presence.upgradeStatus === 'upgrade-available') {
+    return [
+      presence.safeToUpgradeNow
+        ? `agent-loop upgrade available on ${presence.machineId}; this machine is idle enough to upgrade now`
+        : `agent-loop upgrade available on ${presence.machineId}; wait for the machine to go idle before restarting`,
+    ]
+  }
+  if (presence.upgradeStatus === 'error') {
+    return [
+      `agent-loop upgrade check is failing on ${presence.machineId}; inspect this daemon before relying on auto-upgrade`,
+    ]
+  }
+  if (presence.upgradeStatus === 'ahead-of-channel') {
+    return [
+      `agent-loop build on ${presence.machineId} is ahead of the tracked channel; verify this machine is pinned intentionally`,
+    ]
+  }
+
+  return []
 }
 
 function preferLocalLease(
@@ -1648,7 +1700,12 @@ function renderSummary(snapshot) {
   const stats = [
     { label: '机器数', value: snapshot.summary.machineCount, tone: 'accent' },
     { label: '本地运行时', value: snapshot.summary.localRuntimeCount, tone: '' },
+    { label: '受管心跳', value: snapshot.summary.managedPresenceCount, tone: snapshot.summary.managedPresenceCount > 0 ? 'accent' : '' },
     { label: '活跃租约', value: snapshot.summary.activeLeaseCount, tone: 'gold' },
+    { label: '待升级机器', value: snapshot.summary.upgradePendingMachineCount, tone: snapshot.summary.upgradePendingMachineCount > 0 ? 'gold' : '' },
+    { label: '可立刻升级', value: snapshot.summary.upgradeReadyMachineCount, tone: snapshot.summary.upgradeReadyMachineCount > 0 ? 'accent' : '' },
+    { label: '升级被阻塞', value: snapshot.summary.upgradeBlockedMachineCount, tone: snapshot.summary.upgradeBlockedMachineCount > 0 ? 'gold' : '' },
+    { label: '升级检查错误', value: snapshot.summary.upgradeErrorMachineCount, tone: snapshot.summary.upgradeErrorMachineCount > 0 ? 'error' : '' },
     { label: '就绪 Issue', value: snapshot.summary.readyIssueCount, tone: '' },
     { label: '处理中 Issue', value: snapshot.summary.workingIssueCount, tone: 'accent' },
     { label: '失败 Issue', value: snapshot.summary.failedIssueCount, tone: snapshot.summary.failedIssueCount > 0 ? 'gold' : '' },


### PR DESCRIPTION
## Summary
- add dashboard summary counters for managed presences, upgrade-pending machines, upgrade-ready machines, blocked upgrades, and upgrade check errors
- surface per-machine upgrade warnings from shared presence state so rollout blockers are visible immediately
- cover the rollout summary and localized dashboard copy in tests

## Testing
- bun test apps/agent-daemon/src/dashboard.test.ts
- bun run typecheck