### PR TITLE
feat(upgrade): report rollout outcomes in presence

### DIFF
--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -3513,6 +3513,7 @@ export class AgentDaemon {
       latestRevision: upgrade.latestRevision,
       upgradeCheckedAt: upgrade.checkedAt,
       upgradeMessage: upgrade.message,
+      autoUpgrade: runtime.autoUpgrade ?? null,
     }
   }
 

--- a/apps/agent-daemon/src/dashboard.test.ts
+++ b/apps/agent-daemon/src/dashboard.test.ts
@@ -101,6 +101,18 @@ function buildPresence(overrides: Partial<DashboardPresenceView> = {}): Dashboar
     latestRevision: 'abcdef1234567890',
     upgradeCheckedAt: '2026-04-05T09:10:00.000Z',
     upgradeMessage: 'local and latest versions match',
+    autoUpgrade: {
+      attemptCount: 1,
+      successCount: 1,
+      failureCount: 0,
+      noChangeCount: 0,
+      lastAttemptAt: '2026-04-05T09:09:10.000Z',
+      lastSuccessAt: '2026-04-05T09:09:12.000Z',
+      lastOutcome: 'succeeded',
+      lastTargetVersion: '0.1.0',
+      lastTargetRevision: 'abcdef1234567890',
+      lastError: null,
+    },
     source: 'github',
     ...overrides,
   }
@@ -262,6 +274,7 @@ describe('dashboard machine aggregation', () => {
       upgradeBlockedMachineCount: 0,
       upgradeManualMachineCount: 0,
       upgradeErrorMachineCount: 0,
+      upgradeFailedMachineCount: 0,
     })
   })
 
