### PR TITLE
feat(upgrade): persist auto-upgrade runtime state

### DIFF
--- a/apps/agent-daemon/src/auto-upgrade-state.test.ts
+++ b/apps/agent-daemon/src/auto-upgrade-state.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createInitialAutoUpgradeRuntimeState,
+  readAutoUpgradeRuntimeState,
+  recordAutoUpgradeAttemptCompleted,
+  recordAutoUpgradeAttemptStarted,
+  resolveAutoUpgradeStatePath,
+  writeAutoUpgradeRuntimeState,
+} from './auto-upgrade-state'
+
+describe('auto-upgrade state helpers', () => {
+  test('derives a stable sidecar path from the managed runtime record path', () => {
+    expect(resolveAutoUpgradeStatePath('/tmp/daemon.json')).toBe('/tmp/daemon.auto-upgrade.json')
+    expect(resolveAutoUpgradeStatePath('/tmp/daemon')).toBe('/tmp/daemon.auto-upgrade.json')
+    expect(resolveAutoUpgradeStatePath(null)).toBeNull()
+  })
+
+  test('records attempt lifecycle and persists it on disk', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-loop-auto-upgrade-state-'))
+    const path = join(dir, 'daemon.auto-upgrade.json')
+
+    let state = createInitialAutoUpgradeRuntimeState()
+    state = recordAutoUpgradeAttemptStarted(state, {
+      attemptedAt: '2026-04-11T12:00:00.000Z',
+      targetVersion: '0.1.2',
+      targetRevision: '2222222222222222222222222222222222222222',
+    })
+    state = recordAutoUpgradeAttemptCompleted(state, {
+      outcome: 'succeeded',
+      completedAt: '2026-04-11T12:00:05.000Z',
+      targetVersion: '0.1.2',
+      targetRevision: '2222222222222222222222222222222222222222',
+    })
+    writeAutoUpgradeRuntimeState(path, state)
+
+    expect(existsSync(path)).toBe(true)
+    expect(readFileSync(path, 'utf-8')).toContain('"successCount": 1')
+    expect(readAutoUpgradeRuntimeState(path)).toEqual({
+      attemptCount: 1,
+      successCount: 1,
+      failureCount: 0,
+      noChangeCount: 0,
+      lastAttemptAt: '2026-04-11T12:00:00.000Z',
+      lastSuccessAt: '2026-04-11T12:00:05.000Z',
+      lastOutcome: 'succeeded',
+      lastTargetVersion: '0.1.2',
+      lastTargetRevision: '2222222222222222222222222222222222222222',
+      lastError: null,
+    })
+  })
+
+  test('tolerates missing or malformed persisted state files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-loop-auto-upgrade-state-invalid-'))
+    const missingPath = join(dir, 'missing.auto-upgrade.json')
+    const malformedPath = join(dir, 'malformed.auto-upgrade.json')
+
+    writeAutoUpgradeRuntimeState(malformedPath, {
+      ...createInitialAutoUpgradeRuntimeState(),
+      attemptCount: 3,
+    })
+
+    expect(readAutoUpgradeRuntimeState(missingPath)).toEqual(createInitialAutoUpgradeRuntimeState())
+
+    writeFileSync(malformedPath, '{not-json', 'utf-8')
+    expect(readAutoUpgradeRuntimeState(malformedPath)).toEqual(createInitialAutoUpgradeRuntimeState())
+  })
+
+  test('tracks failed and no-change outcomes separately', () => {
+    let state = createInitialAutoUpgradeRuntimeState()
+    state = recordAutoUpgradeAttemptStarted(state, {
+      attemptedAt: '2026-04-11T12:10:00.000Z',
+      targetVersion: '0.1.2',
+      targetRevision: '2222222222222222222222222222222222222222',
+    })
+    state = recordAutoUpgradeAttemptCompleted(state, {
+      outcome: 'failed',
+      completedAt: '2026-04-11T12:10:02.000Z',
+      targetVersion: '0.1.2',
+      targetRevision: '2222222222222222222222222222222222222222',
+      error: 'git pull failed',
+    })
+    state = recordAutoUpgradeAttemptStarted(state, {
+      attemptedAt: '2026-04-11T12:11:00.000Z',
+      targetVersion: '0.1.2',
+      targetRevision: '2222222222222222222222222222222222222222',
+    })
+    state = recordAutoUpgradeAttemptCompleted(state, {
+      outcome: 'no_change',
+      completedAt: '2026-04-11T12:11:01.000Z',
+      targetVersion: '0.1.2',
+      targetRevision: '2222222222222222222222222222222222222222',
+    })
+
+    expect(state).toMatchObject({
+      attemptCount: 2,
+      failureCount: 1,
+      noChangeCount: 1,
+      lastOutcome: 'no_change',
+      lastError: null,
+    })
+  })
+})

