### PR TITLE
feat: show upgrade rollout completion in dashboard

### DIFF
--- a/apps/agent-daemon/src/dashboard.test.ts
+++ b/apps/agent-daemon/src/dashboard.test.ts
@@ -274,9 +274,11 @@ describe('dashboard machine aggregation', () => {
       failedIssueCount: 1,
       openPrCount: 1,
       upgradePendingMachineCount: 0,
+      upgradeCurrentMachineCount: 0,
       upgradeReadyMachineCount: 0,
       upgradeBlockedMachineCount: 0,
       upgradeManualMachineCount: 0,
+      upgradeAheadMachineCount: 0,
       upgradeErrorMachineCount: 0,
       upgradeFailedMachineCount: 0,
     })
@@ -368,9 +370,11 @@ describe('dashboard machine aggregation', () => {
       failedIssueCount: 0,
       openPrCount: 0,
       upgradePendingMachineCount: 3,
+      upgradeCurrentMachineCount: 0,
       upgradeReadyMachineCount: 1,
       upgradeBlockedMachineCount: 1,
       upgradeManualMachineCount: 1,
+      upgradeAheadMachineCount: 0,
       upgradeErrorMachineCount: 1,
       upgradeFailedMachineCount: 1,
     })
@@ -389,6 +393,52 @@ describe('dashboard machine aggregation', () => {
     )
     expect(machines.find((machine) => machine.machineId === 'machine-error')?.warnings).toContain(
       'agent-loop upgrade check is failing on machine-error: agent-loop upgrade repo could not be resolved; inspect this daemon before relying on auto-upgrade',
+    )
+  })
+
+  test('counts machines already upgraded or ahead of the tracked channel', () => {
+    const machines = buildDashboardMachineCards(
+      [],
+      [],
+      [
+        buildPresence({
+          machineId: 'machine-current',
+          daemonInstanceId: 'daemon-current',
+          upgradeStatus: 'up-to-date',
+          latestVersion: '0.1.2',
+          latestRevision: '2222222222222222222222222222222222222222',
+        }),
+        buildPresence({
+          machineId: 'machine-ahead',
+          daemonInstanceId: 'daemon-ahead',
+          upgradeStatus: 'ahead-of-channel',
+          latestVersion: '0.1.2',
+          latestRevision: '2222222222222222222222222222222222222222',
+        }),
+      ],
+    )
+
+    expect(buildDashboardSummary(machines, [], [])).toEqual({
+      machineCount: 2,
+      localRuntimeCount: 0,
+      managedPresenceCount: 2,
+      activeLeaseCount: 0,
+      readyIssueCount: 0,
+      workingIssueCount: 0,
+      failedIssueCount: 0,
+      openPrCount: 0,
+      upgradePendingMachineCount: 0,
+      upgradeCurrentMachineCount: 1,
+      upgradeReadyMachineCount: 0,
+      upgradeBlockedMachineCount: 0,
+      upgradeManualMachineCount: 0,
+      upgradeAheadMachineCount: 1,
+      upgradeErrorMachineCount: 0,
+      upgradeFailedMachineCount: 0,
+    })
+
+    expect(machines.find((machine) => machine.machineId === 'machine-ahead')?.warnings).toContain(
+      'agent-loop build on machine-ahead is ahead of the tracked channel; verify this machine is pinned intentionally',
     )
   })
 