@@ -305,6 +318,18 @@ describe('dashboard machine aggregation', () => {
           upgradeStatus: 'upgrade-available',
           safeToUpgradeNow: false,
           latestVersion: '0.1.2',
+          autoUpgrade: {
+            attemptCount: 2,
+            successCount: 0,
+            failureCount: 1,
+            noChangeCount: 1,
+            lastAttemptAt: '2026-04-05T09:10:20.000Z',
+            lastSuccessAt: null,
+            lastOutcome: 'failed',
+            lastTargetVersion: '0.1.2',
+            lastTargetRevision: 'fedcba9876543210',
+            lastError: 'git pull failed',
+          },
         }),
         buildPresence({
           machineId: 'machine-manual',
@@ -340,6 +365,7 @@ describe('dashboard machine aggregation', () => {
       upgradeBlockedMachineCount: 1,
       upgradeManualMachineCount: 1,
       upgradeErrorMachineCount: 1,
+      upgradeFailedMachineCount: 1,
     })
 
     expect(machines.find((machine) => machine.machineId === 'machine-ready')?.warnings).toContain(
@@ -347,6 +373,9 @@ describe('dashboard machine aggregation', () => {
     )
     expect(machines.find((machine) => machine.machineId === 'machine-busy')?.warnings).toContain(
       'agent-loop upgrade available on machine-busy; wait for the machine to go idle before restarting',
+    )
+    expect(machines.find((machine) => machine.machineId === 'machine-busy')?.warnings).toContain(
+      'automatic agent-loop upgrade last failed on machine-busy: git pull failed',
     )
     expect(machines.find((machine) => machine.machineId === 'machine-manual')?.warnings).toContain(
       'agent-loop upgrade available on machine-manual, but auto-apply is disabled on this machine; manual restart is required',
@@ -374,6 +403,7 @@ describe('dashboard localization', () => {
     expect(script).toContain('机器数')
     expect(script).toContain('待升级机器')
     expect(script).toContain('可立刻升级')
+    expect(script).toContain('升级执行失败')
     expect(script).toContain('手动升级机器')
     expect(script).toContain('本地运行时')
     expect(script).toContain('可认领')

--- a/apps/agent-daemon/src/dashboard.ts
+++ b/apps/agent-daemon/src/dashboard.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import {
+  type AgentLoopAutoUpgradeRuntimeState,
   type AgentLoopUpgradeStatusKind,
   PR_REVIEW_LABELS,
   getActiveManagedLease,
@@ -51,6 +52,7 @@ export interface DashboardSummary {
   upgradeBlockedMachineCount: number
   upgradeManualMachineCount: number
   upgradeErrorMachineCount: number
+  upgradeFailedMachineCount: number
 }
 
 export interface DashboardLeaseView {
@@ -131,6 +133,7 @@ export interface DashboardPresenceView {
   latestRevision: string | null
   upgradeCheckedAt: string | null
   upgradeMessage: string | null
+  autoUpgrade: AgentLoopAutoUpgradeRuntimeState | null
   source: 'github'
 }
 
@@ -382,6 +385,7 @@ export function buildDashboardSummary(
   let upgradeBlockedMachineCount = 0
   let upgradeManualMachineCount = 0
   let upgradeErrorMachineCount = 0
+  let upgradeFailedMachineCount = 0
 
   for (const machine of machines) {
     localRuntimeCount += machine.localRuntimes.length
@@ -404,6 +408,9 @@ export function buildDashboardSummary(
       if (machine.presence.upgradeStatus === 'error') {
         upgradeErrorMachineCount += 1
       }
+      if (machine.presence.autoUpgrade?.lastOutcome === 'failed') {
+        upgradeFailedMachineCount += 1
+      }
     }
   }
 
@@ -421,6 +428,7 @@ export function buildDashboardSummary(
     upgradeBlockedMachineCount,
     upgradeManualMachineCount,
     upgradeErrorMachineCount,
+    upgradeFailedMachineCount,
   }
 }
 
@@ -884,27 +892,35 @@ function buildPresenceUpgradeWarnings(machine: DashboardMachineCard): string[] {
   }
 
   const presence = machine.presence
+  const warnings: string[] = []
+
+  if (presence.autoUpgrade?.lastOutcome === 'failed') {
+    warnings.push(
+      `automatic agent-loop upgrade last failed on ${presence.machineId}${presence.autoUpgrade.lastError ? `: ${presence.autoUpgrade.lastError}` : ''}`,
+    )
+  }
+
   if (presence.upgradeStatus === 'upgrade-available') {
-    return [
+    warnings.push(
       !presence.upgradeAutoApplyEnabled
         ? `agent-loop upgrade available on ${presence.machineId}, but auto-apply is disabled on this machine; manual restart is required`
         : presence.safeToUpgradeNow
           ? `agent-loop upgrade available on ${presence.machineId}; this machine is idle enough to upgrade now`
           : `agent-loop upgrade available on ${presence.machineId}; wait for the machine to go idle before restarting`,
-    ]
+    )
   }
   if (presence.upgradeStatus === 'error') {
-    return [
+    warnings.push(
       `agent-loop upgrade check is failing on ${presence.machineId}${presence.upgradeMessage ? `: ${presence.upgradeMessage}` : ''}; inspect this daemon before relying on auto-upgrade`,
-    ]
+    )
   }
   if (presence.upgradeStatus === 'ahead-of-channel') {
-    return [
+    warnings.push(
       `agent-loop build on ${presence.machineId} is ahead of the tracked channel; verify this machine is pinned intentionally`,
-    ]
+    )
   }
 
-  return []
+  return warnings
 }
 
 function preferLocalLease(
@@ -1047,6 +1063,7 @@ function buildDashboardPresenceView(comment: ManagedDaemonPresenceComment): Dash
     latestRevision: comment.presence.latestRevision,
     upgradeCheckedAt: comment.presence.upgradeCheckedAt,
     upgradeMessage: comment.presence.upgradeMessage ?? null,
+    autoUpgrade: comment.presence.autoUpgrade ?? null,
     source: 'github',
   }
 }
@@ -1718,6 +1735,7 @@ function renderSummary(snapshot) {
     { label: '升级被阻塞', value: snapshot.summary.upgradeBlockedMachineCount, tone: snapshot.summary.upgradeBlockedMachineCount > 0 ? 'gold' : '' },
     { label: '手动升级机器', value: snapshot.summary.upgradeManualMachineCount, tone: snapshot.summary.upgradeManualMachineCount > 0 ? 'gold' : '' },
     { label: '升级检查错误', value: snapshot.summary.upgradeErrorMachineCount, tone: snapshot.summary.upgradeErrorMachineCount > 0 ? 'error' : '' },
+    { label: '升级执行失败', value: snapshot.summary.upgradeFailedMachineCount, tone: snapshot.summary.upgradeFailedMachineCount > 0 ? 'error' : '' },
     { label: '就绪 Issue', value: snapshot.summary.readyIssueCount, tone: '' },
     { label: '处理中 Issue', value: snapshot.summary.workingIssueCount, tone: 'accent' },
     { label: '失败 Issue', value: snapshot.summary.failedIssueCount, tone: snapshot.summary.failedIssueCount > 0 ? 'gold' : '' },
@@ -1917,10 +1935,33 @@ function renderPresenceItem(presence) {
     presence.heartbeatAgeSeconds === null ? null : '心跳 ' + presence.heartbeatAgeSeconds + ' 秒',
     presence.expiresInSeconds === null ? null : 'TTL ' + presence.expiresInSeconds + ' 秒',
   ].filter(Boolean).join(' | ');
+  const autoUpgrade = presence.autoUpgrade;
   const upgradeHint = presence.upgradeStatus === 'upgrade-available'
     ? (!presence.upgradeAutoApplyEnabled
       ? '自动升级已关闭'
       : (presence.safeToUpgradeNow ? '可安全升级' : '待空闲后升级'))
+    : null;
+  const autoUpgradeOutcome = autoUpgrade && autoUpgrade.lastOutcome
+    ? localizeAutoUpgradeOutcome(autoUpgrade.lastOutcome)
+    : null;
+  const autoUpgradeOutcomeTone = autoUpgrade && autoUpgrade.lastOutcome === 'failed'
+    ? 'error'
+    : autoUpgrade && autoUpgrade.lastOutcome === 'succeeded'
+      ? 'accent'
+      : autoUpgrade && autoUpgrade.lastOutcome === 'attempting'
+        ? 'gold'
+        : '';
+  const autoUpgradeSummary = autoUpgrade
+    ? '自动升级 ' + (autoUpgradeOutcome || '未知') + ' | 尝试 ' + autoUpgrade.attemptCount + ' | 成功 ' + autoUpgrade.successCount + ' | 失败 ' + autoUpgrade.failureCount + ' | 无变化 ' + autoUpgrade.noChangeCount
+    : null;
+  const autoUpgradeMeta = autoUpgrade && (autoUpgrade.lastAttemptAt || autoUpgrade.lastSuccessAt || autoUpgrade.lastTargetVersion || autoUpgrade.lastTargetRevision)
+    ? [
+      autoUpgrade.lastAttemptAt ? '上次尝试 ' + formatTimestamp(autoUpgrade.lastAttemptAt) : null,
+      autoUpgrade.lastSuccessAt ? '上次成功 ' + formatTimestamp(autoUpgrade.lastSuccessAt) : null,
+      (autoUpgrade.lastTargetVersion || autoUpgrade.lastTargetRevision)
+        ? '目标 v' + (autoUpgrade.lastTargetVersion || 'unknown') + '@' + shortDaemonId(autoUpgrade.lastTargetRevision || 'unknown')
+        : null,
+    ].filter(Boolean).join(' | ')
     : null;
 
   return [
@@ -1931,6 +1972,7 @@ function renderPresenceItem(presence) {
     renderChip(shortDaemonId(presence.daemonInstanceId), ''),
     renderChip('v' + presence.agentLoopVersion, ''),
     renderChip(presence.upgradeStatus, presence.upgradeStatus === 'upgrade-available' ? 'danger' : ''),
+    autoUpgradeOutcome ? renderChip('自动升级' + autoUpgradeOutcome, autoUpgradeOutcomeTone) : '',
     renderChip(presence.upgradeAutoApplyEnabled ? '自动升级开' : '自动升级关', presence.upgradeAutoApplyEnabled ? 'accent' : 'gold'),
     renderChip('工作树 ' + presence.activeWorktreeCount, ''),
     renderChip('租约 ' + presence.activeLeaseCount, ''),
@@ -1938,7 +1980,10 @@ function renderPresenceItem(presence) {
     '<div class="muted" style="margin-top:8px">启动于 ' + escapeHtml(formatTimestamp(presence.startedAt)) + '</div>',
     '<div class="muted" style="margin-top:6px">revision ' + escapeHtml(shortDaemonId(presence.agentLoopRevision || 'unknown')) + (presence.latestVersion ? ' | latest v' + escapeHtml(String(presence.latestVersion)) : '') + '</div>',
     upgradeHint ? '<div class="muted" style="margin-top:6px">' + escapeHtml(upgradeHint) + '</div>' : '',
+    autoUpgradeSummary ? '<div class="muted" style="margin-top:6px">' + escapeHtml(autoUpgradeSummary) + '</div>' : '',
+    autoUpgradeMeta ? '<div class="muted" style="margin-top:6px">' + escapeHtml(autoUpgradeMeta) + '</div>' : '',
     presence.upgradeMessage ? '<div class="muted" style="margin-top:6px">' + escapeHtml(presence.upgradeMessage) + '</div>' : '',
+    autoUpgrade && autoUpgrade.lastError ? '<div class="muted" style="margin-top:6px">错误：' + escapeHtml(autoUpgrade.lastError) + '</div>' : '',
     timing ? '<div class="muted" style="margin-top:6px">' + escapeHtml(timing) + '</div>' : '',
     '</div>',
   ].join('');
@@ -2021,6 +2066,21 @@ function localizePresenceStatus(status) {
       return '已停止'
     default:
       return status || '未知'
+  }
+}
+
+function localizeAutoUpgradeOutcome(outcome) {
+  switch (outcome) {
+    case 'attempting':
+      return '进行中'
+    case 'succeeded':
+      return '成功'
+    case 'failed':
+      return '失败'
+    case 'no_change':
+      return '无变化'
+    default:
+      return outcome || '未知'
   }
 }
 

--- a/apps/agent-daemon/src/presence.test.ts
+++ b/apps/agent-daemon/src/presence.test.ts
@@ -79,6 +79,18 @@ function buildPresence(overrides: Partial<ManagedDaemonPresence> = {}): ManagedD
     latestRevision: 'abcdef1234567890',
     upgradeCheckedAt: '2026-04-05T08:00:20.000Z',
     upgradeMessage: 'local and latest versions match',
+    autoUpgrade: {
+      attemptCount: 1,
+      successCount: 1,
+      failureCount: 0,
+      noChangeCount: 0,
+      lastAttemptAt: '2026-04-05T08:00:10.000Z',
+      lastSuccessAt: '2026-04-05T08:00:12.000Z',
+      lastOutcome: 'succeeded',
+      lastTargetVersion: '0.1.0',
+      lastTargetRevision: 'abcdef1234567890',
+      lastError: null,
+    },
     ...overrides,
   }
 }
@@ -142,6 +154,8 @@ describe('managed daemon presence helpers', () => {
     const body = buildManagedDaemonPresenceComment(presence)
 
     expect(extractManagedDaemonPresenceComment(body)).toEqual(presence)
+    expect(body).toContain('"autoUpgrade":{')
+    expect(body).toContain('Auto-upgrade outcome: succeeded')
   })
 
   test('round-trips managed daemon upgrade announcement comments and picks the newest one', () => {
@@ -272,6 +286,18 @@ describe('managed daemon presence publisher', () => {
       latestRevision: 'abcdef1234567890',
       upgradeCheckedAt: '2026-04-05T08:00:20.000Z',
       upgradeMessage: 'local and latest versions match',
+      autoUpgrade: {
+        attemptCount: 1,
+        successCount: 1,
+        failureCount: 0,
+        noChangeCount: 0,
+        lastAttemptAt: '2026-04-05T08:00:10.000Z',
+        lastSuccessAt: '2026-04-05T08:00:12.000Z',
+        lastOutcome: 'succeeded',
+        lastTargetVersion: '0.1.0',
+        lastTargetRevision: 'abcdef1234567890',
+        lastError: null,
+      },
     }
 
     const publisher = new ManagedDaemonPresencePublisher({
@@ -296,6 +322,18 @@ describe('managed daemon presence publisher', () => {
     runtime.latestVersion = '0.1.1'
     runtime.latestRevision = 'fedcba9876543210'
     runtime.upgradeMessage = 'channel master is newer: local v0.1.0, latest v0.1.1'
+    runtime.autoUpgrade = {
+      attemptCount: 2,
+      successCount: 1,
+      failureCount: 1,
+      noChangeCount: 0,
+      lastAttemptAt: '2026-04-05T08:00:40.000Z',
+      lastSuccessAt: '2026-04-05T08:00:12.000Z',
+      lastOutcome: 'failed',
+      lastTargetVersion: '0.1.1',
+      lastTargetRevision: 'fedcba9876543210',
+      lastError: 'git pull failed',
+    }
 
     await publisher.flushHeartbeat()
     expect(comments).toHaveLength(1)
@@ -305,6 +343,8 @@ describe('managed daemon presence publisher', () => {
     expect(comments[0]?.body).toContain('"upgradeAutoApplyEnabled":false')
     expect(comments[0]?.body).toContain('"safeToUpgradeNow":false')
     expect(comments[0]?.body).toContain('"upgradeMessage":"channel master is newer: local v0.1.0, latest v0.1.1"')
+    expect(comments[0]?.body).toContain('"lastOutcome":"failed"')
+    expect(comments[0]?.body).toContain('Auto-upgrade last error: git pull failed')
 
     await publisher.stop()
     expect(comments[0]?.body).toContain('"status":"stopped"')

--- a/apps/agent-daemon/src/presence.ts
+++ b/apps/agent-daemon/src/presence.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path'
 import {
   runBoundedGhCommand,
   type AgentConfig,
+  type AgentLoopAutoUpgradeOutcome,
+  type AgentLoopAutoUpgradeRuntimeState,
   type GitHubApiOutcome,
   type AgentLoopUpgradeStatusKind,
   type IssueComment,
@@ -40,6 +42,7 @@ export interface ManagedDaemonPresence {
   latestRevision: string | null
   upgradeCheckedAt: string | null
   upgradeMessage: string | null
+  autoUpgrade: AgentLoopAutoUpgradeRuntimeState | null
 }
 
 export interface ManagedDaemonPresenceComment extends IssueComment {
@@ -59,6 +62,7 @@ export interface ManagedDaemonPresenceRuntimeState {
   latestRevision: string | null
   upgradeCheckedAt: string | null
   upgradeMessage: string | null
+  autoUpgrade: AgentLoopAutoUpgradeRuntimeState | null
 }
 
 export interface ManagedDaemonUpgradeAnnouncement {
@@ -307,6 +311,14 @@ export function extractManagedDaemonPresenceIssueNumber(
 }
 
 export function buildManagedDaemonPresenceComment(presence: ManagedDaemonPresence): string {
+  const autoUpgrade = presence.autoUpgrade
+  const autoUpgradeCounts = autoUpgrade
+    ? `attempt ${autoUpgrade.attemptCount} / success ${autoUpgrade.successCount} / failed ${autoUpgrade.failureCount} / no-change ${autoUpgrade.noChangeCount}`
+    : 'unavailable'
+  const autoUpgradeTarget = autoUpgrade && (autoUpgrade.lastTargetVersion || autoUpgrade.lastTargetRevision)
+    ? `v${autoUpgrade.lastTargetVersion ?? 'unknown'} (${autoUpgrade.lastTargetRevision ?? 'unknown'})`
+    : 'unknown'
+
   return `${MANAGED_DAEMON_PRESENCE_COMMENT_PREFIX}${JSON.stringify(presence)} -->
 ## Managed daemon presence
 
@@ -327,7 +339,13 @@ export function buildManagedDaemonPresenceComment(presence: ManagedDaemonPresenc
 - Safe to upgrade now: ${presence.safeToUpgradeNow ? 'yes' : 'no'}
 - Latest known version: ${presence.latestVersion ?? 'unknown'}
 - Latest known revision: ${presence.latestRevision ?? 'unknown'}
-- Upgrade message: ${presence.upgradeMessage ?? 'none'}`
+- Upgrade message: ${presence.upgradeMessage ?? 'none'}
+- Auto-upgrade outcome: ${autoUpgrade?.lastOutcome ?? 'unknown'}
+- Auto-upgrade counts: ${autoUpgradeCounts}
+- Auto-upgrade last attempt: ${autoUpgrade?.lastAttemptAt ?? 'never'}
+- Auto-upgrade last success: ${autoUpgrade?.lastSuccessAt ?? 'never'}
+- Auto-upgrade target: ${autoUpgradeTarget}
+- Auto-upgrade last error: ${autoUpgrade?.lastError ?? 'none'}`
 }
 
 export function buildManagedDaemonUpgradeAnnouncementComment(
@@ -394,6 +412,7 @@ export function extractManagedDaemonPresenceComment(body: string): ManagedDaemon
     const upgradeMessage = typeof parsed.upgradeMessage === 'string' && parsed.upgradeMessage.trim().length > 0
       ? parsed.upgradeMessage
       : null
+    const autoUpgrade = normalizeManagedAutoUpgradeRuntimeState(parsed.autoUpgrade)
 
     return {
       repo: parsed.repo,
@@ -417,10 +436,53 @@ export function extractManagedDaemonPresenceComment(body: string): ManagedDaemon
       latestRevision,
       upgradeCheckedAt,
       upgradeMessage,
+      autoUpgrade,
     }
   } catch {
     return null
   }
+}
+
+function normalizeManagedAutoUpgradeRuntimeState(value: unknown): AgentLoopAutoUpgradeRuntimeState | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const parsed = value as Record<string, unknown>
+
+  return {
+    attemptCount: normalizeNonNegativeInteger(parsed.attemptCount),
+    successCount: normalizeNonNegativeInteger(parsed.successCount),
+    failureCount: normalizeNonNegativeInteger(parsed.failureCount),
+    noChangeCount: normalizeNonNegativeInteger(parsed.noChangeCount),
+    lastAttemptAt: normalizeOptionalString(parsed.lastAttemptAt),
+    lastSuccessAt: normalizeOptionalString(parsed.lastSuccessAt),
+    lastOutcome: normalizeAutoUpgradeOutcome(parsed.lastOutcome),
+    lastTargetVersion: normalizeOptionalString(parsed.lastTargetVersion),
+    lastTargetRevision: normalizeOptionalString(parsed.lastTargetRevision),
+    lastError: normalizeOptionalString(parsed.lastError),
+  }
+}
+
+function normalizeAutoUpgradeOutcome(value: unknown): AgentLoopAutoUpgradeOutcome | null {
+  return value === 'attempting'
+    || value === 'succeeded'
+    || value === 'failed'
+    || value === 'no_change'
+    ? value
+    : null
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+function normalizeNonNegativeInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : 0
 }
 
 export function extractManagedDaemonUpgradeAnnouncementComment(
@@ -773,6 +835,7 @@ export class ManagedDaemonPresencePublisher {
       latestRevision: runtime.latestRevision,
       upgradeCheckedAt: runtime.upgradeCheckedAt,
       upgradeMessage: runtime.upgradeMessage,
+      autoUpgrade: runtime.autoUpgrade,
     }
   }
 


### PR DESCRIPTION
## Summary
- publish automatic self-upgrade runtime outcomes in managed daemon presence heartbeats
- surface upgrade execution failures and last outcomes in the dashboard summary, warnings, and presence cards
- extend presence/dashboard coverage so rollout failures stay visible from the shared GitHub control plane

## Testing
- bun test apps/agent-daemon/src/presence.test.ts apps/agent-daemon/src/dashboard.test.ts apps/agent-daemon/src/daemon.test.ts
- bun run typecheck