### PR TITLE
feat: publish upgrade failure alerts for paused rollouts

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -46,7 +46,10 @@ import {
   shouldResumeManagedIssue,
 } from './daemon'
 import { ISSUE_LABELS, PR_REVIEW_LABELS } from '@agent/shared'
-import { buildManagedDaemonUpgradeAnnouncementComment } from './presence'
+import {
+  buildManagedDaemonUpgradeAnnouncementComment,
+  buildManagedDaemonUpgradeFailureAlertComment,
+} from './presence'
 import { getMetrics, registry } from './metrics'
 import { appendWakeRequest, buildWakeQueuePath } from './wake-queue'
 
@@ -650,6 +653,85 @@ describe('agent-loop upgrade coordination', () => {
 
     expect(warnings).toHaveLength(1)
     expect(warnings[0]).toContain('auto-apply is enabled; this daemon will restart into the latest build once it goes idle')
+  })
+
+  test('publishes a deduplicated GitHub alert comment after repeated auto-upgrade failures', async () => {
+    const daemon = createTestDaemon({
+      upgrade: {
+        enabled: true,
+        repo: 'JamesWuHK/agent-loop',
+        channel: 'master',
+        checkIntervalMs: 60_000,
+        reminderIntervalMs: 3_600_000,
+        autoApply: true,
+      },
+    }) as any
+
+    const postedBodies: string[] = []
+
+    daemon.ensurePresenceIssueNumber = async () => 500
+    daemon.commentOnPresenceRegistryIssue = async (_issueNumber: number, body: string) => {
+      postedBodies.push(body)
+    }
+    daemon.listPresenceRegistryComments = async () => [{
+      commentId: 18,
+      body: buildManagedDaemonUpgradeFailureAlertComment({
+        repo: 'JamesWuHK/digital-employee',
+        machineId: 'codex-dev',
+        daemonInstanceId: 'daemon-codex-dev-1',
+        channel: 'master',
+        targetVersion: '0.1.2',
+        targetRevision: '2222222222222222222222222222222222222222',
+        consecutiveFailureCount: 2,
+        pausedUntil: '2026-04-11T12:15:00.000Z',
+        lastAttemptAt: '2026-04-11T12:00:00.000Z',
+        lastError: 'git pull failed',
+        alertedAt: '2026-04-11T12:00:10.000Z',
+      }),
+      createdAt: '2026-04-11T12:00:10.000Z',
+      updatedAt: '2026-04-11T12:00:10.000Z',
+    }]
+
+    daemon.autoUpgradeState = {
+      attemptCount: 2,
+      successCount: 0,
+      failureCount: 2,
+      noChangeCount: 0,
+      consecutiveFailureCount: 2,
+      lastAttemptAt: '2026-04-11T12:00:00.000Z',
+      lastSuccessAt: null,
+      lastOutcome: 'failed',
+      lastTargetVersion: '0.1.2',
+      lastTargetRevision: '2222222222222222222222222222222222222222',
+      lastError: 'git pull failed',
+      pausedUntil: '2026-04-11T12:15:00.000Z',
+    }
+
+    await daemon.maybePublishAutoUpgradeFailureAlert({
+      channel: 'master',
+      latestVersion: '0.1.2',
+      latestRevision: '2222222222222222222222222222222222222222',
+    })
+
+    expect(postedBodies).toHaveLength(0)
+
+    daemon.autoUpgradeState = {
+      ...daemon.autoUpgradeState,
+      failureCount: 3,
+      consecutiveFailureCount: 3,
+      lastAttemptAt: '2026-04-11T12:15:10.000Z',
+      pausedUntil: '2026-04-11T12:45:10.000Z',
+    }
+
+    await daemon.maybePublishAutoUpgradeFailureAlert({
+      channel: 'master',
+      latestVersion: '0.1.2',
+      latestRevision: '2222222222222222222222222222222222222222',
+    })
+
+    expect(postedBodies).toHaveLength(1)
+    expect(postedBodies[0]).toContain('"consecutiveFailureCount":3')
+    expect(postedBodies[0]).toContain('"pausedUntil":"2026-04-11T12:45:10.000Z"')
   })
 })
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -91,9 +91,11 @@ import {
 import {
   ManagedDaemonPresencePublisher,
   buildManagedDaemonUpgradeAnnouncementComment,
+  buildManagedDaemonUpgradeFailureAlertComment,
   commentOnIssue as commentOnPresenceIssue,
   ensureManagedDaemonPresenceIssue,
   getLatestManagedDaemonUpgradeAnnouncement,
+  getLatestManagedDaemonUpgradeFailureAlert,
   listIssueComments as listPresenceIssueComments,
   type ManagedDaemonPresenceRuntimeState,
 } from './presence'
@@ -305,6 +307,7 @@ export class AgentDaemon {
   private lastAutoUpgradeAttemptAt: number | null = null
   private lastAutoUpgradeAttemptTarget: string | null = null
   private lastPublishedUpgradeAnnouncementKey: string | null = null
+  private lastPublishedUpgradeFailureAlertKey: string | null = null
   private lastObservedUpgradeAnnouncementKey: string | null = null
   private upgradeAnnouncementCheckPromise: Promise<void> | null = null
 
@@ -3657,6 +3660,67 @@ export class AgentDaemon {
     )
   }
 
+  private async maybePublishAutoUpgradeFailureAlert(
+    upgrade: Pick<AgentLoopUpgradeMetadata, 'channel' | 'latestVersion' | 'latestRevision'>,
+  ): Promise<void> {
+    if (
+      this.autoUpgradeState.lastOutcome !== 'failed'
+      || !this.autoUpgradeState.pausedUntil
+      || this.autoUpgradeState.consecutiveFailureCount < 2
+    ) {
+      return
+    }
+
+    const key = this.getAutoUpgradeFailureAlertKey({
+      channel: upgrade.channel,
+      targetVersion: upgrade.latestVersion,
+      targetRevision: upgrade.latestRevision,
+      consecutiveFailureCount: this.autoUpgradeState.consecutiveFailureCount,
+      pausedUntil: this.autoUpgradeState.pausedUntil,
+    })
+    if (!key || key === this.lastPublishedUpgradeFailureAlertKey) {
+      return
+    }
+
+    const issueNumber = await this.ensurePresenceIssueNumber()
+    const comments = await this.listPresenceRegistryComments(issueNumber)
+    const latest = getLatestManagedDaemonUpgradeFailureAlert(comments, this.config.repo, this.config.machineId)
+    const latestKey = latest
+      ? this.getAutoUpgradeFailureAlertKey({
+          channel: latest.alert.channel,
+          targetVersion: latest.alert.targetVersion,
+          targetRevision: latest.alert.targetRevision,
+          consecutiveFailureCount: latest.alert.consecutiveFailureCount,
+          pausedUntil: latest.alert.pausedUntil,
+        })
+      : null
+    if (latestKey === key) {
+      this.lastPublishedUpgradeFailureAlertKey = key
+      return
+    }
+
+    await this.commentOnPresenceRegistryIssue(
+      issueNumber,
+      buildManagedDaemonUpgradeFailureAlertComment({
+        repo: this.config.repo,
+        machineId: this.config.machineId,
+        daemonInstanceId: this.daemonInstanceId,
+        channel: upgrade.channel,
+        targetVersion: upgrade.latestVersion,
+        targetRevision: upgrade.latestRevision,
+        consecutiveFailureCount: this.autoUpgradeState.consecutiveFailureCount,
+        pausedUntil: this.autoUpgradeState.pausedUntil,
+        lastAttemptAt: this.autoUpgradeState.lastAttemptAt,
+        lastError: this.autoUpgradeState.lastError,
+        alertedAt: new Date().toISOString(),
+      }),
+    )
+    this.lastPublishedUpgradeFailureAlertKey = key
+    this.logger.warn(
+      `[daemon] published agent-loop auto-upgrade failure alert for ${upgrade.channel ?? 'default'} -> v${upgrade.latestVersion ?? 'unknown'}@${abbreviateRevision(upgrade.latestRevision)} after ${this.autoUpgradeState.consecutiveFailureCount} consecutive failures`,
+    )
+  }
+
   private shouldRefreshFromUpgradeAnnouncement(
     announcedAt: string,
     key: string,
@@ -3807,6 +3871,26 @@ export class AgentDaemon {
     return `${input.channel ?? 'default'}:${input.latestVersion ?? 'unknown'}:${input.latestRevision ?? 'unknown'}`
   }
 
+  private getAutoUpgradeFailureAlertKey(input: {
+    channel: string | null
+    targetVersion: string | null
+    targetRevision: string | null
+    consecutiveFailureCount: number
+    pausedUntil: string | null
+  }): string | null {
+    if (!input.targetVersion && !input.targetRevision) {
+      return null
+    }
+
+    return [
+      input.channel ?? 'default',
+      input.targetVersion ?? 'unknown',
+      input.targetRevision ?? 'unknown',
+      String(input.consecutiveFailureCount),
+      input.pausedUntil ?? 'none',
+    ].join(':')
+  }
+
   private assertDetachedUpgradeRestartReady(): void {
     if (!process.env.AGENT_LOOP_RUNTIME_FILE || !process.env.AGENT_LOOP_LOG_FILE || !process.argv[1]) {
       throw new Error('managed detached auto-upgrade restart requires runtime file, log path, and script path')
@@ -3921,7 +4005,7 @@ export class AgentDaemon {
 
   private noteAutoUpgradeAttemptCompleted(
     outcome: 'succeeded' | 'failed' | 'no_change',
-    upgrade: Pick<AgentLoopUpgradeMetadata, 'latestVersion' | 'latestRevision'>,
+    upgrade: Pick<AgentLoopUpgradeMetadata, 'channel' | 'latestVersion' | 'latestRevision'>,
     error?: string,
   ): void {
     const completedAt = new Date().toISOString()
@@ -3946,6 +4030,11 @@ export class AgentDaemon {
       }),
     )
     this.syncRuntimeMetrics()
+    if (outcome === 'failed') {
+      void this.maybePublishAutoUpgradeFailureAlert(upgrade).catch((publishError) => {
+        this.logger.warn(`[daemon] failed to publish agent-loop auto-upgrade failure alert: ${formatDaemonError(publishError)}`)
+      })
+    }
   }
 
   private getOldestLeaseHeartbeatAgeSeconds(): number {

--- a/apps/agent-daemon/src/dashboard.test.ts
+++ b/apps/agent-daemon/src/dashboard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   buildDashboardMachineCards,
   buildDashboardSummary,
+  buildDashboardUpgradeFailureAlertMessages,
   type DashboardIssueView,
   type DashboardLeaseView,
   type DashboardLocalMachineSnapshot,
@@ -10,6 +11,7 @@ import {
   renderDashboardAppScript,
   renderDashboardHtml,
 } from './dashboard'
+import type { ManagedDaemonUpgradeFailureAlertComment } from './presence'
 
 function buildLease(overrides: Partial<DashboardLeaseView> = {}): DashboardLeaseView {
   return {
@@ -388,6 +390,61 @@ describe('dashboard machine aggregation', () => {
     expect(machines.find((machine) => machine.machineId === 'machine-error')?.warnings).toContain(
       'agent-loop upgrade check is failing on machine-error: agent-loop upgrade repo could not be resolved; inspect this daemon before relying on auto-upgrade',
     )
+  })
+
+  test('formats active GitHub upgrade failure alerts confirmed by current presence state', () => {
+    const alerts: ManagedDaemonUpgradeFailureAlertComment[] = [
+      {
+        commentId: 501,
+        body: 'ignored',
+        createdAt: '2026-04-05T09:10:21.000Z',
+        updatedAt: '2026-04-05T09:10:21.000Z',
+        alert: {
+          repo: 'JamesWuHK/digital-employee',
+          machineId: 'machine-busy',
+          daemonInstanceId: 'daemon-busy',
+          channel: 'master',
+          targetVersion: '0.1.2',
+          targetRevision: 'fedcba9876543210',
+          consecutiveFailureCount: 2,
+          pausedUntil: '2026-04-05T09:25:20.000Z',
+          lastAttemptAt: '2026-04-05T09:10:20.000Z',
+          lastError: 'git pull failed',
+          alertedAt: '2026-04-05T09:10:21.000Z',
+        },
+      },
+    ]
+
+    const messages = buildDashboardUpgradeFailureAlertMessages(
+      alerts,
+      [
+        buildPresence({
+          machineId: 'machine-busy',
+          daemonInstanceId: 'daemon-busy',
+          latestVersion: '0.1.2',
+          latestRevision: 'fedcba9876543210',
+          autoUpgrade: {
+            attemptCount: 2,
+            successCount: 0,
+            failureCount: 2,
+            noChangeCount: 0,
+            consecutiveFailureCount: 2,
+            lastAttemptAt: '2026-04-05T09:10:20.000Z',
+            lastSuccessAt: null,
+            lastOutcome: 'failed',
+            lastTargetVersion: '0.1.2',
+            lastTargetRevision: 'fedcba9876543210',
+            lastError: 'git pull failed',
+            pausedUntil: '2026-04-05T09:25:20.000Z',
+          },
+        }),
+      ],
+      Date.parse('2026-04-05T09:11:00.000Z'),
+    )
+
+    expect(messages).toEqual([
+      'GitHub 升级告警：machine-busy 自动升级连续失败 2 次，暂停到 2026-04-05T09:25:20.000Z，最近错误：git pull failed',
+    ])
   })
 })
 

--- a/apps/agent-daemon/src/dashboard.ts
+++ b/apps/agent-daemon/src/dashboard.ts
@@ -27,7 +27,9 @@ import {
 } from './background'
 import {
   listActiveManagedDaemonPresence,
+  listActiveManagedDaemonUpgradeFailureAlerts,
   type ManagedDaemonPresenceComment,
+  type ManagedDaemonUpgradeFailureAlertComment,
 } from './presence'
 
 export const DEFAULT_DASHBOARD_HOST = '127.0.0.1'
@@ -284,6 +286,20 @@ export async function collectDashboardSnapshot(
     errors.push(`GitHub presence 不可用：${formatError(error)}`)
   }
 
+  try {
+    const alerts = await listActiveManagedDaemonUpgradeFailureAlerts({
+      ...options.config,
+      repo,
+    })
+    errors.push(...buildDashboardUpgradeFailureAlertMessages(
+      alerts,
+      remotePresences,
+      Date.parse(generatedAt),
+    ))
+  } catch (error) {
+    errors.push(`GitHub 升级告警不可用：${formatError(error)}`)
+  }
+
   const machines = buildDashboardMachineCards(localSnapshots, remoteLeases, remotePresences)
 
   return {
@@ -430,6 +446,45 @@ export function buildDashboardSummary(
     upgradeErrorMachineCount,
     upgradeFailedMachineCount,
   }
+}
+
+export function buildDashboardUpgradeFailureAlertMessages(
+  alerts: ManagedDaemonUpgradeFailureAlertComment[],
+  presences: DashboardPresenceView[],
+  now = Date.now(),
+): string[] {
+  const presenceByMachine = new Map<string, DashboardPresenceView>()
+  for (const presence of presences) {
+    const current = presenceByMachine.get(presence.machineId)
+    if (!current || (presence.heartbeatAgeSeconds ?? Number.POSITIVE_INFINITY) <= (current.heartbeatAgeSeconds ?? Number.POSITIVE_INFINITY)) {
+      presenceByMachine.set(presence.machineId, presence)
+    }
+  }
+
+  const messages: string[] = []
+  for (const comment of alerts) {
+    const pausedUntilMs = Date.parse(comment.alert.pausedUntil ?? '')
+    if (!Number.isFinite(pausedUntilMs) || pausedUntilMs <= now) {
+      continue
+    }
+
+    const presence = presenceByMachine.get(comment.alert.machineId)
+    const confirmedActive = !presence || (
+      presence.autoUpgrade?.lastOutcome === 'failed'
+      && presence.autoUpgrade?.pausedUntil === comment.alert.pausedUntil
+      && presence.autoUpgrade?.lastTargetVersion === comment.alert.targetVersion
+      && presence.autoUpgrade?.lastTargetRevision === comment.alert.targetRevision
+    )
+    if (!confirmedActive) {
+      continue
+    }
+
+    messages.push(
+      `GitHub 升级告警：${comment.alert.machineId} 自动升级连续失败 ${comment.alert.consecutiveFailureCount} 次，暂停到 ${comment.alert.pausedUntil}${comment.alert.lastError ? `，最近错误：${comment.alert.lastError}` : ''}`,
+    )
+  }
+
+  return [...new Set(messages)]
 }
 
 export function readDashboardLog(

--- a/apps/agent-daemon/src/presence.test.ts
+++ b/apps/agent-daemon/src/presence.test.ts
@@ -3,11 +3,15 @@ import type { AgentConfig, IssueComment } from '@agent/shared'
 import {
   buildManagedDaemonPresenceComment,
   buildManagedDaemonUpgradeAnnouncementComment,
+  buildManagedDaemonUpgradeFailureAlertComment,
   extractManagedDaemonPresenceIssueNumber,
   extractManagedDaemonPresenceComment,
   extractManagedDaemonUpgradeAnnouncementComment,
+  extractManagedDaemonUpgradeFailureAlertComment,
   getLatestManagedDaemonUpgradeAnnouncement,
+  getLatestManagedDaemonUpgradeFailureAlert,
   listActiveManagedDaemonPresenceComments,
+  listActiveManagedDaemonUpgradeFailureAlertComments,
   ManagedDaemonPresencePublisher,
   type ManagedDaemonPresence,
   type PresenceApiAdapter,
@@ -202,6 +206,50 @@ describe('managed daemon presence helpers', () => {
     ], TEST_CONFIG.repo)
 
     expect(latest?.announcement.latestRevision).toBe(newer.latestRevision)
+  })
+
+  test('round-trips managed daemon upgrade failure alerts and filters active latest comments', () => {
+    const older = {
+      repo: TEST_CONFIG.repo,
+      machineId: 'machine-a',
+      daemonInstanceId: 'daemon-a',
+      channel: 'master',
+      targetVersion: '0.1.2',
+      targetRevision: '2222222222222222222222222222222222222222',
+      consecutiveFailureCount: 2,
+      pausedUntil: '2026-04-11T09:20:00.000Z',
+      lastAttemptAt: '2026-04-11T09:00:10.000Z',
+      lastError: 'git pull failed',
+      alertedAt: '2026-04-11T09:00:20.000Z',
+    }
+    const newer = {
+      ...older,
+      consecutiveFailureCount: 3,
+      pausedUntil: '2026-04-11T10:00:00.000Z',
+      alertedAt: '2026-04-11T09:30:20.000Z',
+    }
+
+    expect(extractManagedDaemonUpgradeFailureAlertComment(
+      buildManagedDaemonUpgradeFailureAlertComment(newer),
+    )).toEqual(newer)
+
+    const comments = [
+      {
+        commentId: 21,
+        body: buildManagedDaemonUpgradeFailureAlertComment(older),
+        createdAt: older.alertedAt,
+        updatedAt: older.alertedAt,
+      },
+      {
+        commentId: 22,
+        body: buildManagedDaemonUpgradeFailureAlertComment(newer),
+        createdAt: newer.alertedAt,
+        updatedAt: newer.alertedAt,
+      },
+    ]
+
+    expect(getLatestManagedDaemonUpgradeFailureAlert(comments, TEST_CONFIG.repo, 'machine-a')?.alert.pausedUntil).toBe(newer.pausedUntil)
+    expect(listActiveManagedDaemonUpgradeFailureAlertComments(comments, TEST_CONFIG.repo, Date.parse('2026-04-11T09:40:00.000Z'))).toHaveLength(1)
   })
 
   test('filters active managed daemon presence comments by repo and expiry', () => {

--- a/apps/agent-daemon/src/presence.ts
+++ b/apps/agent-daemon/src/presence.ts
@@ -16,6 +16,7 @@ const MANAGED_DAEMON_PRESENCE_ISSUE_TITLE = 'Agent Loop Presence'
 const MANAGED_DAEMON_PRESENCE_ISSUE_MARKER = '<!-- agent-loop:presence-registry -->'
 const MANAGED_DAEMON_PRESENCE_COMMENT_PREFIX = '<!-- agent-loop:presence '
 const MANAGED_DAEMON_UPGRADE_ANNOUNCEMENT_COMMENT_PREFIX = '<!-- agent-loop:upgrade-announcement '
+const MANAGED_DAEMON_UPGRADE_FAILURE_ALERT_COMMENT_PREFIX = '<!-- agent-loop:upgrade-failure-alert '
 const GITHUB_REST_TIMEOUT_MS = 180_000
 
 export type ManagedDaemonPresenceStatus = 'idle' | 'busy' | 'stopped'
@@ -78,6 +79,24 @@ export interface ManagedDaemonUpgradeAnnouncement {
 
 export interface ManagedDaemonUpgradeAnnouncementComment extends IssueComment {
   announcement: ManagedDaemonUpgradeAnnouncement
+}
+
+export interface ManagedDaemonUpgradeFailureAlert {
+  repo: string
+  machineId: string
+  daemonInstanceId: string
+  channel: string | null
+  targetVersion: string | null
+  targetRevision: string | null
+  consecutiveFailureCount: number
+  pausedUntil: string | null
+  lastAttemptAt: string | null
+  lastError: string | null
+  alertedAt: string
+}
+
+export interface ManagedDaemonUpgradeFailureAlertComment extends IssueComment {
+  alert: ManagedDaemonUpgradeFailureAlert
 }
 
 export interface PresenceApiAdapter {
@@ -367,6 +386,27 @@ A managed daemon detected a newer agent-loop build and is broadcasting it to oth
 - Announced by: ${announcement.announcedByMachineId} (${announcement.announcedByDaemonInstanceId})`
 }
 
+export function buildManagedDaemonUpgradeFailureAlertComment(
+  alert: ManagedDaemonUpgradeFailureAlert,
+): string {
+  return `${MANAGED_DAEMON_UPGRADE_FAILURE_ALERT_COMMENT_PREFIX}${JSON.stringify(alert)} -->
+## Agent Loop auto-upgrade failure alert
+
+A managed daemon is backing off repeated self-upgrade retries after consecutive failures.
+
+- Repo: ${alert.repo}
+- Machine: ${alert.machineId}
+- Daemon: ${alert.daemonInstanceId}
+- Channel: ${alert.channel ?? 'default'}
+- Target version: ${alert.targetVersion ?? 'unknown'}
+- Target revision: ${alert.targetRevision ?? 'unknown'}
+- Consecutive failures: ${alert.consecutiveFailureCount}
+- Paused until: ${alert.pausedUntil ?? 'none'}
+- Last attempt: ${alert.lastAttemptAt ?? 'never'}
+- Last error: ${alert.lastError ?? 'none'}
+- Alerted at: ${alert.alertedAt}`
+}
+
 export function extractManagedDaemonPresenceComment(body: string): ManagedDaemonPresence | null {
   const match = body.match(/<!-- agent-loop:presence (\{.*\}) -->/)
   if (!match?.[1]) return null
@@ -516,6 +556,36 @@ export function extractManagedDaemonUpgradeAnnouncementComment(
   }
 }
 
+export function extractManagedDaemonUpgradeFailureAlertComment(
+  body: string,
+): ManagedDaemonUpgradeFailureAlert | null {
+  const match = body.match(/<!-- agent-loop:upgrade-failure-alert (\{.*\}) -->/)
+  if (!match?.[1]) return null
+
+  try {
+    const parsed = JSON.parse(match[1]) as Partial<ManagedDaemonUpgradeFailureAlert>
+    if (!parsed || typeof parsed !== 'object') return null
+    if (typeof parsed.repo !== 'string' || typeof parsed.machineId !== 'string' || typeof parsed.daemonInstanceId !== 'string') return null
+    if (typeof parsed.alertedAt !== 'string') return null
+
+    return {
+      repo: parsed.repo,
+      machineId: parsed.machineId,
+      daemonInstanceId: parsed.daemonInstanceId,
+      channel: typeof parsed.channel === 'string' && parsed.channel.trim().length > 0 ? parsed.channel : null,
+      targetVersion: typeof parsed.targetVersion === 'string' && parsed.targetVersion.trim().length > 0 ? parsed.targetVersion : null,
+      targetRevision: typeof parsed.targetRevision === 'string' && parsed.targetRevision.trim().length > 0 ? parsed.targetRevision : null,
+      consecutiveFailureCount: normalizeNonNegativeInteger(parsed.consecutiveFailureCount),
+      pausedUntil: typeof parsed.pausedUntil === 'string' && parsed.pausedUntil.trim().length > 0 ? parsed.pausedUntil : null,
+      lastAttemptAt: typeof parsed.lastAttemptAt === 'string' && parsed.lastAttemptAt.trim().length > 0 ? parsed.lastAttemptAt : null,
+      lastError: typeof parsed.lastError === 'string' && parsed.lastError.trim().length > 0 ? parsed.lastError : null,
+      alertedAt: parsed.alertedAt,
+    }
+  } catch {
+    return null
+  }
+}
+
 export function parseManagedDaemonPresenceComments(
   comments: IssueComment[],
 ): ManagedDaemonPresenceComment[] {
@@ -547,6 +617,22 @@ export function parseManagedDaemonUpgradeAnnouncementComments(
     .filter((comment): comment is ManagedDaemonUpgradeAnnouncementComment => comment !== null)
 }
 
+export function parseManagedDaemonUpgradeFailureAlertComments(
+  comments: IssueComment[],
+): ManagedDaemonUpgradeFailureAlertComment[] {
+  return comments
+    .map((comment) => {
+      const alert = extractManagedDaemonUpgradeFailureAlertComment(comment.body)
+      if (!alert) return null
+
+      return {
+        ...comment,
+        alert,
+      } satisfies ManagedDaemonUpgradeFailureAlertComment
+    })
+    .filter((comment): comment is ManagedDaemonUpgradeFailureAlertComment => comment !== null)
+}
+
 export function getLatestManagedDaemonUpgradeAnnouncement(
   comments: IssueComment[],
   repo: string,
@@ -558,6 +644,47 @@ export function getLatestManagedDaemonUpgradeAnnouncement(
       if (announcedDiff !== 0) return announcedDiff
       return right.commentId - left.commentId
     })[0] ?? null
+}
+
+export function getLatestManagedDaemonUpgradeFailureAlert(
+  comments: IssueComment[],
+  repo: string,
+  machineId: string,
+): ManagedDaemonUpgradeFailureAlertComment | null {
+  return parseManagedDaemonUpgradeFailureAlertComments(comments)
+    .filter((comment) => comment.alert.repo === repo && comment.alert.machineId === machineId)
+    .sort((left, right) => {
+      const alertedDiff = Date.parse(right.alert.alertedAt) - Date.parse(left.alert.alertedAt)
+      if (alertedDiff !== 0) return alertedDiff
+      return right.commentId - left.commentId
+    })[0] ?? null
+}
+
+export function listActiveManagedDaemonUpgradeFailureAlertComments(
+  comments: IssueComment[],
+  repo: string,
+  now = Date.now(),
+): ManagedDaemonUpgradeFailureAlertComment[] {
+  const deduped = new Map<string, ManagedDaemonUpgradeFailureAlertComment>()
+  const matches = parseManagedDaemonUpgradeFailureAlertComments(comments)
+    .filter((comment) => comment.alert.repo === repo)
+    .filter((comment) => {
+      const pausedUntil = Date.parse(comment.alert.pausedUntil ?? '')
+      return Number.isFinite(pausedUntil) && pausedUntil > now
+    })
+    .sort((left, right) => {
+      const alertedDiff = Date.parse(right.alert.alertedAt) - Date.parse(left.alert.alertedAt)
+      if (alertedDiff !== 0) return alertedDiff
+      return right.commentId - left.commentId
+    })
+
+  for (const comment of matches) {
+    if (!deduped.has(comment.alert.machineId)) {
+      deduped.set(comment.alert.machineId, comment)
+    }
+  }
+
+  return [...deduped.values()]
 }
 
 export function isManagedDaemonPresenceExpired(
@@ -738,6 +865,17 @@ export async function listActiveManagedDaemonPresence(
   if (issueNumber === null) return []
   const comments = await api.listIssueComments(issueNumber, config)
   return listActiveManagedDaemonPresenceComments(comments, config.repo, now)
+}
+
+export async function listActiveManagedDaemonUpgradeFailureAlerts(
+  config: AgentConfig,
+  now = Date.now(),
+  api: PresenceApiAdapter = defaultPresenceApi,
+): Promise<ManagedDaemonUpgradeFailureAlertComment[]> {
+  const issueNumber = await findManagedDaemonPresenceIssue(config)
+  if (issueNumber === null) return []
+  const comments = await api.listIssueComments(issueNumber, config)
+  return listActiveManagedDaemonUpgradeFailureAlertComments(comments, config.repo, now)
 }
 
 export class ManagedDaemonPresencePublisher {


### PR DESCRIPTION
## Summary
- publish a structured presence-registry alert comment when automatic self-upgrade enters repeated-failure backoff
- dedupe failure alerts per machine and target pause window to avoid comment spam
- surface active GitHub upgrade alerts in the dashboard global alerts area

## Testing
- bun test apps/agent-daemon/src/presence.test.ts apps/agent-daemon/src/dashboard.test.ts apps/agent-daemon/src/daemon.test.ts
- bun run typecheck