@@ -464,9 +514,13 @@ describe('dashboard localization', () => {
     expect(script).toContain('未发现本仓库的本地受管 daemon 运行时。')
     expect(script).toContain('机器数')
     expect(script).toContain('待升级机器')
+    expect(script).toContain('已升级最新')
     expect(script).toContain('可立刻升级')
+    expect(script).toContain('超前 Channel')
     expect(script).toContain('升级执行失败')
     expect(script).toContain('手动升级机器')
+    expect(script).toContain('已是最新')
+    expect(script).toContain('可升级')
     expect(script).toContain('本地运行时')
     expect(script).toContain('可认领')
     expect(script).toContain('阻塞原因')

--- a/apps/agent-daemon/src/dashboard.ts
+++ b/apps/agent-daemon/src/dashboard.ts
@@ -50,9 +50,11 @@ export interface DashboardSummary {
   failedIssueCount: number
   openPrCount: number
   upgradePendingMachineCount: number
+  upgradeCurrentMachineCount: number
   upgradeReadyMachineCount: number
   upgradeBlockedMachineCount: number
   upgradeManualMachineCount: number
+  upgradeAheadMachineCount: number
   upgradeErrorMachineCount: number
   upgradeFailedMachineCount: number
 }
@@ -397,9 +399,11 @@ export function buildDashboardSummary(
   let localRuntimeCount = 0
   let managedPresenceCount = 0
   let upgradePendingMachineCount = 0
+  let upgradeCurrentMachineCount = 0
   let upgradeReadyMachineCount = 0
   let upgradeBlockedMachineCount = 0
   let upgradeManualMachineCount = 0
+  let upgradeAheadMachineCount = 0
   let upgradeErrorMachineCount = 0
   let upgradeFailedMachineCount = 0
 
@@ -411,6 +415,9 @@ export function buildDashboardSummary(
 
     if (machine.presence) {
       managedPresenceCount += 1
+      if (machine.presence.upgradeStatus === 'up-to-date') {
+        upgradeCurrentMachineCount += 1
+      }
       if (machine.presence.upgradeStatus === 'upgrade-available') {
         upgradePendingMachineCount += 1
         if (!machine.presence.upgradeAutoApplyEnabled) {
@@ -423,6 +430,9 @@ export function buildDashboardSummary(
       }
       if (machine.presence.upgradeStatus === 'error') {
         upgradeErrorMachineCount += 1
+      }
+      if (machine.presence.upgradeStatus === 'ahead-of-channel') {
+        upgradeAheadMachineCount += 1
       }
       if (machine.presence.autoUpgrade?.lastOutcome === 'failed') {
         upgradeFailedMachineCount += 1
@@ -440,9 +450,11 @@ export function buildDashboardSummary(
     failedIssueCount: issues.filter((issue) => issue.state === 'failed').length,
     openPrCount: prs.length,
     upgradePendingMachineCount,
+    upgradeCurrentMachineCount,
     upgradeReadyMachineCount,
     upgradeBlockedMachineCount,
     upgradeManualMachineCount,
+    upgradeAheadMachineCount,
     upgradeErrorMachineCount,
     upgradeFailedMachineCount,
   }
@@ -1791,9 +1803,11 @@ function renderSummary(snapshot) {
     { label: '受管心跳', value: snapshot.summary.managedPresenceCount, tone: snapshot.summary.managedPresenceCount > 0 ? 'accent' : '' },
     { label: '活跃租约', value: snapshot.summary.activeLeaseCount, tone: 'gold' },
     { label: '待升级机器', value: snapshot.summary.upgradePendingMachineCount, tone: snapshot.summary.upgradePendingMachineCount > 0 ? 'gold' : '' },
+    { label: '已升级最新', value: snapshot.summary.upgradeCurrentMachineCount, tone: snapshot.summary.upgradeCurrentMachineCount > 0 ? 'accent' : '' },
     { label: '可立刻升级', value: snapshot.summary.upgradeReadyMachineCount, tone: snapshot.summary.upgradeReadyMachineCount > 0 ? 'accent' : '' },
     { label: '升级被阻塞', value: snapshot.summary.upgradeBlockedMachineCount, tone: snapshot.summary.upgradeBlockedMachineCount > 0 ? 'gold' : '' },
     { label: '手动升级机器', value: snapshot.summary.upgradeManualMachineCount, tone: snapshot.summary.upgradeManualMachineCount > 0 ? 'gold' : '' },
+    { label: '超前 Channel', value: snapshot.summary.upgradeAheadMachineCount, tone: snapshot.summary.upgradeAheadMachineCount > 0 ? 'gold' : '' },
     { label: '升级检查错误', value: snapshot.summary.upgradeErrorMachineCount, tone: snapshot.summary.upgradeErrorMachineCount > 0 ? 'error' : '' },
     { label: '升级执行失败', value: snapshot.summary.upgradeFailedMachineCount, tone: snapshot.summary.upgradeFailedMachineCount > 0 ? 'error' : '' },
     { label: '就绪 Issue', value: snapshot.summary.readyIssueCount, tone: '' },
@@ -2035,7 +2049,7 @@ function renderPresenceItem(presence) {
     renderChip(localizePresenceStatus(presence.status), presence.status === 'busy' ? 'accent' : 'gold'),
     renderChip(shortDaemonId(presence.daemonInstanceId), ''),
     renderChip('v' + presence.agentLoopVersion, ''),
-    renderChip(presence.upgradeStatus, presence.upgradeStatus === 'upgrade-available' ? 'danger' : ''),
+    renderChip(localizeUpgradeStatus(presence.upgradeStatus), presence.upgradeStatus === 'upgrade-available' ? 'danger' : ''),
     autoUpgradeOutcome ? renderChip('自动升级' + autoUpgradeOutcome, autoUpgradeOutcomeTone) : '',
     renderChip(presence.upgradeAutoApplyEnabled ? '自动升级开' : '自动升级关', presence.upgradeAutoApplyEnabled ? 'accent' : 'gold'),
     renderChip('工作树 ' + presence.activeWorktreeCount, ''),
@@ -2145,6 +2159,25 @@ function localizeAutoUpgradeOutcome(outcome) {
       return '无变化'
     default:
       return outcome || '未知'
+  }
+}
+
+function localizeUpgradeStatus(status) {
+  switch (status) {
+    case 'disabled':
+      return '已禁用'
+    case 'unknown':
+      return '未知'
+    case 'up-to-date':
+      return '已是最新'
+    case 'upgrade-available':
+      return '可升级'
+    case 'ahead-of-channel':
+      return '超前 channel'
+    case 'error':
+      return '检查失败'
+    default:
+      return status || '未知'
   }
 }
 


### PR DESCRIPTION
## Summary
- add dashboard summary counts for machines already up to date and machines ahead of the tracked channel
- localize per-machine upgrade status chips so rollout state reads cleanly in the Chinese dashboard
- cover rollout completion summary cases in dashboard tests

## Testing
- bun test apps/agent-daemon/src/dashboard.test.ts
- bun run typecheck