### PR TITLE
feat(upgrade): back off repeated auto-upgrade failures

### DIFF
--- a/apps/agent-daemon/src/auto-upgrade-state.test.ts
+++ b/apps/agent-daemon/src/auto-upgrade-state.test.ts
@@ -3,7 +3,9 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  computeAutoUpgradePauseUntil,
   createInitialAutoUpgradeRuntimeState,
+  isAutoUpgradePauseActiveForTarget,
   readAutoUpgradeRuntimeState,
   recordAutoUpgradeAttemptCompleted,
   recordAutoUpgradeAttemptStarted,
@@ -43,12 +45,14 @@ describe('auto-upgrade state helpers', () => {
       successCount: 1,
       failureCount: 0,
       noChangeCount: 0,
+      consecutiveFailureCount: 0,
       lastAttemptAt: '2026-04-11T12:00:00.000Z',
       lastSuccessAt: '2026-04-11T12:00:05.000Z',
       lastOutcome: 'succeeded',
       lastTargetVersion: '0.1.2',
       lastTargetRevision: '2222222222222222222222222222222222222222',
       lastError: null,
+      pausedUntil: null,
     })
   })
 
@@ -81,6 +85,7 @@ describe('auto-upgrade state helpers', () => {
       targetVersion: '0.1.2',
       targetRevision: '2222222222222222222222222222222222222222',
       error: 'git pull failed',
+      pausedUntil: '2026-04-11T12:25:02.000Z',
     })
     state = recordAutoUpgradeAttemptStarted(state, {
       attemptedAt: '2026-04-11T12:11:00.000Z',
@@ -98,8 +103,34 @@ describe('auto-upgrade state helpers', () => {
       attemptCount: 2,
       failureCount: 1,
       noChangeCount: 1,
+      consecutiveFailureCount: 0,
       lastOutcome: 'no_change',
       lastError: null,
+      pausedUntil: null,
     })
+  })
+
+  test('computes exponential pause windows for repeated failures and only applies them to the same target', () => {
+    expect(computeAutoUpgradePauseUntil('2026-04-11T12:00:00.000Z', 900_000, 1)).toBe('2026-04-11T12:15:00.000Z')
+    expect(computeAutoUpgradePauseUntil('2026-04-11T12:00:00.000Z', 900_000, 3)).toBe('2026-04-11T13:00:00.000Z')
+
+    const pausedState = {
+      ...createInitialAutoUpgradeRuntimeState(),
+      lastTargetVersion: '0.1.2',
+      lastTargetRevision: '2222222222222222222222222222222222222222',
+      pausedUntil: '2026-04-11T12:15:00.000Z',
+      consecutiveFailureCount: 1,
+      lastOutcome: 'failed' as const,
+    }
+
+    expect(isAutoUpgradePauseActiveForTarget(pausedState, {
+      targetVersion: '0.1.2',
+      targetRevision: '2222222222222222222222222222222222222222',
+    }, Date.parse('2026-04-11T12:05:00.000Z'))).toBe(true)
+
+    expect(isAutoUpgradePauseActiveForTarget(pausedState, {
+      targetVersion: '0.1.3',
+      targetRevision: '3333333333333333333333333333333333333333',
+    }, Date.parse('2026-04-11T12:05:00.000Z'))).toBe(false)
   })
 })

--- a/apps/agent-daemon/src/auto-upgrade-state.ts
+++ b/apps/agent-daemon/src/auto-upgrade-state.ts
@@ -10,12 +10,14 @@ interface AutoUpgradeStateRecord {
   successCount?: unknown
   failureCount?: unknown
   noChangeCount?: unknown
+  consecutiveFailureCount?: unknown
   lastAttemptAt?: unknown
   lastSuccessAt?: unknown
   lastOutcome?: unknown
   lastTargetVersion?: unknown
   lastTargetRevision?: unknown
   lastError?: unknown
+  pausedUntil?: unknown
 }
 
 export function createInitialAutoUpgradeRuntimeState(): AgentLoopAutoUpgradeRuntimeState {
@@ -24,12 +26,14 @@ export function createInitialAutoUpgradeRuntimeState(): AgentLoopAutoUpgradeRunt
     successCount: 0,
     failureCount: 0,
     noChangeCount: 0,
+    consecutiveFailureCount: 0,
     lastAttemptAt: null,
     lastSuccessAt: null,
     lastOutcome: null,
     lastTargetVersion: null,
     lastTargetRevision: null,
     lastError: null,
+    pausedUntil: null,
   }
 }
 
