### PR TITLE
fix(cli-agent): follow isolated codex base url config

### DIFF
--- a/apps/agent-daemon/src/cli-agent.test.ts
+++ b/apps/agent-daemon/src/cli-agent.test.ts
@@ -157,6 +157,59 @@ describe('cli-agent', () => {
     }
   })
 
+  test('runs Codex with isolated config base URL and without deprecated base-url env vars', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'cli-agent-codex-env-test-'))
+    const scriptPath = join(tempDir, 'fake-codex.sh')
+    const worktreePath = join(tempDir, 'worktree')
+    const envDumpPath = join(worktreePath, 'codex-env.txt')
+
+    try {
+      mkdirSync(worktreePath, { recursive: true })
+      writeFileSync(
+        scriptPath,
+        [
+          '#!/bin/sh',
+          'cat >/dev/null',
+          'for key in OPENAI_BASE_URL OPENAI_API_BASE OPENAI_API_URL OPENAI_BASE; do',
+          '  eval "value=\\${' + '$key-__UNSET__}"',
+          '  printf \'%s=%s\\n\' "$key" "$value"',
+          `done > ${JSON.stringify(envDumpPath)}`,
+          "printf 'ok\\n'",
+          '',
+        ].join('\n'),
+        'utf-8',
+      )
+      chmodSync(scriptPath, 0o755)
+
+      const result = await runConfiguredAgent({
+        prompt: 'noop',
+        worktreePath,
+        timeoutMs: 5_000,
+        config: {
+          ...baseConfig,
+          agent: {
+            ...baseConfig.agent,
+            primary: 'codex',
+            fallback: null,
+            codexPath: scriptPath,
+            codexBaseUrl: 'http://127.0.0.1:18777/v1',
+          },
+        },
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.usedAgent).toBe('codex')
+      expect(readFileSync(envDumpPath, 'utf-8')).toBe(
+        'OPENAI_BASE_URL=__UNSET__\n'
+        + 'OPENAI_API_BASE=__UNSET__\n'
+        + 'OPENAI_API_URL=__UNSET__\n'
+        + 'OPENAI_BASE=__UNSET__\n',
+      )
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
   test('marks hung agent runs as idle_timeout when no output or git progress occurs', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'cli-agent-hung-test-'))
     const scriptPath = join(tempDir, 'fake-claude.sh')

--- a/apps/agent-daemon/src/cli-agent.ts
+++ b/apps/agent-daemon/src/cli-agent.ts
@@ -629,6 +629,14 @@ function buildRuntimeEnv(
 
   const { homeDir, codexHomeDir } = createIsolatedCodexHome(tempDir, cleanEnv)
 
+  // Codex already reads the provider base URL from the isolated config.toml.
+  // Drop deprecated base-url env vars so child runs avoid warning noise and
+  // don't accidentally override the isolated config.
+  delete cleanEnv.OPENAI_BASE_URL
+  delete cleanEnv.OPENAI_API_BASE
+  delete cleanEnv.OPENAI_API_URL
+  delete cleanEnv.OPENAI_BASE
+
   return {
     ...cleanEnv,
     HOME: homeDir,


### PR DESCRIPTION
## Summary\n- keep Codex provider routing driven by the isolated config.toml instead of deprecated base-url env vars\n- drop deprecated OpenAI base-url env vars before spawning Codex child runs\n- add a regression test proving the child process no longer inherits those env vars\n\n## Why\nThis keeps agent-loop generic across machines: the framework only follows local config, and provider switching can stay in cc-switch rather than being hardcoded in repo logic.\n\n## Testing\n- bun test apps/agent-daemon/src/cli-agent.test.ts\n- bun run --cwd apps/agent-daemon typecheck