--- a/apps/agent-daemon/src/auto-upgrade-state.ts
+++ b/apps/agent-daemon/src/auto-upgrade-state.ts
@@ -1,0 +1,156 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import type {
+  AgentLoopAutoUpgradeOutcome,
+  AgentLoopAutoUpgradeRuntimeState,
+} from '@agent/shared'
+
+interface AutoUpgradeStateRecord {
+  attemptCount?: unknown
+  successCount?: unknown
+  failureCount?: unknown
+  noChangeCount?: unknown
+  lastAttemptAt?: unknown
+  lastSuccessAt?: unknown
+  lastOutcome?: unknown
+  lastTargetVersion?: unknown
+  lastTargetRevision?: unknown
+  lastError?: unknown
+}
+
+export function createInitialAutoUpgradeRuntimeState(): AgentLoopAutoUpgradeRuntimeState {
+  return {
+    attemptCount: 0,
+    successCount: 0,
+    failureCount: 0,
+    noChangeCount: 0,
+    lastAttemptAt: null,
+    lastSuccessAt: null,
+    lastOutcome: null,
+    lastTargetVersion: null,
+    lastTargetRevision: null,
+    lastError: null,
+  }
+}
+
+export function resolveAutoUpgradeStatePath(runtimeRecordPath: string | null): string | null {
+  if (!runtimeRecordPath || runtimeRecordPath.trim().length === 0) {
+    return null
+  }
+
+  return runtimeRecordPath.endsWith('.json')
+    ? `${runtimeRecordPath.slice(0, -'.json'.length)}.auto-upgrade.json`
+    : `${runtimeRecordPath}.auto-upgrade.json`
+}
+
+export function readAutoUpgradeRuntimeState(
+  path: string | null,
+): AgentLoopAutoUpgradeRuntimeState {
+  if (!path || !existsSync(path)) {
+    return createInitialAutoUpgradeRuntimeState()
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as AutoUpgradeStateRecord
+    return {
+      attemptCount: normalizeNonNegativeInteger(parsed.attemptCount),
+      successCount: normalizeNonNegativeInteger(parsed.successCount),
+      failureCount: normalizeNonNegativeInteger(parsed.failureCount),
+      noChangeCount: normalizeNonNegativeInteger(parsed.noChangeCount),
+      lastAttemptAt: normalizeOptionalString(parsed.lastAttemptAt),
+      lastSuccessAt: normalizeOptionalString(parsed.lastSuccessAt),
+      lastOutcome: normalizeOutcome(parsed.lastOutcome),
+      lastTargetVersion: normalizeOptionalString(parsed.lastTargetVersion),
+      lastTargetRevision: normalizeOptionalString(parsed.lastTargetRevision),
+      lastError: normalizeOptionalString(parsed.lastError),
+    }
+  } catch {
+    return createInitialAutoUpgradeRuntimeState()
+  }
+}
+
+export function writeAutoUpgradeRuntimeState(
+  path: string | null,
+  state: AgentLoopAutoUpgradeRuntimeState,
+): AgentLoopAutoUpgradeRuntimeState {
+  if (!path) {
+    return state
+  }
+
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(state, null, 2) + '\n', 'utf-8')
+  return state
+}
+
+export function recordAutoUpgradeAttemptStarted(
+  state: AgentLoopAutoUpgradeRuntimeState,
+  input: {
+    attemptedAt: string
+    targetVersion: string | null
+    targetRevision: string | null
+  },
+): AgentLoopAutoUpgradeRuntimeState {
+  return {
+    ...state,
+    attemptCount: state.attemptCount + 1,
+    lastAttemptAt: input.attemptedAt,
+    lastOutcome: 'attempting',
+    lastTargetVersion: normalizeOptionalString(input.targetVersion),
+    lastTargetRevision: normalizeOptionalString(input.targetRevision),
+    lastError: null,
+  }
+}
+
+export function recordAutoUpgradeAttemptCompleted(
+  state: AgentLoopAutoUpgradeRuntimeState,
+  input: {
+    outcome: Exclude<AgentLoopAutoUpgradeOutcome, 'attempting'>
+    completedAt: string
+    targetVersion: string | null
+    targetRevision: string | null
+    error?: string | null
+  },
+): AgentLoopAutoUpgradeRuntimeState {
+  const next: AgentLoopAutoUpgradeRuntimeState = {
+    ...state,
+    lastAttemptAt: state.lastAttemptAt ?? input.completedAt,
+    lastOutcome: input.outcome,
+    lastTargetVersion: normalizeOptionalString(input.targetVersion),
+    lastTargetRevision: normalizeOptionalString(input.targetRevision),
+    lastError: normalizeOptionalString(input.error),
+  }
+
+  if (input.outcome === 'succeeded') {
+    next.successCount += 1
+    next.lastSuccessAt = input.completedAt
+    next.lastError = null
+  } else if (input.outcome === 'failed') {
+    next.failureCount += 1
+  } else {
+    next.noChangeCount += 1
+    next.lastError = null
+  }
+
+  return next
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+function normalizeNonNegativeInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : 0
+}
+
+function normalizeOutcome(value: unknown): AgentLoopAutoUpgradeOutcome | null {
+  return value === 'attempting'
+    || value === 'succeeded'
+    || value === 'failed'
+    || value === 'no_change'
+    ? value
+    : null
+}

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -958,6 +958,18 @@ describe('daemon merge recovery helpers', () => {
         },
       ],
       oldestBlockedIssueResumeEscalationAgeSeconds: 6,