@@ -57,12 +61,14 @@ export function readAutoUpgradeRuntimeState(
       successCount: normalizeNonNegativeInteger(parsed.successCount),
       failureCount: normalizeNonNegativeInteger(parsed.failureCount),
       noChangeCount: normalizeNonNegativeInteger(parsed.noChangeCount),
+      consecutiveFailureCount: normalizeNonNegativeInteger(parsed.consecutiveFailureCount),
       lastAttemptAt: normalizeOptionalString(parsed.lastAttemptAt),
       lastSuccessAt: normalizeOptionalString(parsed.lastSuccessAt),
       lastOutcome: normalizeOutcome(parsed.lastOutcome),
       lastTargetVersion: normalizeOptionalString(parsed.lastTargetVersion),
       lastTargetRevision: normalizeOptionalString(parsed.lastTargetRevision),
       lastError: normalizeOptionalString(parsed.lastError),
+      pausedUntil: normalizeOptionalString(parsed.pausedUntil),
     }
   } catch {
     return createInitialAutoUpgradeRuntimeState()
@@ -90,14 +96,20 @@ export function recordAutoUpgradeAttemptStarted(
     targetRevision: string | null
   },
 ): AgentLoopAutoUpgradeRuntimeState {
+  const targetVersion = normalizeOptionalString(input.targetVersion)
+  const targetRevision = normalizeOptionalString(input.targetRevision)
+  const targetChanged = hasAutoUpgradeTargetChanged(state, targetVersion, targetRevision)
+
   return {
     ...state,
     attemptCount: state.attemptCount + 1,
     lastAttemptAt: input.attemptedAt,
     lastOutcome: 'attempting',
-    lastTargetVersion: normalizeOptionalString(input.targetVersion),
-    lastTargetRevision: normalizeOptionalString(input.targetRevision),
+    lastTargetVersion: targetVersion,
+    lastTargetRevision: targetRevision,
     lastError: null,
+    consecutiveFailureCount: targetChanged ? 0 : state.consecutiveFailureCount,
+    pausedUntil: targetChanged ? null : state.pausedUntil,
   }
 }
 
