### PR TITLE
feat(upgrade): surface auto-apply rollout reasons

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -547,6 +547,46 @@ describe('agent-loop upgrade coordination', () => {
     expect(autoUpgradeAttempts).toBe(1)
     expect(scheduledPolls).toBe(0)
   })
+
+  test('logs a fresh upgrade notice when the announced target changes inside the reminder cooldown', () => {
+    const warnings: string[] = []
+    const daemon = createTestDaemon({
+      upgrade: {
+        enabled: true,
+        repo: 'JamesWuHK/agent-loop',
+        channel: 'master',
+        checkIntervalMs: 60_000,
+        reminderIntervalMs: 3_600_000,
+        autoApply: true,
+      },
+    }) as any
+
+    daemon.logger = {
+      log() {},
+      warn(message: string) {
+        warnings.push(message)
+      },
+      error() {},
+    }
+    daemon.lastUpgradeReminderAt = Date.now()
+    daemon.lastUpgradeReminderTargetKey = 'master:0.1.1:1111111111111111111111111111111111111111'
+
+    daemon.maybeLogAgentLoopUpgradeNotice({
+      enabled: true,
+      repo: 'JamesWuHK/agent-loop',
+      channel: 'master',
+      checkedAt: '2026-04-11T12:00:00.000Z',
+      status: 'upgrade-available',
+      latestVersion: '0.1.2',
+      latestRevision: '2222222222222222222222222222222222222222',
+      latestCommitAt: '2026-04-11T11:59:50.000Z',
+      safeToUpgradeNow: false,
+      message: 'channel master is newer: local v0.1.0, latest v0.1.2',
+    })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('auto-apply is enabled; this daemon will restart into the latest build once it goes idle')
+  })
 })
 
 describe('daemon merge recovery helpers', () => {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -287,6 +287,7 @@ export class AgentDaemon {
   private agentLoopUpgrade: AgentLoopUpgradeMetadata
   private upgradeCheckPromise: Promise<void> | null = null
   private lastUpgradeReminderAt: number | null = null
+  private lastUpgradeReminderTargetKey: string | null = null
   private autoUpgradePromise: Promise<boolean> | null = null
   private lastAutoUpgradeAttemptAt: number | null = null
   private lastAutoUpgradeAttemptTarget: string | null = null
@@ -3484,6 +3485,7 @@ export class AgentDaemon {
   private readPresenceRuntimeState(): ManagedDaemonPresenceRuntimeState {
     const runtime = this.buildRuntimeStatus()
     const upgrade = this.buildUpgradeStatus()
+    const policy = resolveAgentLoopUpgradePolicy(this.config, this.agentLoopBuild)
     return {
       activeLeaseCount: runtime.activeLeaseCount,
       activeWorktreeCount: this.activeWorktrees.size,
@@ -3491,10 +3493,12 @@ export class AgentDaemon {
       agentLoopVersion: this.agentLoopBuild.version,
       agentLoopRevision: this.agentLoopBuild.revision,
       upgradeStatus: upgrade.status,
+      upgradeAutoApplyEnabled: policy.autoApply,
       safeToUpgradeNow: upgrade.safeToUpgradeNow,
       latestVersion: upgrade.latestVersion,
       latestRevision: upgrade.latestRevision,
       upgradeCheckedAt: upgrade.checkedAt,
+      upgradeMessage: upgrade.message,
     }
   }
 
@@ -3815,20 +3819,37 @@ export class AgentDaemon {
     }
 
     const policy = resolveAgentLoopUpgradePolicy(this.config, this.agentLoopBuild)
+    const reminderTargetKey = this.getUpgradeAnnouncementKey(upgrade)
     const now = Date.now()
     if (
-      this.lastUpgradeReminderAt !== null
+      reminderTargetKey !== null
+      && reminderTargetKey === this.lastUpgradeReminderTargetKey
+      && this.lastUpgradeReminderAt !== null
       && this.lastUpgradeReminderAt + policy.reminderIntervalMs > now
     ) {
       return
     }
 
     this.lastUpgradeReminderAt = now
+    this.lastUpgradeReminderTargetKey = reminderTargetKey
     const local = `v${this.agentLoopBuild.version}@${abbreviateRevision(this.agentLoopBuild.revision)}`
     const latest = `v${upgrade.latestVersion ?? 'unknown'}@${abbreviateRevision(upgrade.latestRevision)}`
     this.logger.warn(
-      `[daemon] agent-loop upgrade available on ${upgrade.channel ?? 'default'}: ${local} -> ${latest}; ${upgrade.safeToUpgradeNow ? 'safe to upgrade now' : 'defer upgrade until this daemon is idle'}`,
+      `[daemon] agent-loop upgrade available on ${upgrade.channel ?? 'default'}: ${local} -> ${latest}; ${this.describeAgentLoopUpgradeNoticeAction(upgrade, policy.autoApply)}`,
     )
+  }
+
+  private describeAgentLoopUpgradeNoticeAction(
+    upgrade: Pick<AgentLoopUpgradeMetadata, 'safeToUpgradeNow'>,
+    autoApplyEnabled: boolean,
+  ): string {
+    if (!autoApplyEnabled) {
+      return 'auto-apply is disabled on this machine; manual restart is required'
+    }
+    if (upgrade.safeToUpgradeNow) {
+      return 'auto-apply is enabled and this daemon can restart into the latest build now'
+    }
+    return 'auto-apply is enabled; this daemon will restart into the latest build once it goes idle'
   }
 
   private syncRuntimeMetrics(): void {

--- a/apps/agent-daemon/src/dashboard.test.ts
+++ b/apps/agent-daemon/src/dashboard.test.ts
@@ -95,10 +95,12 @@ function buildPresence(overrides: Partial<DashboardPresenceView> = {}): Dashboar
     agentLoopVersion: '0.1.0',
     agentLoopRevision: 'abcdef1234567890',
     upgradeStatus: 'up-to-date',
+    upgradeAutoApplyEnabled: true,
     safeToUpgradeNow: true,
     latestVersion: '0.1.0',
     latestRevision: 'abcdef1234567890',
     upgradeCheckedAt: '2026-04-05T09:10:00.000Z',
+    upgradeMessage: 'local and latest versions match',
     source: 'github',
     ...overrides,
   }
@@ -258,6 +260,7 @@ describe('dashboard machine aggregation', () => {
       upgradePendingMachineCount: 0,
       upgradeReadyMachineCount: 0,
       upgradeBlockedMachineCount: 0,
+      upgradeManualMachineCount: 0,
       upgradeErrorMachineCount: 0,
     })
   })
@@ -304,27 +307,38 @@ describe('dashboard machine aggregation', () => {
           latestVersion: '0.1.2',
         }),
         buildPresence({
+          machineId: 'machine-manual',
+          daemonInstanceId: 'daemon-manual',
+          upgradeStatus: 'upgrade-available',
+          upgradeAutoApplyEnabled: false,
+          safeToUpgradeNow: true,
+          latestVersion: '0.1.2',
+          upgradeMessage: 'auto-apply disabled on this machine',
+        }),
+        buildPresence({
           machineId: 'machine-error',
           daemonInstanceId: 'daemon-error',
           upgradeStatus: 'error',
           safeToUpgradeNow: false,
           latestVersion: null,
+          upgradeMessage: 'agent-loop upgrade repo could not be resolved',
         }),
       ],
     )
 
     expect(buildDashboardSummary(machines, [], [])).toEqual({
-      machineCount: 4,
+      machineCount: 5,
       localRuntimeCount: 1,
-      managedPresenceCount: 3,
+      managedPresenceCount: 4,
       activeLeaseCount: 1,
       readyIssueCount: 0,
       workingIssueCount: 0,
       failedIssueCount: 0,
       openPrCount: 0,
-      upgradePendingMachineCount: 2,
+      upgradePendingMachineCount: 3,
       upgradeReadyMachineCount: 1,
       upgradeBlockedMachineCount: 1,
+      upgradeManualMachineCount: 1,
       upgradeErrorMachineCount: 1,
     })
 