+      autoUpgrade: {
+        attemptCount: 1,
+        successCount: 1,
+        failureCount: 0,
+        noChangeCount: 0,
+        lastAttemptAt: '2026-04-05T08:11:05.000Z',
+        lastSuccessAt: '2026-04-05T08:11:05.000Z',
+        lastOutcome: 'succeeded',
+        lastTargetVersion: '0.1.1',
+        lastTargetRevision: '2222222222222222222222222222222222222222',
+        lastError: null,
+      },
     })).toEqual({
       supervisor: 'launchd',
       workingDirectory: '/Users/wujames/codeRepo/digital-employee-main',
@@ -1037,6 +1049,18 @@ describe('daemon merge recovery helpers', () => {
         },
       ],
       oldestBlockedIssueResumeEscalationAgeSeconds: 6,
+      autoUpgrade: {
+        attemptCount: 1,
+        successCount: 1,
+        failureCount: 0,
+        noChangeCount: 0,
+        lastAttemptAt: '2026-04-05T08:11:05.000Z',
+        lastSuccessAt: '2026-04-05T08:11:05.000Z',
+        lastOutcome: 'succeeded',
+        lastTargetVersion: '0.1.1',
+        lastTargetRevision: '2222222222222222222222222222222222222222',
+        lastError: null,
+      },
     })
   })
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path'
 import type {
   ActiveLeaseRuntimeDetail,
   AgentConfig,
+  AgentLoopAutoUpgradeRuntimeState,
   AgentLoopBuildMetadata,
   AgentLoopUpgradeMetadata,
   AgentIssue,
@@ -64,11 +65,19 @@ import {
   setLastTransientLoopErrorAgeSeconds,
   setPendingWakeRequests,
   setStartupRecoveryPending,
+  setAutoUpgradeSnapshot,
   startMetricsServer,
   METRICS_PORT_DEFAULT,
   METRICS_PATH,
   type MetricsServer,
 } from './metrics'
+import {
+  readAutoUpgradeRuntimeState,
+  recordAutoUpgradeAttemptCompleted,
+  recordAutoUpgradeAttemptStarted,
+  resolveAutoUpgradeStatePath,
+  writeAutoUpgradeRuntimeState,
+} from './auto-upgrade-state'
 import { resolveCurrentRuntimeSupervisor, sanitizeDaemonBackgroundArgs } from './background'
 import {
   buildWakeQueuePath,
@@ -269,6 +278,7 @@ export class AgentDaemon {
     port: DEFAULT_HEALTH_SERVER_PORT,
   }
   private readonly wakeQueuePath: string
+  private readonly autoUpgradeStatePath: string | null
   private metricsServer: MetricsServer | null = null
   private metricsPort: number
   private presencePublisher: ManagedDaemonPresencePublisher | null = null
@@ -289,6 +299,7 @@ export class AgentDaemon {
   private lastUpgradeReminderAt: number | null = null
   private lastUpgradeReminderTargetKey: string | null = null
   private autoUpgradePromise: Promise<boolean> | null = null
+  private autoUpgradeState: AgentLoopAutoUpgradeRuntimeState
   private lastAutoUpgradeAttemptAt: number | null = null
   private lastAutoUpgradeAttemptTarget: string | null = null
   private lastPublishedUpgradeAnnouncementKey: string | null = null
@@ -310,6 +321,8 @@ export class AgentDaemon {
       machineId: this.config.machineId,
       homeDir: resolveWakeQueueHomeDirFromWorktreesBase(this.config.worktreesBase),
     })
+    this.autoUpgradeStatePath = resolveAutoUpgradeStatePath(process.env.AGENT_LOOP_RUNTIME_FILE ?? null)
+    this.autoUpgradeState = readAutoUpgradeRuntimeState(this.autoUpgradeStatePath)
     this.agentLoopBuild = resolveAgentLoopBuildMetadata()
     this.agentLoopUpgrade = createInitialAgentLoopUpgradeMetadata(
       this.config,
@@ -3479,6 +3492,7 @@ export class AgentDaemon {
       lastRecoveryActionKind: this.lastRecoveryActionKind,
       recentRecoveryActions: [...this.recoveryActionHistory],
       oldestBlockedIssueResumeEscalationAgeSeconds: this.getOldestBlockedIssueResumeEscalationAgeSeconds(),
+      autoUpgrade: this.autoUpgradeState,
     })
   }
 
@@ -3692,8 +3706,10 @@ export class AgentDaemon {
 
     this.lastAutoUpgradeAttemptTarget = attemptTarget
     this.lastAutoUpgradeAttemptAt = Date.now()
+    this.noteAutoUpgradeAttemptStarted(upgrade)
     this.autoUpgradePromise = this.performAutomaticAgentLoopUpgrade(upgrade)
       .catch((error) => {
+        this.noteAutoUpgradeAttemptCompleted('failed', upgrade, formatDaemonError(error))
         this.logger.warn(`[daemon] automatic agent-loop upgrade failed: ${formatDaemonError(error)}`)
         return false
       })
@@ -3709,6 +3725,11 @@ export class AgentDaemon {
   ): Promise<boolean> {
     const supervisor = resolveCurrentRuntimeSupervisor()
     if (supervisor === 'direct') {
+      this.noteAutoUpgradeAttemptCompleted(
+        'failed',
+        upgrade,
+        'automatic agent-loop upgrade requires a managed detached or launchd runtime',
+      )
       this.logger.warn('[daemon] automatic agent-loop upgrade requires a managed detached or launchd runtime; direct mode will keep reminder-only behavior')
       return false
     }
@@ -3721,6 +3742,7 @@ export class AgentDaemon {
       upgrade,
     })
     if (!result.changed) {
+      this.noteAutoUpgradeAttemptCompleted('no_change', upgrade)
       this.logger.log('[daemon] agent-loop auto-upgrade found no local revision change after pull; keeping current daemon process')
       return false
     }
@@ -3729,6 +3751,7 @@ export class AgentDaemon {
     this.logger.log(
       `[daemon] upgraded local agent-loop checkout on ${result.currentBranch}: v${this.agentLoopBuild.version}@${fromRevision} -> v${upgrade.latestVersion ?? this.agentLoopBuild.version}@${toRevision}`,
     )
+    this.noteAutoUpgradeAttemptCompleted('succeeded', upgrade)
 
     await this.stop({
       preserveActiveIssueStates: true,
@@ -3870,6 +3893,39 @@ export class AgentDaemon {
     setBlockedIssueResumeEscalations(runtime.blockedIssueResumeEscalationCount)
     setBlockedIssueResumeEscalationAgeSeconds(runtime.oldestBlockedIssueResumeEscalationAgeSeconds)
     setPendingWakeRequests(this.pendingWakeRequests.length)
+    setAutoUpgradeSnapshot(this.autoUpgradeState)
+  }
+
+  private noteAutoUpgradeAttemptStarted(upgrade: AgentLoopUpgradeMetadata): void {
+    const attemptedAt = new Date().toISOString()
+    this.autoUpgradeState = writeAutoUpgradeRuntimeState(
+      this.autoUpgradeStatePath,
+      recordAutoUpgradeAttemptStarted(this.autoUpgradeState, {
+        attemptedAt,
+        targetVersion: upgrade.latestVersion,
+        targetRevision: upgrade.latestRevision,
+      }),
+    )
+    this.syncRuntimeMetrics()
+  }
+
+  private noteAutoUpgradeAttemptCompleted(
+    outcome: 'succeeded' | 'failed' | 'no_change',
+    upgrade: Pick<AgentLoopUpgradeMetadata, 'latestVersion' | 'latestRevision'>,
+    error?: string,
+  ): void {
+    const completedAt = new Date().toISOString()
+    this.autoUpgradeState = writeAutoUpgradeRuntimeState(
+      this.autoUpgradeStatePath,
+      recordAutoUpgradeAttemptCompleted(this.autoUpgradeState, {
+        outcome,
+        completedAt,
+        targetVersion: upgrade.latestVersion,
+        targetRevision: upgrade.latestRevision,
+        error,
+      }),
+    )
+    this.syncRuntimeMetrics()
   }
 
   private getOldestLeaseHeartbeatAgeSeconds(): number {
@@ -4407,6 +4463,7 @@ export function buildDaemonRuntimeStatus(input: {
   lastRecoveryActionKind: string | null
   recentRecoveryActions: RecoveryActionRuntimeDetail[]
   oldestBlockedIssueResumeEscalationAgeSeconds: number
+  autoUpgrade: AgentLoopAutoUpgradeRuntimeState
 }): DaemonStatus['runtime'] {
   return {
     supervisor: input.supervisor,
@@ -4444,6 +4501,7 @@ export function buildDaemonRuntimeStatus(input: {
     lastRecoveryActionKind: input.lastRecoveryActionKind,
     recentRecoveryActions: input.recentRecoveryActions,
     oldestBlockedIssueResumeEscalationAgeSeconds: input.oldestBlockedIssueResumeEscalationAgeSeconds,
+    autoUpgrade: input.autoUpgrade,
   }
 }
 

--- a/apps/agent-daemon/src/metrics.test.ts
+++ b/apps/agent-daemon/src/metrics.test.ts
@@ -25,6 +25,7 @@ import {
   setLastTransientLoopErrorAgeSeconds,
   setNextPollDelaySeconds,
   setPendingWakeRequests,
+  setAutoUpgradeSnapshot,
   setInFlightIssueProcesses,
   setInFlightPrReviews,
   setLeaseHeartbeatAgeSeconds,
@@ -200,6 +201,29 @@ describe('metrics', () => {
       expect(metrics).toContain('outcome="success"')
       expect(metrics).toContain('outcome="rate_limited"')
       expect(metrics).toContain('agent_loop_github_api_request_duration_seconds')
+    })
+
+    test('tracks persisted auto-upgrade counts and ages', async () => {
+      setAutoUpgradeSnapshot({
+        attemptCount: 3,
+        successCount: 1,
+        failureCount: 1,
+        noChangeCount: 1,
+        lastAttemptAt: '2026-04-11T12:10:00.000Z',
+        lastSuccessAt: '2026-04-11T12:00:00.000Z',
+        lastOutcome: 'failed',
+        lastTargetVersion: '0.1.2',
+        lastTargetRevision: '2222222222222222222222222222222222222222',
+        lastError: 'git pull failed',
+      }, Date.parse('2026-04-11T12:15:00.000Z'))
+
+      const metrics = await getMetrics()
+      expect(metrics).toContain('agent_loop_auto_upgrade_attempts 3')
+      expect(metrics).toContain('agent_loop_auto_upgrade_successes 1')
+      expect(metrics).toContain('agent_loop_auto_upgrade_failures 1')
+      expect(metrics).toContain('agent_loop_auto_upgrade_no_changes 1')
+      expect(metrics).toContain('agent_loop_auto_upgrade_last_attempt_age_seconds 300')
+      expect(metrics).toContain('agent_loop_auto_upgrade_last_success_age_seconds 900')
     })
 
     test('tracks wake queue and handling outcomes', async () => {

--- a/apps/agent-daemon/src/metrics.ts
+++ b/apps/agent-daemon/src/metrics.ts
@@ -28,6 +28,12 @@
  * - agent_loop_wake_requests_total: Counter of wake requests queued/handled (labels: kind, outcome)
  * - agent_loop_last_transient_loop_error_age_seconds: Gauge of the most recent transient loop error age
  * - agent_loop_pending_wake_requests: Gauge of queued wake requests waiting in memory
+ * - agent_loop_auto_upgrade_attempts: Gauge of persisted automatic self-upgrade attempts
+ * - agent_loop_auto_upgrade_successes: Gauge of persisted successful automatic self-upgrades
+ * - agent_loop_auto_upgrade_failures: Gauge of persisted failed automatic self-upgrades
+ * - agent_loop_auto_upgrade_no_changes: Gauge of automatic self-upgrades that found no revision change
+ * - agent_loop_auto_upgrade_last_attempt_age_seconds: Gauge of the last automatic self-upgrade attempt age
+ * - agent_loop_auto_upgrade_last_success_age_seconds: Gauge of the last successful automatic self-upgrade age
  * - agent_loop_blocked_issue_resumes: Gauge of failed issue resumes currently blocked by linked PR state
  * - agent_loop_blocked_issue_resume_age_seconds: Gauge of the oldest blocked failed-issue resume age
  * - agent_loop_poll_duration_seconds: Histogram of poll cycle durations
@@ -45,6 +51,7 @@ import {
   collectDefaultMetrics,
 } from 'prom-client'
 import type {
+  AgentLoopAutoUpgradeRuntimeState,
   ConcurrencyPolicy,
   GitHubApiMode,
   GitHubApiOutcome,
@@ -444,6 +451,60 @@ export const lastTransientLoopErrorAgeSeconds = new Gauge({
 export const pendingWakeRequests = new Gauge({
   name: 'agent_loop_pending_wake_requests',
   help: 'Current number of pending wake requests held in the daemon in-memory queue',
+  registers: [registry],
+})
+
+/**
+ * Persisted automatic self-upgrade attempt count.
+ */
+export const autoUpgradeAttempts = new Gauge({
+  name: 'agent_loop_auto_upgrade_attempts',
+  help: 'Persisted count of automatic agent-loop self-upgrade attempts',
+  registers: [registry],
+})
+
+/**
+ * Persisted successful automatic self-upgrade count.
+ */
+export const autoUpgradeSuccesses = new Gauge({
+  name: 'agent_loop_auto_upgrade_successes',
+  help: 'Persisted count of successful automatic agent-loop self-upgrades',
+  registers: [registry],
+})
+
+/**
+ * Persisted failed automatic self-upgrade count.
+ */
+export const autoUpgradeFailures = new Gauge({
+  name: 'agent_loop_auto_upgrade_failures',
+  help: 'Persisted count of failed automatic agent-loop self-upgrades',
+  registers: [registry],
+})
+
+/**
+ * Persisted automatic self-upgrade no-change count.
+ */
+export const autoUpgradeNoChanges = new Gauge({
+  name: 'agent_loop_auto_upgrade_no_changes',
+  help: 'Persisted count of automatic agent-loop self-upgrades that found no local revision change',
+  registers: [registry],
+})
+
+/**
+ * Age of the most recent automatic self-upgrade attempt.
+ */
+export const autoUpgradeLastAttemptAgeSeconds = new Gauge({
+  name: 'agent_loop_auto_upgrade_last_attempt_age_seconds',
+  help: 'Age in seconds of the most recent automatic agent-loop self-upgrade attempt',
+  registers: [registry],
+})
+
+/**
+ * Age of the most recent successful automatic self-upgrade.
+ */
+export const autoUpgradeLastSuccessAgeSeconds = new Gauge({
+  name: 'agent_loop_auto_upgrade_last_success_age_seconds',
+  help: 'Age in seconds of the most recent successful automatic agent-loop self-upgrade',
   registers: [registry],
 })
 
@@ -847,6 +908,21 @@ export function setPendingWakeRequests(count: number): void {
 }
 
 /**
+ * Update persisted automatic self-upgrade gauges.
+ */
+export function setAutoUpgradeSnapshot(
+  state: AgentLoopAutoUpgradeRuntimeState,
+  nowMs = Date.now(),
+): void {
+  autoUpgradeAttempts.set(state.attemptCount)
+  autoUpgradeSuccesses.set(state.successCount)
+  autoUpgradeFailures.set(state.failureCount)
+  autoUpgradeNoChanges.set(state.noChangeCount)
+  autoUpgradeLastAttemptAgeSeconds.set(computeIsoAgeSeconds(state.lastAttemptAt, nowMs))
+  autoUpgradeLastSuccessAgeSeconds.set(computeIsoAgeSeconds(state.lastSuccessAt, nowMs))
+}
+
+/**
  * Record poll duration.
  */
 export function recordPollDuration(durationMs: number): void {
@@ -858,6 +934,19 @@ export function recordPollDuration(durationMs: number): void {
  */
 export function recordIssueProcessingDuration(durationMs: number): void {
   issueProcessingDurationSeconds.observe(durationMs / 1000)
+}
+
+function computeIsoAgeSeconds(iso: string | null, nowMs: number): number {
+  if (!iso) {
+    return 0
+  }
+
+  const parsed = Date.parse(iso)
+  if (!Number.isFinite(parsed)) {
+    return 0
+  }
+
+  return Math.max(0, (nowMs - parsed) / 1000)
 }
 
 /**

--- a/apps/agent-daemon/src/status.test.ts
+++ b/apps/agent-daemon/src/status.test.ts
@@ -188,6 +188,18 @@ const baseHealth: DaemonStatus & {
         reason: 'worker idle timeout',
       },
     ],
+    autoUpgrade: {
+      attemptCount: 2,
+      successCount: 1,
+      failureCount: 0,
+      noChangeCount: 1,
+      lastAttemptAt: '2026-04-05T08:09:55.000Z',
+      lastSuccessAt: '2026-04-05T07:55:00.000Z',
+      lastOutcome: 'no_change',
+      lastTargetVersion: '0.1.1',
+      lastTargetRevision: '2222222222222222222222222222222222222222',
+      lastError: null,
+    },
   },
   activeWorktrees: [
     {
@@ -243,6 +255,12 @@ agent_loop_blocked_issue_resumes 1
 agent_loop_blocked_issue_resume_age_seconds 45
 agent_loop_blocked_issue_resume_escalations 1
 agent_loop_blocked_issue_resume_escalation_age_seconds 15
+agent_loop_auto_upgrade_attempts 3
+agent_loop_auto_upgrade_successes 1
+agent_loop_auto_upgrade_failures 1
+agent_loop_auto_upgrade_no_changes 1
+agent_loop_auto_upgrade_last_attempt_age_seconds 300
+agent_loop_auto_upgrade_last_success_age_seconds 900
 agent_loop_lease_conflicts_total{scope="issue-process"} 1
 agent_loop_rate_limit_hits_total 0
 `
@@ -381,6 +399,12 @@ describe('status helpers', () => {
       blockedIssueResumeAgeSeconds: 45,
       blockedIssueResumeEscalations: 1,
       blockedIssueResumeEscalationAgeSeconds: 15,
+      autoUpgradeAttempts: 3,
+      autoUpgradeSuccesses: 1,
+      autoUpgradeFailures: 1,
+      autoUpgradeNoChanges: 1,
+      autoUpgradeLastAttemptAgeSeconds: 300,
+      autoUpgradeLastSuccessAgeSeconds: 900,
       leaseConflicts: 1,
       rateLimitHits: 0,
     })
@@ -431,6 +455,7 @@ describe('status helpers', () => {
     expect(report).toContain('leases: active 2 | oldest heartbeat 75s | stalled 1 | last recovery issue-process-idle-timeout @ 2026-04-05T08:08:30.000Z')
     expect(report).toContain('lease detail: issue-process#77 implementation hb=75s progress=42s adoptable=yes')
     expect(report).toContain('state: startup pending yes | failed resumes 1 | cooldowns 1 | blocked resumes 1 | oldest blocked 45s | escalated 1 | oldest escalation 15s')
+    expect(report).toContain('auto-upgrade: attempts 2 | success 1 | failed 0 | no-change 1 | last outcome no_change | last attempt 2026-04-05T08:09:55.000Z | last success 2026-04-05T07:55:00.000Z | target v0.1.1@2222222')
     expect(report).toContain('poll: last 2026-04-05T08:10:00.000Z | last claim 2026-04-05T08:09:00.000Z | next 5s (deferred-transient) @ 2026-04-05T08:10:05.000Z')
     expect(report).toContain('recent recovery: issue-process-idle-timeout/recoverable issue-process#77')
     expect(report).toContain('blocked resumes: issue#91<-pr#110 45s esc=1/15s')
@@ -438,6 +463,7 @@ describe('status helpers', () => {
     expect(report).toContain('runtime files: record /Users/wujames/.agent-loop/runtime/jameswuhk-digital-employee__codex-dev__9310.json | log /Users/wujames/.agent-loop/runtime/jameswuhk-digital-employee__codex-dev__9310.log')
     expect(report).toContain('outcomes: polls success=12, skipped_concurrency=3, no_issues=4, error=1 | wake queued=2, started_work=1, no_match=1, allow_fallback=1')
     expect(report).toContain('github api: graphql/direct[success=8, error=0, timeout=0, rate_limited=1], rest/gh_cli[success=5, error=1, timeout=0, rate_limited=0]')
+    expect(report).toContain('auto-upgrade metrics: attempts 3 | success 1 | failed 1 | no-change 1 | last attempt age 300s | last success age 900s')
     expect(report).toContain('wake: pending 2 | now[queued=0, started_work=0, no_match=0, allow_fallback=1], issue[queued=2, started_work=1, no_match=0, allow_fallback=0], pr[queued=0, started_work=0, no_match=1, allow_fallback=0]')
     expect(report).toContain('pr blockers: pr#239<-issue#105 attempt 5 @ 2026-04-06T01:23:45.000Z: The PR breaks the existing approval-bar flow')
     expect(report).toContain('warnings: startup recovery is still pending')
@@ -526,11 +552,54 @@ describe('status helpers', () => {
     expect(report).toContain('worker-idle-timeouts: issue-process=2')
     expect(report).toContain('blocked-issue-resumes: 1')
     expect(report).toContain('blocked-issue-resume-age-seconds: 45')
+    expect(report).toContain('auto-upgrade-attempts: 3')
+    expect(report).toContain('auto-upgrade-successes: 1')
+    expect(report).toContain('auto-upgrade-failures: 1')
+    expect(report).toContain('auto-upgrade-no-changes: 1')
+    expect(report).toContain('auto-upgrade-last-attempt-age-seconds: 300')
+    expect(report).toContain('auto-upgrade-last-success-age-seconds: 900')
     expect(report).toContain('oldest blocked issue resume age: 45s')
+    expect(report).toContain('auto-upgrade runtime: attempts 2 | success 1 | failed 0 | no-change 1 | last outcome no_change | last attempt 2026-04-05T08:09:55.000Z | last success 2026-04-05T07:55:00.000Z | target v0.1.1@2222222')
     expect(report).toContain('- agent-loop upgrade available; defer restart until the daemon is idle to avoid interrupting active work')
     expect(report).toContain('- open PR review blockers: pr#239')
     expect(report).toContain('- github api rate limits observed: graphql/direct[success=0, error=0, timeout=0, rate_limited=1]')
     expect(report).toContain('- review auto-fix push failures observed: 1')
+    expect(report).toContain('- automatic agent-loop upgrade failures observed: 1')
+  })
+
+  test('doctor warnings surface the last failed automatic upgrade runtime error', () => {
+    const report = formatDoctorReport({
+      ok: true,
+      healthUrl: 'http://127.0.0.1:9310/health',
+      metricsUrl: 'http://127.0.0.1:9090/metrics',
+      error: null,
+      diagnosticRepo: baseHealth.repo,
+      localRuntime: baseLocalRuntime,
+      health: {
+        ...baseHealth,
+        runtime: {
+          ...baseHealth.runtime,
+          autoUpgrade: {
+            ...baseHealth.runtime.autoUpgrade!,
+            failureCount: 1,
+            lastOutcome: 'failed',
+            lastError: 'git pull failed',
+          },
+        },
+      },
+      metrics: summarizeDaemonMetrics(metricsText),
+      metricsError: null,
+      githubAudit: {
+        ok: true,
+        error: null,
+        checks: [],
+        prBlockers: [],
+        warnings: [],
+      },
+      warnings: [],
+    })
+
+    expect(report).toContain('- last automatic agent-loop upgrade failed: git pull failed')
   })
 
   test('doctor warnings call out adoptable leases and repeated recoveries for the same target', async () => {

--- a/apps/agent-daemon/src/status.ts
+++ b/apps/agent-daemon/src/status.ts
@@ -74,6 +74,12 @@ export interface DaemonMetricSummary {
   blockedIssueResumeAgeSeconds: number | null
   blockedIssueResumeEscalations: number | null
   blockedIssueResumeEscalationAgeSeconds: number | null
+  autoUpgradeAttempts: number | null
+  autoUpgradeSuccesses: number | null
+  autoUpgradeFailures: number | null
+  autoUpgradeNoChanges: number | null
+  autoUpgradeLastAttemptAgeSeconds: number | null
+  autoUpgradeLastSuccessAgeSeconds: number | null
   leaseConflicts: number
   rateLimitHits: number
 }
@@ -431,6 +437,7 @@ export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): strin
     `connectivity: transient ${transientLoopErrorCount} | startup deferred ${startupRecoveryDeferredCount} | last transient ${formatTransientLoopError(health.runtime.lastTransientLoopErrorKind, health.runtime.lastTransientLoopErrorAgeSeconds)}`,
     `leases: active ${health.runtime.activeLeaseCount} | oldest heartbeat ${formatNullableSeconds(health.runtime.oldestLeaseHeartbeatAgeSeconds)} | stalled ${health.runtime.stalledWorkerCount} | last recovery ${formatLastRecovery(health.runtime.lastRecoveryActionKind, health.runtime.lastRecoveryActionAt)}`,
     `state: startup pending ${formatBoolean(health.runtime.startupRecoveryPending)} | failed resumes ${health.runtime.failedIssueResumeAttemptsTracked} | cooldowns ${health.runtime.failedIssueResumeCooldownsTracked} | blocked resumes ${blockedIssueResumeCount} | oldest blocked ${formatNullableSeconds(oldestBlockedIssueResumeAgeSeconds)} | escalated ${blockedIssueResumeEscalationCount} | oldest escalation ${formatNullableSeconds(oldestBlockedIssueResumeEscalationAgeSeconds)}`,
+    `auto-upgrade: ${formatAutoUpgradeRuntimeSummary(health.runtime.autoUpgrade ?? null)}`,
     `poll: last ${health.lastPollAt ?? 'never'} | last claim ${health.lastClaimedAt ?? 'never'} | next ${formatNextPollSummary(health.nextPollAt, health.nextPollReason, health.nextPollDelayMs)}`,
   ]
 
@@ -458,6 +465,7 @@ export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): strin
       `outcomes: polls ${formatOrderedMap(snapshot.metrics.polls, POLL_OUTCOME_ORDER)} | wake ${formatOrderedMap(summarizeWakeOutcomes(snapshot.metrics.wakeRequests), WAKE_OUTCOME_ORDER)} | reviews ${formatOrderedMap(reviewTotals, REVIEW_OUTCOME_ORDER)} | auto-fix ${formatOrderedMap(snapshot.metrics.autoFixes, AUTO_FIX_OUTCOME_ORDER)} | merge ${formatOrderedMap(snapshot.metrics.mergeRecovery, MERGE_RECOVERY_OUTCOME_ORDER)}`,
     )
     lines.push(`github api: ${formatGitHubApiRequestSummary(snapshot.metrics.githubApiRequests)}`)
+    lines.push(`auto-upgrade metrics: ${formatAutoUpgradeMetricSummary(snapshot.metrics)}`)
     lines.push(
       `wake: pending ${snapshot.metrics.pendingWakeRequests ?? 0} | ${formatWakeRequestSummary(snapshot.metrics.wakeRequests)}`,
     )
@@ -579,6 +587,12 @@ export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): strin
         `blocked-issue-resume-age-seconds: ${snapshot.metrics.blockedIssueResumeAgeSeconds ?? 0}`,
         `blocked-issue-resume-escalations: ${snapshot.metrics.blockedIssueResumeEscalations ?? 0}`,
         `blocked-issue-resume-escalation-age-seconds: ${snapshot.metrics.blockedIssueResumeEscalationAgeSeconds ?? 0}`,
+        `auto-upgrade-attempts: ${snapshot.metrics.autoUpgradeAttempts ?? 0}`,
+        `auto-upgrade-successes: ${snapshot.metrics.autoUpgradeSuccesses ?? 0}`,
+        `auto-upgrade-failures: ${snapshot.metrics.autoUpgradeFailures ?? 0}`,
+        `auto-upgrade-no-changes: ${snapshot.metrics.autoUpgradeNoChanges ?? 0}`,
+        `auto-upgrade-last-attempt-age-seconds: ${snapshot.metrics.autoUpgradeLastAttemptAgeSeconds ?? 0}`,
+        `auto-upgrade-last-success-age-seconds: ${snapshot.metrics.autoUpgradeLastSuccessAgeSeconds ?? 0}`,
         `recovery-actions: ${formatRecoveryActionSummary(snapshot.metrics.recoveryActions)}`,
         `rate-limit-hits: ${snapshot.metrics.rateLimitHits}`,
       ]
@@ -635,6 +649,7 @@ export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): strin
     `last recovery action: ${formatLastRecovery(health.runtime.lastRecoveryActionKind, health.runtime.lastRecoveryActionAt)}`,
     `failed issue resume attempts tracked: ${health.runtime.failedIssueResumeAttemptsTracked}`,
     `failed issue resume cooldowns tracked: ${health.runtime.failedIssueResumeCooldownsTracked}`,
+    `auto-upgrade runtime: ${formatAutoUpgradeRuntimeSummary(health.runtime.autoUpgrade ?? null)}`,
     '',
     'Outcomes',
     ...outcomeLines,
@@ -808,6 +823,12 @@ export function summarizeDaemonMetrics(metricsText: string): DaemonMetricSummary
     blockedIssueResumeAgeSeconds: null,
     blockedIssueResumeEscalations: null,
     blockedIssueResumeEscalationAgeSeconds: null,
+    autoUpgradeAttempts: null,
+    autoUpgradeSuccesses: null,
+    autoUpgradeFailures: null,
+    autoUpgradeNoChanges: null,
+    autoUpgradeLastAttemptAgeSeconds: null,
+    autoUpgradeLastSuccessAgeSeconds: null,
     leaseConflicts: 0,
     rateLimitHits: 0,
   }
@@ -878,6 +899,24 @@ export function summarizeDaemonMetrics(metricsText: string): DaemonMetricSummary
         break
       case 'agent_loop_blocked_issue_resume_escalation_age_seconds':
         summary.blockedIssueResumeEscalationAgeSeconds = sample.value
+        break
+      case 'agent_loop_auto_upgrade_attempts':
+        summary.autoUpgradeAttempts = sample.value
+        break
+      case 'agent_loop_auto_upgrade_successes':
+        summary.autoUpgradeSuccesses = sample.value
+        break
+      case 'agent_loop_auto_upgrade_failures':
+        summary.autoUpgradeFailures = sample.value
+        break
+      case 'agent_loop_auto_upgrade_no_changes':
+        summary.autoUpgradeNoChanges = sample.value
+        break
+      case 'agent_loop_auto_upgrade_last_attempt_age_seconds':
+        summary.autoUpgradeLastAttemptAgeSeconds = sample.value
+        break
+      case 'agent_loop_auto_upgrade_last_success_age_seconds':
+        summary.autoUpgradeLastSuccessAgeSeconds = sample.value
         break
       case 'agent_loop_lease_conflicts_total':
         summary.leaseConflicts += sample.value
@@ -973,6 +1012,11 @@ function buildDoctorWarnings(snapshot: DaemonObservabilitySnapshot): string[] {
   if (snapshot.health.upgrade?.status === 'error' && snapshot.health.upgrade.message) {
     warnings.push(`agent-loop upgrade check failed: ${snapshot.health.upgrade.message}`)
   }
+  if (snapshot.health.runtime.autoUpgrade?.lastOutcome === 'failed') {
+    warnings.push(
+      `last automatic agent-loop upgrade failed${snapshot.health.runtime.autoUpgrade.lastError ? `: ${snapshot.health.runtime.autoUpgrade.lastError}` : ''}`,
+    )
+  }
   if (snapshot.health.runtime.supervisor === 'direct') {
     warnings.push('daemon is running in direct mode; closing the current terminal/session will stop it')
   }
@@ -1050,6 +1094,9 @@ function buildDoctorWarnings(snapshot: DaemonObservabilitySnapshot): string[] {
   }
   if ((snapshot.metrics?.autoFixes.push_failed ?? 0) > 0) {
     warnings.push(`review auto-fix push failures observed: ${snapshot.metrics?.autoFixes.push_failed}`)
+  }
+  if ((snapshot.metrics?.autoUpgradeFailures ?? 0) > 0) {
+    warnings.push(`automatic agent-loop upgrade failures observed: ${snapshot.metrics?.autoUpgradeFailures}`)
   }
   if (((snapshot.metrics?.mergeRecovery.refresh_push_failed ?? 0) + (snapshot.metrics?.mergeRecovery.retry_merge_failed ?? 0)) > 0) {
     warnings.push('merge recovery has recent push/merge retry failures; inspect the latest PR recovery comments')
@@ -1447,6 +1494,39 @@ function formatUpgradeSummary(upgrade: DaemonHealthPayload['upgrade'] | undefine
   }
 
   return `${upgrade.status} | latest v${upgrade.latestVersion ?? 'unknown'}@${formatRevision(upgrade.latestRevision)} | checked ${upgrade.checkedAt ?? 'never'} | safe now ${formatBoolean(upgrade.safeToUpgradeNow)}`
+}
+
+function formatAutoUpgradeRuntimeSummary(autoUpgrade: DaemonHealthPayload['runtime']['autoUpgrade'] | null | undefined): string {
+  if (!autoUpgrade) {
+    return 'unavailable'
+  }
+
+  const target = autoUpgrade.lastTargetVersion || autoUpgrade.lastTargetRevision
+    ? `target v${autoUpgrade.lastTargetVersion ?? 'unknown'}@${formatRevision(autoUpgrade.lastTargetRevision ?? null)}`
+    : 'target unknown'
+  const lastError = autoUpgrade.lastError ? ` | error ${autoUpgrade.lastError}` : ''
+
+  return [
+    `attempts ${autoUpgrade.attemptCount}`,
+    `success ${autoUpgrade.successCount}`,
+    `failed ${autoUpgrade.failureCount}`,
+    `no-change ${autoUpgrade.noChangeCount}`,
+    `last outcome ${autoUpgrade.lastOutcome ?? 'never'}`,
+    `last attempt ${autoUpgrade.lastAttemptAt ?? 'never'}`,
+    `last success ${autoUpgrade.lastSuccessAt ?? 'never'}`,
+    target,
+  ].join(' | ') + lastError
+}
+
+function formatAutoUpgradeMetricSummary(metrics: DaemonMetricSummary): string {
+  return [
+    `attempts ${metrics.autoUpgradeAttempts ?? 0}`,
+    `success ${metrics.autoUpgradeSuccesses ?? 0}`,
+    `failed ${metrics.autoUpgradeFailures ?? 0}`,
+    `no-change ${metrics.autoUpgradeNoChanges ?? 0}`,
+    `last attempt age ${formatNullableSeconds(metrics.autoUpgradeLastAttemptAgeSeconds ?? 0)}`,
+    `last success age ${formatNullableSeconds(metrics.autoUpgradeLastSuccessAgeSeconds ?? 0)}`,
+  ].join(' | ')
 }
 
 function inferIssueStateFromLabels(labels: string[]): string {

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -173,6 +173,25 @@ export interface AgentLoopUpgradeMetadata {
   message: string | null
 }
 
+export type AgentLoopAutoUpgradeOutcome =
+  | 'attempting'
+  | 'succeeded'
+  | 'failed'
+  | 'no_change'
+
+export interface AgentLoopAutoUpgradeRuntimeState {
+  attemptCount: number
+  successCount: number
+  failureCount: number
+  noChangeCount: number
+  lastAttemptAt: string | null
+  lastSuccessAt: string | null
+  lastOutcome: AgentLoopAutoUpgradeOutcome | null
+  lastTargetVersion: string | null
+  lastTargetRevision: string | null
+  lastError: string | null
+}
+
 export type ManagedLeaseScope = 'issue-process' | 'pr-review' | 'pr-merge'
 export type ManagedLeaseStatus = 'active' | 'completed' | 'recoverable' | 'released'
 export type ManagedLeaseProgressKind = 'stdout' | 'stderr' | 'git-state' | 'phase'
@@ -404,6 +423,7 @@ export interface DaemonStatus {
     lastRecoveryActionKind: string | null
     recentRecoveryActions: RecoveryActionRuntimeDetail[]
     oldestBlockedIssueResumeEscalationAgeSeconds: number
+    autoUpgrade?: AgentLoopAutoUpgradeRuntimeState | null
   }
   activeWorktrees: WorktreeInfo[]
   lastPollAt: string | null


### PR DESCRIPTION
## Summary
- persist automatic self-upgrade attempt state alongside the managed runtime record so outcomes survive daemon restarts
- publish persisted auto-upgrade counts and ages through health/status/doctor/metrics surfaces
- add coverage for runtime snapshots, metrics parsing, status rendering, and auto-upgrade state persistence

## Testing
- bun test apps/agent-daemon/src/auto-upgrade-state.test.ts apps/agent-daemon/src/metrics.test.ts apps/agent-daemon/src/daemon.test.ts apps/agent-daemon/src/status.test.ts
- bun run typecheck