@@ -109,6 +121,7 @@ export function recordAutoUpgradeAttemptCompleted(
     targetVersion: string | null
     targetRevision: string | null
     error?: string | null
+    pausedUntil?: string | null
   },
 ): AgentLoopAutoUpgradeRuntimeState {
   const next: AgentLoopAutoUpgradeRuntimeState = {
@@ -118,20 +131,74 @@ export function recordAutoUpgradeAttemptCompleted(
     lastTargetVersion: normalizeOptionalString(input.targetVersion),
     lastTargetRevision: normalizeOptionalString(input.targetRevision),
     lastError: normalizeOptionalString(input.error),
+    pausedUntil: normalizeOptionalString(input.pausedUntil),
   }
 
   if (input.outcome === 'succeeded') {
     next.successCount += 1
+    next.consecutiveFailureCount = 0
     next.lastSuccessAt = input.completedAt
     next.lastError = null
+    next.pausedUntil = null
   } else if (input.outcome === 'failed') {
     next.failureCount += 1
+    next.consecutiveFailureCount += 1
   } else {
     next.noChangeCount += 1
+    next.consecutiveFailureCount = 0
     next.lastError = null
+    next.pausedUntil = null
   }
 
   return next
+}
+
+export function computeAutoUpgradePauseUntil(
+  completedAt: string,
+  baseDelayMs: number,
+  consecutiveFailureCount: number,
+): string | null {
+  const completedAtMs = Date.parse(completedAt)
+  if (!Number.isFinite(completedAtMs)) {
+    return null
+  }
+
+  const normalizedBaseDelayMs = Math.max(0, Math.floor(baseDelayMs))
+  if (normalizedBaseDelayMs <= 0 || consecutiveFailureCount <= 0) {
+    return null
+  }
+
+  const multiplier = Math.min(2 ** Math.max(0, consecutiveFailureCount - 1), 8)
+  return new Date(completedAtMs + normalizedBaseDelayMs * multiplier).toISOString()
+}
+
+export function isAutoUpgradePauseActiveForTarget(
+  state: AgentLoopAutoUpgradeRuntimeState,
+  input: {
+    targetVersion: string | null
+    targetRevision: string | null
+  },
+  nowMs = Date.now(),
+): boolean {
+  const pausedUntilMs = Date.parse(state.pausedUntil ?? '')
+  if (!Number.isFinite(pausedUntilMs) || pausedUntilMs <= nowMs) {
+    return false
+  }
+
+  return !hasAutoUpgradeTargetChanged(
+    state,
+    normalizeOptionalString(input.targetVersion),
+    normalizeOptionalString(input.targetRevision),
+  )
+}
+
+function hasAutoUpgradeTargetChanged(
+  state: Pick<AgentLoopAutoUpgradeRuntimeState, 'lastTargetVersion' | 'lastTargetRevision'>,
+  targetVersion: string | null,
+  targetRevision: string | null,
+): boolean {
+  return state.lastTargetVersion !== targetVersion
+    || state.lastTargetRevision !== targetRevision
 }
 
 function normalizeOptionalString(value: unknown): string | null {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -548,6 +548,70 @@ describe('agent-loop upgrade coordination', () => {
     expect(scheduledPolls).toBe(0)
   })
 
+  test('pauses repeated automatic self-upgrade retries for the same target after a failure', async () => {
+    const daemon = createTestDaemon({
+      upgrade: {
+        enabled: true,
+        repo: 'JamesWuHK/agent-loop',
+        channel: 'master',
+        checkIntervalMs: 60_000,
+        reminderIntervalMs: 3_600_000,
+        autoApply: true,
+      },
+    }) as any
+
+    let autoUpgradeAttempts = 0
+
+    daemon.running = true
+    daemon.startupRecoveryPending = false
+    daemon.maybeRefreshAgentLoopUpgradeStatus = async () => {}
+    daemon.performAutomaticAgentLoopUpgrade = async () => {
+      autoUpgradeAttempts += 1
+      return true
+    }
+    daemon.agentLoopUpgrade = {
+      enabled: true,
+      repo: 'JamesWuHK/agent-loop',
+      channel: 'master',
+      checkedAt: '2026-04-11T11:00:00.000Z',
+      status: 'upgrade-available',
+      latestVersion: '0.1.2',
+      latestRevision: '2222222222222222222222222222222222222222',
+      latestCommitAt: '2026-04-11T10:59:30.000Z',
+      safeToUpgradeNow: true,
+      message: 'channel master is newer: local v0.1.0, latest v0.1.2',
+    }
+    daemon.autoUpgradeState = {
+      attemptCount: 1,
+      successCount: 0,
+      failureCount: 1,
+      noChangeCount: 0,
+      consecutiveFailureCount: 1,
+      lastAttemptAt: '2026-04-11T11:30:00.000Z',
+      lastSuccessAt: null,
+      lastOutcome: 'failed',
+      lastTargetVersion: '0.1.2',
+      lastTargetRevision: '2222222222222222222222222222222222222222',
+      lastError: 'git pull failed',
+      pausedUntil: '2099-04-11T12:00:00.000Z',
+    }
+
+    await daemon.maybeAutoApplyAgentLoopUpgrade()
+
+    expect(autoUpgradeAttempts).toBe(0)
+
+    daemon.agentLoopUpgrade = {
+      ...daemon.agentLoopUpgrade,
+      latestVersion: '0.1.3',
+      latestRevision: '3333333333333333333333333333333333333333',
+      message: 'channel master is newer: local v0.1.0, latest v0.1.3',
+    }
+
+    await daemon.maybeAutoApplyAgentLoopUpgrade()
+
+    expect(autoUpgradeAttempts).toBe(1)
+  })
+
   test('logs a fresh upgrade notice when the announced target changes inside the reminder cooldown', () => {
     const warnings: string[] = []
     const daemon = createTestDaemon({
@@ -963,12 +1027,14 @@ describe('daemon merge recovery helpers', () => {
         successCount: 1,
         failureCount: 0,
         noChangeCount: 0,
+        consecutiveFailureCount: 0,
         lastAttemptAt: '2026-04-05T08:11:05.000Z',
         lastSuccessAt: '2026-04-05T08:11:05.000Z',
         lastOutcome: 'succeeded',
         lastTargetVersion: '0.1.1',
         lastTargetRevision: '2222222222222222222222222222222222222222',
         lastError: null,
+        pausedUntil: null,
       },
     })).toEqual({
       supervisor: 'launchd',
@@ -1054,12 +1120,14 @@ describe('daemon merge recovery helpers', () => {
         successCount: 1,
         failureCount: 0,
         noChangeCount: 0,
+        consecutiveFailureCount: 0,
         lastAttemptAt: '2026-04-05T08:11:05.000Z',
         lastSuccessAt: '2026-04-05T08:11:05.000Z',
         lastOutcome: 'succeeded',
         lastTargetVersion: '0.1.1',
         lastTargetRevision: '2222222222222222222222222222222222222222',
         lastError: null,
+        pausedUntil: null,
       },
     })
   })

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -72,6 +72,8 @@ import {
   type MetricsServer,
 } from './metrics'
 import {
+  computeAutoUpgradePauseUntil,
+  isAutoUpgradePauseActiveForTarget,
   readAutoUpgradeRuntimeState,
   recordAutoUpgradeAttemptCompleted,
   recordAutoUpgradeAttemptStarted,
@@ -3692,6 +3694,13 @@ export class AgentDaemon {
     }
 
     const attemptTarget = this.getUpgradeAnnouncementKey(upgrade)
+    if (isAutoUpgradePauseActiveForTarget(this.autoUpgradeState, {
+      targetVersion: upgrade.latestVersion,
+      targetRevision: upgrade.latestRevision,
+    })) {
+      return false
+    }
+
     if (
       attemptTarget
       && this.lastAutoUpgradeAttemptTarget === attemptTarget
@@ -3916,6 +3925,9 @@ export class AgentDaemon {
     error?: string,
   ): void {
     const completedAt = new Date().toISOString()
+    const nextFailureCount = outcome === 'failed'
+      ? this.autoUpgradeState.consecutiveFailureCount + 1
+      : 0
     this.autoUpgradeState = writeAutoUpgradeRuntimeState(
       this.autoUpgradeStatePath,
       recordAutoUpgradeAttemptCompleted(this.autoUpgradeState, {
@@ -3924,6 +3936,13 @@ export class AgentDaemon {
         targetVersion: upgrade.latestVersion,
         targetRevision: upgrade.latestRevision,
         error,
+        pausedUntil: outcome === 'failed'
+          ? computeAutoUpgradePauseUntil(
+            completedAt,
+            resolveAgentLoopUpgradePolicy(this.config, this.agentLoopBuild).checkIntervalMs,
+            nextFailureCount,
+          )
+          : null,
       }),
     )
     this.syncRuntimeMetrics()

--- a/apps/agent-daemon/src/dashboard.test.ts
+++ b/apps/agent-daemon/src/dashboard.test.ts
@@ -106,12 +106,14 @@ function buildPresence(overrides: Partial<DashboardPresenceView> = {}): Dashboar
       successCount: 1,
       failureCount: 0,
       noChangeCount: 0,
+      consecutiveFailureCount: 0,
       lastAttemptAt: '2026-04-05T09:09:10.000Z',
       lastSuccessAt: '2026-04-05T09:09:12.000Z',
       lastOutcome: 'succeeded',
       lastTargetVersion: '0.1.0',
       lastTargetRevision: 'abcdef1234567890',
       lastError: null,
+      pausedUntil: null,
     },
     source: 'github',
     ...overrides,
@@ -318,17 +320,20 @@ describe('dashboard machine aggregation', () => {
           upgradeStatus: 'upgrade-available',
           safeToUpgradeNow: false,
           latestVersion: '0.1.2',
+          latestRevision: 'fedcba9876543210',
           autoUpgrade: {
             attemptCount: 2,
             successCount: 0,
             failureCount: 1,
             noChangeCount: 1,
+            consecutiveFailureCount: 1,
             lastAttemptAt: '2026-04-05T09:10:20.000Z',
             lastSuccessAt: null,
             lastOutcome: 'failed',
             lastTargetVersion: '0.1.2',
             lastTargetRevision: 'fedcba9876543210',
             lastError: 'git pull failed',
+            pausedUntil: '2026-04-05T09:25:20.000Z',
           },
         }),
         buildPresence({
@@ -375,7 +380,7 @@ describe('dashboard machine aggregation', () => {
       'agent-loop upgrade available on machine-busy; wait for the machine to go idle before restarting',
     )
     expect(machines.find((machine) => machine.machineId === 'machine-busy')?.warnings).toContain(
-      'automatic agent-loop upgrade last failed on machine-busy: git pull failed',
+      'automatic agent-loop upgrades paused on machine-busy until 2026-04-05T09:25:20.000Z after 1 consecutive failure(s): git pull failed',
     )
     expect(machines.find((machine) => machine.machineId === 'machine-manual')?.warnings).toContain(
       'agent-loop upgrade available on machine-manual, but auto-apply is disabled on this machine; manual restart is required',

--- a/apps/agent-daemon/src/dashboard.ts
+++ b/apps/agent-daemon/src/dashboard.ts
@@ -893,10 +893,15 @@ function buildPresenceUpgradeWarnings(machine: DashboardMachineCard): string[] {
 
   const presence = machine.presence
   const warnings: string[] = []
+  const pauseActive = presence.autoUpgrade?.pausedUntil
+    && presence.autoUpgrade.lastTargetVersion === (presence.latestVersion ?? null)
+    && presence.autoUpgrade.lastTargetRevision === (presence.latestRevision ?? null)
 
   if (presence.autoUpgrade?.lastOutcome === 'failed') {
     warnings.push(
-      `automatic agent-loop upgrade last failed on ${presence.machineId}${presence.autoUpgrade.lastError ? `: ${presence.autoUpgrade.lastError}` : ''}`,
+      pauseActive
+        ? `automatic agent-loop upgrades paused on ${presence.machineId} until ${presence.autoUpgrade.pausedUntil} after ${presence.autoUpgrade.consecutiveFailureCount} consecutive failure(s)${presence.autoUpgrade.lastError ? `: ${presence.autoUpgrade.lastError}` : ''}`
+        : `automatic agent-loop upgrade last failed on ${presence.machineId}${presence.autoUpgrade.lastError ? `: ${presence.autoUpgrade.lastError}` : ''}`,
     )
   }
 
@@ -1936,6 +1941,9 @@ function renderPresenceItem(presence) {
     presence.expiresInSeconds === null ? null : 'TTL ' + presence.expiresInSeconds + ' 秒',
   ].filter(Boolean).join(' | ');
   const autoUpgrade = presence.autoUpgrade;
+  const pauseActive = autoUpgrade && autoUpgrade.pausedUntil
+    && autoUpgrade.lastTargetVersion === (presence.latestVersion || null)
+    && autoUpgrade.lastTargetRevision === (presence.latestRevision || null);
   const upgradeHint = presence.upgradeStatus === 'upgrade-available'
     ? (!presence.upgradeAutoApplyEnabled
       ? '自动升级已关闭'
@@ -1952,12 +1960,13 @@ function renderPresenceItem(presence) {
         ? 'gold'
         : '';
   const autoUpgradeSummary = autoUpgrade
-    ? '自动升级 ' + (autoUpgradeOutcome || '未知') + ' | 尝试 ' + autoUpgrade.attemptCount + ' | 成功 ' + autoUpgrade.successCount + ' | 失败 ' + autoUpgrade.failureCount + ' | 无变化 ' + autoUpgrade.noChangeCount
+    ? '自动升级 ' + (autoUpgradeOutcome || '未知') + ' | 尝试 ' + autoUpgrade.attemptCount + ' | 成功 ' + autoUpgrade.successCount + ' | 失败 ' + autoUpgrade.failureCount + ' | 无变化 ' + autoUpgrade.noChangeCount + ' | 连续失败 ' + autoUpgrade.consecutiveFailureCount
     : null;
-  const autoUpgradeMeta = autoUpgrade && (autoUpgrade.lastAttemptAt || autoUpgrade.lastSuccessAt || autoUpgrade.lastTargetVersion || autoUpgrade.lastTargetRevision)
+  const autoUpgradeMeta = autoUpgrade && (autoUpgrade.lastAttemptAt || autoUpgrade.lastSuccessAt || autoUpgrade.lastTargetVersion || autoUpgrade.lastTargetRevision || pauseActive)
     ? [
       autoUpgrade.lastAttemptAt ? '上次尝试 ' + formatTimestamp(autoUpgrade.lastAttemptAt) : null,
       autoUpgrade.lastSuccessAt ? '上次成功 ' + formatTimestamp(autoUpgrade.lastSuccessAt) : null,
+      pauseActive ? '暂停到 ' + formatTimestamp(autoUpgrade.pausedUntil) : null,
       (autoUpgrade.lastTargetVersion || autoUpgrade.lastTargetRevision)
         ? '目标 v' + (autoUpgrade.lastTargetVersion || 'unknown') + '@' + shortDaemonId(autoUpgrade.lastTargetRevision || 'unknown')
         : null,

--- a/apps/agent-daemon/src/metrics.test.ts
+++ b/apps/agent-daemon/src/metrics.test.ts
@@ -209,12 +209,14 @@ describe('metrics', () => {
         successCount: 1,
         failureCount: 1,
         noChangeCount: 1,
+        consecutiveFailureCount: 1,
         lastAttemptAt: '2026-04-11T12:10:00.000Z',
         lastSuccessAt: '2026-04-11T12:00:00.000Z',
         lastOutcome: 'failed',
         lastTargetVersion: '0.1.2',
         lastTargetRevision: '2222222222222222222222222222222222222222',
         lastError: 'git pull failed',
+        pausedUntil: '2026-04-11T12:30:00.000Z',
       }, Date.parse('2026-04-11T12:15:00.000Z'))
 
       const metrics = await getMetrics()

--- a/apps/agent-daemon/src/presence.test.ts
+++ b/apps/agent-daemon/src/presence.test.ts
@@ -84,12 +84,14 @@ function buildPresence(overrides: Partial<ManagedDaemonPresence> = {}): ManagedD
       successCount: 1,
       failureCount: 0,
       noChangeCount: 0,
+      consecutiveFailureCount: 0,
       lastAttemptAt: '2026-04-05T08:00:10.000Z',
       lastSuccessAt: '2026-04-05T08:00:12.000Z',
       lastOutcome: 'succeeded',
       lastTargetVersion: '0.1.0',
       lastTargetRevision: 'abcdef1234567890',
       lastError: null,
+      pausedUntil: null,
     },
     ...overrides,
   }
@@ -156,6 +158,7 @@ describe('managed daemon presence helpers', () => {
     expect(extractManagedDaemonPresenceComment(body)).toEqual(presence)
     expect(body).toContain('"autoUpgrade":{')
     expect(body).toContain('Auto-upgrade outcome: succeeded')
+    expect(body).toContain('Auto-upgrade failure streak: 0')
   })
 
   test('round-trips managed daemon upgrade announcement comments and picks the newest one', () => {
@@ -291,12 +294,14 @@ describe('managed daemon presence publisher', () => {
         successCount: 1,
         failureCount: 0,
         noChangeCount: 0,
+        consecutiveFailureCount: 0,
         lastAttemptAt: '2026-04-05T08:00:10.000Z',
         lastSuccessAt: '2026-04-05T08:00:12.000Z',
         lastOutcome: 'succeeded',
         lastTargetVersion: '0.1.0',
         lastTargetRevision: 'abcdef1234567890',
         lastError: null,
+        pausedUntil: null,
       },
     }
 
@@ -327,12 +332,14 @@ describe('managed daemon presence publisher', () => {
       successCount: 1,
       failureCount: 1,
       noChangeCount: 0,
+      consecutiveFailureCount: 1,
       lastAttemptAt: '2026-04-05T08:00:40.000Z',
       lastSuccessAt: '2026-04-05T08:00:12.000Z',
       lastOutcome: 'failed',
       lastTargetVersion: '0.1.1',
       lastTargetRevision: 'fedcba9876543210',
       lastError: 'git pull failed',
+      pausedUntil: '2026-04-05T08:15:40.000Z',
     }
 
     await publisher.flushHeartbeat()
@@ -344,7 +351,9 @@ describe('managed daemon presence publisher', () => {
     expect(comments[0]?.body).toContain('"safeToUpgradeNow":false')
     expect(comments[0]?.body).toContain('"upgradeMessage":"channel master is newer: local v0.1.0, latest v0.1.1"')
     expect(comments[0]?.body).toContain('"lastOutcome":"failed"')
+    expect(comments[0]?.body).toContain('"consecutiveFailureCount":1')
     expect(comments[0]?.body).toContain('Auto-upgrade last error: git pull failed')
+    expect(comments[0]?.body).toContain('Auto-upgrade paused until: 2026-04-05T08:15:40.000Z')
 
     await publisher.stop()
     expect(comments[0]?.body).toContain('"status":"stopped"')

--- a/apps/agent-daemon/src/presence.ts
+++ b/apps/agent-daemon/src/presence.ts
@@ -342,8 +342,10 @@ export function buildManagedDaemonPresenceComment(presence: ManagedDaemonPresenc
 - Upgrade message: ${presence.upgradeMessage ?? 'none'}
 - Auto-upgrade outcome: ${autoUpgrade?.lastOutcome ?? 'unknown'}
 - Auto-upgrade counts: ${autoUpgradeCounts}
+- Auto-upgrade failure streak: ${autoUpgrade?.consecutiveFailureCount ?? 0}
 - Auto-upgrade last attempt: ${autoUpgrade?.lastAttemptAt ?? 'never'}
 - Auto-upgrade last success: ${autoUpgrade?.lastSuccessAt ?? 'never'}
+- Auto-upgrade paused until: ${autoUpgrade?.pausedUntil ?? 'none'}
 - Auto-upgrade target: ${autoUpgradeTarget}
 - Auto-upgrade last error: ${autoUpgrade?.lastError ?? 'none'}`
 }
@@ -455,12 +457,14 @@ function normalizeManagedAutoUpgradeRuntimeState(value: unknown): AgentLoopAutoU
     successCount: normalizeNonNegativeInteger(parsed.successCount),
     failureCount: normalizeNonNegativeInteger(parsed.failureCount),
     noChangeCount: normalizeNonNegativeInteger(parsed.noChangeCount),
+    consecutiveFailureCount: normalizeNonNegativeInteger(parsed.consecutiveFailureCount),
     lastAttemptAt: normalizeOptionalString(parsed.lastAttemptAt),
     lastSuccessAt: normalizeOptionalString(parsed.lastSuccessAt),
     lastOutcome: normalizeAutoUpgradeOutcome(parsed.lastOutcome),
     lastTargetVersion: normalizeOptionalString(parsed.lastTargetVersion),
     lastTargetRevision: normalizeOptionalString(parsed.lastTargetRevision),
     lastError: normalizeOptionalString(parsed.lastError),
+    pausedUntil: normalizeOptionalString(parsed.pausedUntil),
   }
 }
 

--- a/apps/agent-daemon/src/status.test.ts
+++ b/apps/agent-daemon/src/status.test.ts
@@ -193,12 +193,14 @@ const baseHealth: DaemonStatus & {
       successCount: 1,
       failureCount: 0,
       noChangeCount: 1,
+      consecutiveFailureCount: 0,
       lastAttemptAt: '2026-04-05T08:09:55.000Z',
       lastSuccessAt: '2026-04-05T07:55:00.000Z',
       lastOutcome: 'no_change',
       lastTargetVersion: '0.1.1',
       lastTargetRevision: '2222222222222222222222222222222222222222',
       lastError: null,
+      pausedUntil: null,
     },
   },
   activeWorktrees: [
@@ -455,7 +457,7 @@ describe('status helpers', () => {
     expect(report).toContain('leases: active 2 | oldest heartbeat 75s | stalled 1 | last recovery issue-process-idle-timeout @ 2026-04-05T08:08:30.000Z')
     expect(report).toContain('lease detail: issue-process#77 implementation hb=75s progress=42s adoptable=yes')
     expect(report).toContain('state: startup pending yes | failed resumes 1 | cooldowns 1 | blocked resumes 1 | oldest blocked 45s | escalated 1 | oldest escalation 15s')
-    expect(report).toContain('auto-upgrade: attempts 2 | success 1 | failed 0 | no-change 1 | last outcome no_change | last attempt 2026-04-05T08:09:55.000Z | last success 2026-04-05T07:55:00.000Z | target v0.1.1@2222222')
+    expect(report).toContain('auto-upgrade: attempts 2 | success 1 | failed 0 | no-change 1 | failure streak 0 | last outcome no_change | last attempt 2026-04-05T08:09:55.000Z | last success 2026-04-05T07:55:00.000Z | paused until none | target v0.1.1@2222222')
     expect(report).toContain('poll: last 2026-04-05T08:10:00.000Z | last claim 2026-04-05T08:09:00.000Z | next 5s (deferred-transient) @ 2026-04-05T08:10:05.000Z')
     expect(report).toContain('recent recovery: issue-process-idle-timeout/recoverable issue-process#77')
     expect(report).toContain('blocked resumes: issue#91<-pr#110 45s esc=1/15s')
@@ -559,7 +561,7 @@ describe('status helpers', () => {
     expect(report).toContain('auto-upgrade-last-attempt-age-seconds: 300')
     expect(report).toContain('auto-upgrade-last-success-age-seconds: 900')
     expect(report).toContain('oldest blocked issue resume age: 45s')
-    expect(report).toContain('auto-upgrade runtime: attempts 2 | success 1 | failed 0 | no-change 1 | last outcome no_change | last attempt 2026-04-05T08:09:55.000Z | last success 2026-04-05T07:55:00.000Z | target v0.1.1@2222222')
+    expect(report).toContain('auto-upgrade runtime: attempts 2 | success 1 | failed 0 | no-change 1 | failure streak 0 | last outcome no_change | last attempt 2026-04-05T08:09:55.000Z | last success 2026-04-05T07:55:00.000Z | paused until none | target v0.1.1@2222222')
     expect(report).toContain('- agent-loop upgrade available; defer restart until the daemon is idle to avoid interrupting active work')
     expect(report).toContain('- open PR review blockers: pr#239')
     expect(report).toContain('- github api rate limits observed: graphql/direct[success=0, error=0, timeout=0, rate_limited=1]')
@@ -582,8 +584,10 @@ describe('status helpers', () => {
           autoUpgrade: {
             ...baseHealth.runtime.autoUpgrade!,
             failureCount: 1,
+            consecutiveFailureCount: 2,
             lastOutcome: 'failed',
             lastError: 'git pull failed',
+            pausedUntil: '2099-04-05T09:00:00.000Z',
           },
         },
       },
@@ -600,6 +604,7 @@ describe('status helpers', () => {
     })
 
     expect(report).toContain('- last automatic agent-loop upgrade failed: git pull failed')
+    expect(report).toContain('- automatic agent-loop upgrades paused until 2099-04-05T09:00:00.000Z after 2 consecutive failure(s)')
   })
 
   test('doctor warnings call out adoptable leases and repeated recoveries for the same target', async () => {

--- a/apps/agent-daemon/src/status.ts
+++ b/apps/agent-daemon/src/status.ts
@@ -22,6 +22,7 @@ import {
   canResumeHumanNeededPrReview,
   extractLatestAutomatedPrReviewBlockerSummary,
 } from './pr-reviewer'
+import { isAutoUpgradePauseActiveForTarget } from './auto-upgrade-state'
 import type { BackgroundRuntimeSnapshot } from './background'
 import {
   buildLaunchdServicePaths,
@@ -1017,6 +1018,14 @@ function buildDoctorWarnings(snapshot: DaemonObservabilitySnapshot): string[] {
       `last automatic agent-loop upgrade failed${snapshot.health.runtime.autoUpgrade.lastError ? `: ${snapshot.health.runtime.autoUpgrade.lastError}` : ''}`,
     )
   }
+  if (snapshot.health.runtime.autoUpgrade && isAutoUpgradePauseActiveForTarget(snapshot.health.runtime.autoUpgrade, {
+    targetVersion: snapshot.health.upgrade?.latestVersion ?? null,
+    targetRevision: snapshot.health.upgrade?.latestRevision ?? null,
+  })) {
+    warnings.push(
+      `automatic agent-loop upgrades paused until ${snapshot.health.runtime.autoUpgrade.pausedUntil} after ${snapshot.health.runtime.autoUpgrade.consecutiveFailureCount} consecutive failure(s)`,
+    )
+  }
   if (snapshot.health.runtime.supervisor === 'direct') {
     warnings.push('daemon is running in direct mode; closing the current terminal/session will stop it')
   }
@@ -1511,9 +1520,11 @@ function formatAutoUpgradeRuntimeSummary(autoUpgrade: DaemonHealthPayload['runti
     `success ${autoUpgrade.successCount}`,
     `failed ${autoUpgrade.failureCount}`,
     `no-change ${autoUpgrade.noChangeCount}`,
+    `failure streak ${autoUpgrade.consecutiveFailureCount}`,
     `last outcome ${autoUpgrade.lastOutcome ?? 'never'}`,
     `last attempt ${autoUpgrade.lastAttemptAt ?? 'never'}`,
     `last success ${autoUpgrade.lastSuccessAt ?? 'never'}`,
+    `paused until ${autoUpgrade.pausedUntil ?? 'none'}`,
     target,
   ].join(' | ') + lastError
 }

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -184,12 +184,14 @@ export interface AgentLoopAutoUpgradeRuntimeState {
   successCount: number
   failureCount: number
   noChangeCount: number
+  consecutiveFailureCount: number
   lastAttemptAt: string | null
   lastSuccessAt: string | null
   lastOutcome: AgentLoopAutoUpgradeOutcome | null
   lastTargetVersion: string | null
   lastTargetRevision: string | null
   lastError: string | null
+  pausedUntil: string | null
 }
 
 export type ManagedLeaseScope = 'issue-process' | 'pr-review' | 'pr-merge'


### PR DESCRIPTION
## Summary
- add persisted consecutive failure tracking and pause windows for repeated automatic self-upgrade failures
- skip same-target upgrade retries while a failure backoff window is active, while still allowing immediate retries for a newer target
- surface pause state and failure streaks through status, presence, and dashboard views

## Testing
- bun test apps/agent-daemon/src/auto-upgrade-state.test.ts apps/agent-daemon/src/metrics.test.ts apps/agent-daemon/src/daemon.test.ts apps/agent-daemon/src/status.test.ts apps/agent-daemon/src/presence.test.ts apps/agent-daemon/src/dashboard.test.ts
- bun run typecheck