@@ -334,8 +348,11 @@ describe('dashboard machine aggregation', () => {
     expect(machines.find((machine) => machine.machineId === 'machine-busy')?.warnings).toContain(
       'agent-loop upgrade available on machine-busy; wait for the machine to go idle before restarting',
     )
+    expect(machines.find((machine) => machine.machineId === 'machine-manual')?.warnings).toContain(
+      'agent-loop upgrade available on machine-manual, but auto-apply is disabled on this machine; manual restart is required',
+    )
     expect(machines.find((machine) => machine.machineId === 'machine-error')?.warnings).toContain(
-      'agent-loop upgrade check is failing on machine-error; inspect this daemon before relying on auto-upgrade',
+      'agent-loop upgrade check is failing on machine-error: agent-loop upgrade repo could not be resolved; inspect this daemon before relying on auto-upgrade',
     )
   })
 })
@@ -357,6 +374,7 @@ describe('dashboard localization', () => {
     expect(script).toContain('机器数')
     expect(script).toContain('待升级机器')
     expect(script).toContain('可立刻升级')
+    expect(script).toContain('手动升级机器')
     expect(script).toContain('本地运行时')
     expect(script).toContain('可认领')
     expect(script).toContain('阻塞原因')

--- a/apps/agent-daemon/src/dashboard.ts
+++ b/apps/agent-daemon/src/dashboard.ts
@@ -49,6 +49,7 @@ export interface DashboardSummary {
   upgradePendingMachineCount: number
   upgradeReadyMachineCount: number
   upgradeBlockedMachineCount: number
+  upgradeManualMachineCount: number
   upgradeErrorMachineCount: number
 }
 
@@ -124,10 +125,12 @@ export interface DashboardPresenceView {
   agentLoopVersion: string
   agentLoopRevision: string | null
   upgradeStatus: AgentLoopUpgradeStatusKind
+  upgradeAutoApplyEnabled: boolean
   safeToUpgradeNow: boolean
   latestVersion: string | null
   latestRevision: string | null
   upgradeCheckedAt: string | null
+  upgradeMessage: string | null
   source: 'github'
 }
 
@@ -377,6 +380,7 @@ export function buildDashboardSummary(
   let upgradePendingMachineCount = 0
   let upgradeReadyMachineCount = 0
   let upgradeBlockedMachineCount = 0
+  let upgradeManualMachineCount = 0
   let upgradeErrorMachineCount = 0
 
   for (const machine of machines) {
@@ -389,7 +393,9 @@ export function buildDashboardSummary(
       managedPresenceCount += 1
       if (machine.presence.upgradeStatus === 'upgrade-available') {
         upgradePendingMachineCount += 1
-        if (machine.presence.safeToUpgradeNow) {
+        if (!machine.presence.upgradeAutoApplyEnabled) {
+          upgradeManualMachineCount += 1
+        } else if (machine.presence.safeToUpgradeNow) {
           upgradeReadyMachineCount += 1
         } else {
           upgradeBlockedMachineCount += 1
@@ -413,6 +419,7 @@ export function buildDashboardSummary(
     upgradePendingMachineCount,
     upgradeReadyMachineCount,
     upgradeBlockedMachineCount,
+    upgradeManualMachineCount,
     upgradeErrorMachineCount,
   }
 }
@@ -879,14 +886,16 @@ function buildPresenceUpgradeWarnings(machine: DashboardMachineCard): string[] {
   const presence = machine.presence
   if (presence.upgradeStatus === 'upgrade-available') {
     return [
-      presence.safeToUpgradeNow
-        ? `agent-loop upgrade available on ${presence.machineId}; this machine is idle enough to upgrade now`
-        : `agent-loop upgrade available on ${presence.machineId}; wait for the machine to go idle before restarting`,
+      !presence.upgradeAutoApplyEnabled
+        ? `agent-loop upgrade available on ${presence.machineId}, but auto-apply is disabled on this machine; manual restart is required`
+        : presence.safeToUpgradeNow
+          ? `agent-loop upgrade available on ${presence.machineId}; this machine is idle enough to upgrade now`
+          : `agent-loop upgrade available on ${presence.machineId}; wait for the machine to go idle before restarting`,
     ]
   }
   if (presence.upgradeStatus === 'error') {
     return [
-      `agent-loop upgrade check is failing on ${presence.machineId}; inspect this daemon before relying on auto-upgrade`,
+      `agent-loop upgrade check is failing on ${presence.machineId}${presence.upgradeMessage ? `: ${presence.upgradeMessage}` : ''}; inspect this daemon before relying on auto-upgrade`,
     ]
   }
   if (presence.upgradeStatus === 'ahead-of-channel') {
@@ -1032,10 +1041,12 @@ function buildDashboardPresenceView(comment: ManagedDaemonPresenceComment): Dash
     agentLoopVersion: comment.presence.agentLoopVersion,
     agentLoopRevision: comment.presence.agentLoopRevision,
     upgradeStatus: comment.presence.upgradeStatus,
+    upgradeAutoApplyEnabled: comment.presence.upgradeAutoApplyEnabled !== false,
     safeToUpgradeNow: comment.presence.safeToUpgradeNow,
     latestVersion: comment.presence.latestVersion,
     latestRevision: comment.presence.latestRevision,
     upgradeCheckedAt: comment.presence.upgradeCheckedAt,
+    upgradeMessage: comment.presence.upgradeMessage ?? null,
     source: 'github',
   }
 }
@@ -1705,6 +1716,7 @@ function renderSummary(snapshot) {
     { label: '待升级机器', value: snapshot.summary.upgradePendingMachineCount, tone: snapshot.summary.upgradePendingMachineCount > 0 ? 'gold' : '' },
     { label: '可立刻升级', value: snapshot.summary.upgradeReadyMachineCount, tone: snapshot.summary.upgradeReadyMachineCount > 0 ? 'accent' : '' },
     { label: '升级被阻塞', value: snapshot.summary.upgradeBlockedMachineCount, tone: snapshot.summary.upgradeBlockedMachineCount > 0 ? 'gold' : '' },
+    { label: '手动升级机器', value: snapshot.summary.upgradeManualMachineCount, tone: snapshot.summary.upgradeManualMachineCount > 0 ? 'gold' : '' },
     { label: '升级检查错误', value: snapshot.summary.upgradeErrorMachineCount, tone: snapshot.summary.upgradeErrorMachineCount > 0 ? 'error' : '' },
     { label: '就绪 Issue', value: snapshot.summary.readyIssueCount, tone: '' },
     { label: '处理中 Issue', value: snapshot.summary.workingIssueCount, tone: 'accent' },
@@ -1906,7 +1918,9 @@ function renderPresenceItem(presence) {
     presence.expiresInSeconds === null ? null : 'TTL ' + presence.expiresInSeconds + ' 秒',
   ].filter(Boolean).join(' | ');
   const upgradeHint = presence.upgradeStatus === 'upgrade-available'
-    ? (presence.safeToUpgradeNow ? '可安全升级' : '待空闲后升级')
+    ? (!presence.upgradeAutoApplyEnabled
+      ? '自动升级已关闭'
+      : (presence.safeToUpgradeNow ? '可安全升级' : '待空闲后升级'))
     : null;
 
   return [
@@ -1917,12 +1931,14 @@ function renderPresenceItem(presence) {
     renderChip(shortDaemonId(presence.daemonInstanceId), ''),
     renderChip('v' + presence.agentLoopVersion, ''),
     renderChip(presence.upgradeStatus, presence.upgradeStatus === 'upgrade-available' ? 'danger' : ''),
+    renderChip(presence.upgradeAutoApplyEnabled ? '自动升级开' : '自动升级关', presence.upgradeAutoApplyEnabled ? 'accent' : 'gold'),
     renderChip('工作树 ' + presence.activeWorktreeCount, ''),
     renderChip('租约 ' + presence.activeLeaseCount, ''),
     '</div>',
     '<div class="muted" style="margin-top:8px">启动于 ' + escapeHtml(formatTimestamp(presence.startedAt)) + '</div>',
     '<div class="muted" style="margin-top:6px">revision ' + escapeHtml(shortDaemonId(presence.agentLoopRevision || 'unknown')) + (presence.latestVersion ? ' | latest v' + escapeHtml(String(presence.latestVersion)) : '') + '</div>',
     upgradeHint ? '<div class="muted" style="margin-top:6px">' + escapeHtml(upgradeHint) + '</div>' : '',
+    presence.upgradeMessage ? '<div class="muted" style="margin-top:6px">' + escapeHtml(presence.upgradeMessage) + '</div>' : '',
     timing ? '<div class="muted" style="margin-top:6px">' + escapeHtml(timing) + '</div>' : '',
     '</div>',
   ].join('');

--- a/apps/agent-daemon/src/presence.test.ts
+++ b/apps/agent-daemon/src/presence.test.ts
@@ -73,10 +73,12 @@ function buildPresence(overrides: Partial<ManagedDaemonPresence> = {}): ManagedD
     agentLoopVersion: '0.1.0',
     agentLoopRevision: 'abcdef1234567890',
     upgradeStatus: 'up-to-date',
+    upgradeAutoApplyEnabled: true,
     safeToUpgradeNow: true,
     latestVersion: '0.1.0',
     latestRevision: 'abcdef1234567890',
     upgradeCheckedAt: '2026-04-05T08:00:20.000Z',
+    upgradeMessage: 'local and latest versions match',
     ...overrides,
   }
 }
@@ -264,10 +266,12 @@ describe('managed daemon presence publisher', () => {
       agentLoopVersion: '0.1.0',
       agentLoopRevision: 'abcdef1234567890',
       upgradeStatus: 'up-to-date',
+      upgradeAutoApplyEnabled: true,
       safeToUpgradeNow: true,
       latestVersion: '0.1.0',
       latestRevision: 'abcdef1234567890',
       upgradeCheckedAt: '2026-04-05T08:00:20.000Z',
+      upgradeMessage: 'local and latest versions match',
     }
 
     const publisher = new ManagedDaemonPresencePublisher({
@@ -287,16 +291,20 @@ describe('managed daemon presence publisher', () => {
     runtime.activeWorktreeCount = 1
     runtime.effectiveActiveTasks = 1
     runtime.upgradeStatus = 'upgrade-available'
+    runtime.upgradeAutoApplyEnabled = false
     runtime.safeToUpgradeNow = false
     runtime.latestVersion = '0.1.1'
     runtime.latestRevision = 'fedcba9876543210'
+    runtime.upgradeMessage = 'channel master is newer: local v0.1.0, latest v0.1.1'
 
     await publisher.flushHeartbeat()
     expect(comments).toHaveLength(1)
     expect(comments[0]?.body).toContain('"status":"busy"')
     expect(comments[0]?.body).toContain('"activeLeaseCount":1')
     expect(comments[0]?.body).toContain('"upgradeStatus":"upgrade-available"')
+    expect(comments[0]?.body).toContain('"upgradeAutoApplyEnabled":false')
     expect(comments[0]?.body).toContain('"safeToUpgradeNow":false')
+    expect(comments[0]?.body).toContain('"upgradeMessage":"channel master is newer: local v0.1.0, latest v0.1.1"')
 
     await publisher.stop()
     expect(comments[0]?.body).toContain('"status":"stopped"')

--- a/apps/agent-daemon/src/presence.ts
+++ b/apps/agent-daemon/src/presence.ts
@@ -34,10 +34,12 @@ export interface ManagedDaemonPresence {
   agentLoopVersion: string
   agentLoopRevision: string | null
   upgradeStatus: AgentLoopUpgradeStatusKind
+  upgradeAutoApplyEnabled: boolean
   safeToUpgradeNow: boolean
   latestVersion: string | null
   latestRevision: string | null
   upgradeCheckedAt: string | null
+  upgradeMessage: string | null
 }
 
 export interface ManagedDaemonPresenceComment extends IssueComment {
@@ -51,10 +53,12 @@ export interface ManagedDaemonPresenceRuntimeState {
   agentLoopVersion: string
   agentLoopRevision: string | null
   upgradeStatus: AgentLoopUpgradeStatusKind
+  upgradeAutoApplyEnabled: boolean
   safeToUpgradeNow: boolean
   latestVersion: string | null
   latestRevision: string | null
   upgradeCheckedAt: string | null
+  upgradeMessage: string | null
 }
 
 export interface ManagedDaemonUpgradeAnnouncement {
@@ -319,9 +323,11 @@ export function buildManagedDaemonPresenceComment(presence: ManagedDaemonPresenc
 - Effective tasks: ${presence.effectiveActiveTasks}
 - Agent Loop: v${presence.agentLoopVersion} (${presence.agentLoopRevision ?? 'unknown'})
 - Upgrade status: ${presence.upgradeStatus}
+- Auto-apply enabled: ${presence.upgradeAutoApplyEnabled ? 'yes' : 'no'}
 - Safe to upgrade now: ${presence.safeToUpgradeNow ? 'yes' : 'no'}
 - Latest known version: ${presence.latestVersion ?? 'unknown'}
-- Latest known revision: ${presence.latestRevision ?? 'unknown'}`
+- Latest known revision: ${presence.latestRevision ?? 'unknown'}
+- Upgrade message: ${presence.upgradeMessage ?? 'none'}`
 }
 
 export function buildManagedDaemonUpgradeAnnouncementComment(
@@ -374,6 +380,7 @@ export function extractManagedDaemonPresenceComment(body: string): ManagedDaemon
       || parsed.upgradeStatus === 'error'
       ? parsed.upgradeStatus
       : 'unknown'
+    const upgradeAutoApplyEnabled = parsed.upgradeAutoApplyEnabled !== false
     const safeToUpgradeNow = parsed.safeToUpgradeNow === true
     const latestVersion = typeof parsed.latestVersion === 'string' && parsed.latestVersion.trim().length > 0
       ? parsed.latestVersion
@@ -383,6 +390,9 @@ export function extractManagedDaemonPresenceComment(body: string): ManagedDaemon
       : null
     const upgradeCheckedAt = typeof parsed.upgradeCheckedAt === 'string' && parsed.upgradeCheckedAt.trim().length > 0
       ? parsed.upgradeCheckedAt
+      : null
+    const upgradeMessage = typeof parsed.upgradeMessage === 'string' && parsed.upgradeMessage.trim().length > 0
+      ? parsed.upgradeMessage
       : null
 
     return {
@@ -401,10 +411,12 @@ export function extractManagedDaemonPresenceComment(body: string): ManagedDaemon
       agentLoopVersion,
       agentLoopRevision,
       upgradeStatus,
+      upgradeAutoApplyEnabled,
       safeToUpgradeNow,
       latestVersion,
       latestRevision,
       upgradeCheckedAt,
+      upgradeMessage,
     }
   } catch {
     return null
@@ -755,10 +767,12 @@ export class ManagedDaemonPresencePublisher {
       agentLoopVersion: runtime.agentLoopVersion,
       agentLoopRevision: runtime.agentLoopRevision,
       upgradeStatus: runtime.upgradeStatus,
+      upgradeAutoApplyEnabled: runtime.upgradeAutoApplyEnabled,
       safeToUpgradeNow: runtime.safeToUpgradeNow,
       latestVersion: runtime.latestVersion,
       latestRevision: runtime.latestRevision,
       upgradeCheckedAt: runtime.upgradeCheckedAt,
+      upgradeMessage: runtime.upgradeMessage,
     }
   }
 


### PR DESCRIPTION
## Summary
- make each daemon log a fresh upgrade notice whenever the announced agent-loop target changes, even inside the normal reminder cooldown
- publish auto-apply state and upgrade message through managed presence heartbeats so all machines can see whether they will auto-upgrade or why they are blocked
- extend the dashboard rollout summary and machine warnings to distinguish auto-upgrade-ready, blocked, manual-only, and upgrade-check-error machines

## Testing
- bun test apps/agent-daemon/src/presence.test.ts apps/agent-daemon/src/dashboard.test.ts apps/agent-daemon/src/daemon.test.ts
- bun run typecheck