### PR TITLE
feat: publish upgrade success acknowledgements after restart

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -49,6 +49,7 @@ import { ISSUE_LABELS, PR_REVIEW_LABELS } from '@agent/shared'
 import {
   buildManagedDaemonUpgradeAnnouncementComment,
   buildManagedDaemonUpgradeFailureAlertComment,
+  buildManagedDaemonUpgradeSuccessComment,
 } from './presence'
 import { getMetrics, registry } from './metrics'
 import { appendWakeRequest, buildWakeQueuePath } from './wake-queue'
@@ -842,6 +843,74 @@ describe('agent-loop upgrade coordination', () => {
     expect(postedBodies).toHaveLength(1)
     expect(postedBodies[0]).toContain('"consecutiveFailureCount":3')
     expect(postedBodies[0]).toContain('"pausedUntil":"2026-04-11T12:45:10.000Z"')
+  })
+
+  test('publishes a deduplicated GitHub success acknowledgement after an auto-upgrade restart', async () => {
+    const daemon = createTestDaemon({
+      upgrade: {
+        enabled: true,
+        repo: 'JamesWuHK/agent-loop',
+        channel: 'master',
+        checkIntervalMs: 60_000,
+        reminderIntervalMs: 3_600_000,
+        autoApply: true,
+      },
+    }) as any
+
+    const postedBodies: string[] = []
+    const currentVersion = daemon.agentLoopBuild.version
+    const currentRevision = daemon.agentLoopBuild.revision
+
+    daemon.ensurePresenceIssueNumber = async () => 500
+    daemon.commentOnPresenceRegistryIssue = async (_issueNumber: number, body: string) => {
+      postedBodies.push(body)
+    }
+    daemon.listPresenceRegistryComments = async () => [{
+      commentId: 28,
+      body: buildManagedDaemonUpgradeSuccessComment({
+        repo: 'JamesWuHK/digital-employee',
+        machineId: 'codex-dev',
+        daemonInstanceId: 'daemon-codex-dev-older',
+        channel: 'master',
+        targetVersion: currentVersion,
+        targetRevision: currentRevision,
+        succeededAt: '2026-04-11T12:00:20.000Z',
+        acknowledgedAt: '2026-04-11T12:00:30.000Z',
+      }),
+      createdAt: '2026-04-11T12:00:30.000Z',
+      updatedAt: '2026-04-11T12:00:30.000Z',
+    }]
+
+    daemon.autoUpgradeState = {
+      attemptCount: 2,
+      successCount: 1,
+      failureCount: 1,
+      noChangeCount: 0,
+      consecutiveFailureCount: 0,
+      lastAttemptAt: '2026-04-11T12:00:10.000Z',
+      lastSuccessAt: '2026-04-11T12:00:20.000Z',
+      lastOutcome: 'succeeded',
+      lastTargetVersion: currentVersion,
+      lastTargetRevision: currentRevision,
+      lastError: null,
+      pausedUntil: null,
+    }
+
+    await daemon.maybePublishAutoUpgradeSuccessAcknowledgement()
+
+    expect(postedBodies).toHaveLength(0)
+
+    daemon.autoUpgradeState = {
+      ...daemon.autoUpgradeState,
+      lastSuccessAt: '2026-04-11T12:30:20.000Z',
+    }
+
+    await daemon.maybePublishAutoUpgradeSuccessAcknowledgement()
+
+    expect(postedBodies).toHaveLength(1)
+    expect(postedBodies[0]).toContain(`"targetVersion":"${currentVersion}"`)
+    expect(postedBodies[0]).toContain(`"targetRevision":"${currentRevision}"`)
+    expect(postedBodies[0]).toContain('"succeededAt":"2026-04-11T12:30:20.000Z"')
   })
 })
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -92,10 +92,12 @@ import {
   ManagedDaemonPresencePublisher,
   buildManagedDaemonUpgradeAnnouncementComment,
   buildManagedDaemonUpgradeFailureAlertComment,
+  buildManagedDaemonUpgradeSuccessComment,
   commentOnIssue as commentOnPresenceIssue,
   ensureManagedDaemonPresenceIssue,
   getLatestManagedDaemonUpgradeAnnouncement,
   getLatestManagedDaemonUpgradeFailureAlert,
+  getLatestManagedDaemonUpgradeSuccess,
   listIssueComments as listPresenceIssueComments,
   type ManagedDaemonPresenceRuntimeState,
 } from './presence'
@@ -308,6 +310,7 @@ export class AgentDaemon {
   private lastAutoUpgradeAttemptTarget: string | null = null
   private lastPublishedUpgradeAnnouncementKey: string | null = null
   private lastPublishedUpgradeFailureAlertKey: string | null = null
+  private lastPublishedUpgradeSuccessKey: string | null = null
   private lastObservedUpgradeAnnouncementKey: string | null = null
   private upgradeAnnouncementCheckPromise: Promise<void> | null = null
 
@@ -858,6 +861,10 @@ export class AgentDaemon {
     } catch (error) {
       this.logger.warn(`[daemon] failed to start GitHub presence heartbeat: ${formatDaemonError(error)}`)
     }
+
+    void this.maybePublishAutoUpgradeSuccessAcknowledgement().catch((error) => {
+      this.logger.warn(`[daemon] failed to publish agent-loop auto-upgrade success acknowledgement: ${formatDaemonError(error)}`)
+    })
 
     void this.maybeRefreshAgentLoopUpgradeStatus(true)
     void this.maybeProcessRemoteUpgradeAnnouncement()
@@ -3722,6 +3729,61 @@ export class AgentDaemon {
     )
   }
 
+  private async maybePublishAutoUpgradeSuccessAcknowledgement(): Promise<void> {
+    if (
+      this.autoUpgradeState.lastOutcome !== 'succeeded'
+      || !this.autoUpgradeState.lastSuccessAt
+      || !this.didLastAutoUpgradeReachCurrentBuild()
+    ) {
+      return
+    }
+
+    const policy = resolveAgentLoopUpgradePolicy(this.config, this.agentLoopBuild)
+    const key = this.getAutoUpgradeSuccessAcknowledgementKey({
+      channel: policy.channel,
+      targetVersion: this.autoUpgradeState.lastTargetVersion,
+      targetRevision: this.autoUpgradeState.lastTargetRevision,
+      succeededAt: this.autoUpgradeState.lastSuccessAt,
+    })
+    if (!key || key === this.lastPublishedUpgradeSuccessKey) {
+      return
+    }
+
+    const issueNumber = await this.ensurePresenceIssueNumber()
+    const comments = await this.listPresenceRegistryComments(issueNumber)
+    const latest = getLatestManagedDaemonUpgradeSuccess(comments, this.config.repo, this.config.machineId)
+    const latestKey = latest
+      ? this.getAutoUpgradeSuccessAcknowledgementKey({
+          channel: latest.success.channel,
+          targetVersion: latest.success.targetVersion,
+          targetRevision: latest.success.targetRevision,
+          succeededAt: latest.success.succeededAt,
+        })
+      : null
+    if (latestKey === key) {
+      this.lastPublishedUpgradeSuccessKey = key
+      return
+    }
+
+    await this.commentOnPresenceRegistryIssue(
+      issueNumber,
+      buildManagedDaemonUpgradeSuccessComment({
+        repo: this.config.repo,
+        machineId: this.config.machineId,
+        daemonInstanceId: this.daemonInstanceId,
+        channel: policy.channel,
+        targetVersion: this.autoUpgradeState.lastTargetVersion,
+        targetRevision: this.autoUpgradeState.lastTargetRevision,
+        succeededAt: this.autoUpgradeState.lastSuccessAt,
+        acknowledgedAt: new Date().toISOString(),
+      }),
+    )
+    this.lastPublishedUpgradeSuccessKey = key
+    this.logger.log(
+      `[daemon] published agent-loop auto-upgrade success acknowledgement for ${policy.channel ?? 'default'} -> v${this.autoUpgradeState.lastTargetVersion ?? this.agentLoopBuild.version}@${abbreviateRevision(this.autoUpgradeState.lastTargetRevision ?? this.agentLoopBuild.revision)}`,
+    )
+  }
+
   private shouldRefreshFromUpgradeAnnouncement(
     announcedAt: string,
     key: string,
@@ -3891,6 +3953,39 @@ export class AgentDaemon {
       String(input.consecutiveFailureCount),
       input.pausedUntil ?? 'none',
     ].join(':')
+  }
+
+  private getAutoUpgradeSuccessAcknowledgementKey(input: {
+    channel: string | null
+    targetVersion: string | null
+    targetRevision: string | null
+    succeededAt: string | null
+  }): string | null {
+    if ((!input.targetVersion && !input.targetRevision) || !input.succeededAt) {
+      return null
+    }
+
+    return [
+      input.channel ?? 'default',
+      input.targetVersion ?? 'unknown',
+      input.targetRevision ?? 'unknown',
+      input.succeededAt,
+    ].join(':')
+  }
+
+  private didLastAutoUpgradeReachCurrentBuild(): boolean {
+    const targetVersion = this.autoUpgradeState.lastTargetVersion
+    const targetRevision = this.autoUpgradeState.lastTargetRevision
+    if (!targetVersion && !targetRevision) {
+      return false
+    }
+    if (targetVersion && targetVersion !== this.agentLoopBuild.version) {
+      return false
+    }
+    if (targetRevision && this.agentLoopBuild.revision && targetRevision !== this.agentLoopBuild.revision) {
+      return false
+    }
+    return true
   }
 
   private assertDetachedUpgradeRestartReady(): void {

--- a/apps/agent-daemon/src/dashboard.test.ts
+++ b/apps/agent-daemon/src/dashboard.test.ts
@@ -3,6 +3,7 @@ import {
   buildDashboardMachineCards,
   buildDashboardSummary,
   buildDashboardUpgradeFailureAlertMessages,
+  buildDashboardUpgradeSuccessNoteMessages,
   type DashboardIssueView,
   type DashboardLeaseView,
   type DashboardLocalMachineSnapshot,
@@ -11,7 +12,10 @@ import {
   renderDashboardAppScript,
   renderDashboardHtml,
 } from './dashboard'
-import type { ManagedDaemonUpgradeFailureAlertComment } from './presence'
+import type {
+  ManagedDaemonUpgradeFailureAlertComment,
+  ManagedDaemonUpgradeSuccessComment,
+} from './presence'
 
 function buildLease(overrides: Partial<DashboardLeaseView> = {}): DashboardLeaseView {
   return {
@@ -494,6 +498,59 @@ describe('dashboard machine aggregation', () => {
 
     expect(messages).toEqual([
       'GitHub 升级告警：machine-busy 自动升级连续失败 2 次，暂停到 2026-04-05T09:25:20.000Z，最近错误：git pull failed',
+    ])
+  })
+
+  test('formats recent GitHub upgrade success notes confirmed by current presence state', () => {
+    const successes: ManagedDaemonUpgradeSuccessComment[] = [
+      {
+        commentId: 601,
+        body: 'ignored',
+        createdAt: '2026-04-05T09:12:21.000Z',
+        updatedAt: '2026-04-05T09:12:21.000Z',
+        success: {
+          repo: 'JamesWuHK/digital-employee',
+          machineId: 'machine-ready',
+          daemonInstanceId: 'daemon-ready-upgraded',
+          channel: 'master',
+          targetVersion: '0.1.2',
+          targetRevision: 'fedcba9876543210',
+          succeededAt: '2026-04-05T09:12:20.000Z',
+          acknowledgedAt: '2026-04-05T09:12:21.000Z',
+        },
+      },
+    ]
+
+    const messages = buildDashboardUpgradeSuccessNoteMessages(
+      successes,
+      [
+        buildPresence({
+          machineId: 'machine-ready',
+          daemonInstanceId: 'daemon-ready-upgraded',
+          upgradeStatus: 'up-to-date',
+          latestVersion: '0.1.2',
+          latestRevision: 'fedcba9876543210',
+          autoUpgrade: {
+            attemptCount: 2,
+            successCount: 1,
+            failureCount: 1,
+            noChangeCount: 0,
+            consecutiveFailureCount: 0,
+            lastAttemptAt: '2026-04-05T09:12:10.000Z',
+            lastSuccessAt: '2026-04-05T09:12:20.000Z',
+            lastOutcome: 'succeeded',
+            lastTargetVersion: '0.1.2',
+            lastTargetRevision: 'fedcba9876543210',
+            lastError: null,
+            pausedUntil: null,
+          },
+        }),
+      ],
+      Date.parse('2026-04-05T09:13:00.000Z'),
+    )
+
+    expect(messages).toEqual([
+      'GitHub 升级完成：machine-ready 已切换到 v0.1.2@fedcba9876543210 并恢复在线',
     ])
   })
 })

--- a/apps/agent-daemon/src/dashboard.ts
+++ b/apps/agent-daemon/src/dashboard.ts
@@ -28,8 +28,10 @@ import {
 import {
   listActiveManagedDaemonPresence,
   listActiveManagedDaemonUpgradeFailureAlerts,
+  listRecentManagedDaemonUpgradeSuccesses,
   type ManagedDaemonPresenceComment,
   type ManagedDaemonUpgradeFailureAlertComment,
+  type ManagedDaemonUpgradeSuccessComment,
 } from './presence'
 
 export const DEFAULT_DASHBOARD_HOST = '127.0.0.1'
@@ -302,6 +304,20 @@ export async function collectDashboardSnapshot(
     errors.push(`GitHub 升级告警不可用：${formatError(error)}`)
   }
 
+  try {
+    const successes = await listRecentManagedDaemonUpgradeSuccesses({
+      ...options.config,
+      repo,
+    }, Date.parse(generatedAt))
+    notes.push(...buildDashboardUpgradeSuccessNoteMessages(
+      successes,
+      remotePresences,
+      Date.parse(generatedAt),
+    ))
+  } catch (error) {
+    errors.push(`GitHub 升级完成记录不可用：${formatError(error)}`)
+  }
+
   const machines = buildDashboardMachineCards(localSnapshots, remoteLeases, remotePresences)
 
   return {
@@ -493,6 +509,50 @@ export function buildDashboardUpgradeFailureAlertMessages(
 
     messages.push(
       `GitHub 升级告警：${comment.alert.machineId} 自动升级连续失败 ${comment.alert.consecutiveFailureCount} 次，暂停到 ${comment.alert.pausedUntil}${comment.alert.lastError ? `，最近错误：${comment.alert.lastError}` : ''}`,
+    )
+  }
+
+  return [...new Set(messages)]
+}
+
+export function buildDashboardUpgradeSuccessNoteMessages(
+  successes: ManagedDaemonUpgradeSuccessComment[],
+  presences: DashboardPresenceView[],
+  now = Date.now(),
+): string[] {
+  const presenceByMachine = new Map<string, DashboardPresenceView>()
+  for (const presence of presences) {
+    const current = presenceByMachine.get(presence.machineId)
+    if (!current || (presence.heartbeatAgeSeconds ?? Number.POSITIVE_INFINITY) <= (current.heartbeatAgeSeconds ?? Number.POSITIVE_INFINITY)) {
+      presenceByMachine.set(presence.machineId, presence)
+    }
+  }
+
+  const messages: string[] = []
+  for (const comment of successes) {
+    const acknowledgedAtMs = Date.parse(comment.success.acknowledgedAt)
+    if (!Number.isFinite(acknowledgedAtMs) || acknowledgedAtMs > now) {
+      continue
+    }
+
+    const presence = presenceByMachine.get(comment.success.machineId)
+    const confirmedOnline = presence && (
+      presence.upgradeStatus === 'up-to-date'
+      || presence.upgradeStatus === 'ahead-of-channel'
+    ) && presence.autoUpgrade?.lastOutcome === 'succeeded'
+      && presence.autoUpgrade?.lastSuccessAt === comment.success.succeededAt
+      && presence.autoUpgrade?.lastTargetVersion === comment.success.targetVersion
+      && presence.autoUpgrade?.lastTargetRevision === comment.success.targetRevision
+    if (!confirmedOnline) {
+      continue
+    }
+
+    const targetRevision = comment.success.targetRevision ?? presence.agentLoopRevision ?? 'unknown'
+    const shortRevision = targetRevision.length <= 18
+      ? targetRevision
+      : `${targetRevision.slice(0, 18)}...`
+    messages.push(
+      `GitHub 升级完成：${comment.success.machineId} 已切换到 v${comment.success.targetVersion ?? presence.agentLoopVersion}@${shortRevision} 并恢复在线`,
     )
   }
 

--- a/apps/agent-daemon/src/presence.test.ts
+++ b/apps/agent-daemon/src/presence.test.ts
@@ -4,14 +4,18 @@ import {
   buildManagedDaemonPresenceComment,
   buildManagedDaemonUpgradeAnnouncementComment,
   buildManagedDaemonUpgradeFailureAlertComment,
+  buildManagedDaemonUpgradeSuccessComment,
   extractManagedDaemonPresenceIssueNumber,
   extractManagedDaemonPresenceComment,
   extractManagedDaemonUpgradeAnnouncementComment,
   extractManagedDaemonUpgradeFailureAlertComment,
+  extractManagedDaemonUpgradeSuccessComment,
   getLatestManagedDaemonUpgradeAnnouncement,
   getLatestManagedDaemonUpgradeFailureAlert,
+  getLatestManagedDaemonUpgradeSuccess,
   listActiveManagedDaemonPresenceComments,
   listActiveManagedDaemonUpgradeFailureAlertComments,
+  listRecentManagedDaemonUpgradeSuccessComments,
   ManagedDaemonPresencePublisher,
   type ManagedDaemonPresence,
   type PresenceApiAdapter,
@@ -250,6 +254,51 @@ describe('managed daemon presence helpers', () => {
 
     expect(getLatestManagedDaemonUpgradeFailureAlert(comments, TEST_CONFIG.repo, 'machine-a')?.alert.pausedUntil).toBe(newer.pausedUntil)
     expect(listActiveManagedDaemonUpgradeFailureAlertComments(comments, TEST_CONFIG.repo, Date.parse('2026-04-11T09:40:00.000Z'))).toHaveLength(1)
+  })
+
+  test('round-trips managed daemon upgrade success acknowledgements and filters recent latest comments', () => {
+    const older = {
+      repo: TEST_CONFIG.repo,
+      machineId: 'machine-a',
+      daemonInstanceId: 'daemon-a',
+      channel: 'master',
+      targetVersion: '0.1.2',
+      targetRevision: '2222222222222222222222222222222222222222',
+      succeededAt: '2026-04-11T09:00:20.000Z',
+      acknowledgedAt: '2026-04-11T09:00:30.000Z',
+    }
+    const newer = {
+      ...older,
+      daemonInstanceId: 'daemon-b',
+      succeededAt: '2026-04-11T09:30:20.000Z',
+      acknowledgedAt: '2026-04-11T09:30:30.000Z',
+    }
+
+    expect(extractManagedDaemonUpgradeSuccessComment(
+      buildManagedDaemonUpgradeSuccessComment(newer),
+    )).toEqual(newer)
+
+    const comments = [
+      {
+        commentId: 31,
+        body: buildManagedDaemonUpgradeSuccessComment(older),
+        createdAt: older.acknowledgedAt,
+        updatedAt: older.acknowledgedAt,
+      },
+      {
+        commentId: 32,
+        body: buildManagedDaemonUpgradeSuccessComment(newer),
+        createdAt: newer.acknowledgedAt,
+        updatedAt: newer.acknowledgedAt,
+      },
+    ]
+
+    expect(getLatestManagedDaemonUpgradeSuccess(comments, TEST_CONFIG.repo, 'machine-a')?.success.succeededAt).toBe(newer.succeededAt)
+    expect(listRecentManagedDaemonUpgradeSuccessComments(
+      comments,
+      TEST_CONFIG.repo,
+      Date.parse('2026-04-11T09:40:00.000Z'),
+    )).toHaveLength(1)
   })
 
   test('filters active managed daemon presence comments by repo and expiry', () => {

--- a/apps/agent-daemon/src/presence.ts
+++ b/apps/agent-daemon/src/presence.ts
@@ -17,6 +17,7 @@ const MANAGED_DAEMON_PRESENCE_ISSUE_MARKER = '<!-- agent-loop:presence-registry 
 const MANAGED_DAEMON_PRESENCE_COMMENT_PREFIX = '<!-- agent-loop:presence '
 const MANAGED_DAEMON_UPGRADE_ANNOUNCEMENT_COMMENT_PREFIX = '<!-- agent-loop:upgrade-announcement '
 const MANAGED_DAEMON_UPGRADE_FAILURE_ALERT_COMMENT_PREFIX = '<!-- agent-loop:upgrade-failure-alert '
+const MANAGED_DAEMON_UPGRADE_SUCCESS_COMMENT_PREFIX = '<!-- agent-loop:upgrade-success '
 const GITHUB_REST_TIMEOUT_MS = 180_000
 
 export type ManagedDaemonPresenceStatus = 'idle' | 'busy' | 'stopped'
@@ -97,6 +98,21 @@ export interface ManagedDaemonUpgradeFailureAlert {
 
 export interface ManagedDaemonUpgradeFailureAlertComment extends IssueComment {
   alert: ManagedDaemonUpgradeFailureAlert
+}
+
+export interface ManagedDaemonUpgradeSuccess {
+  repo: string
+  machineId: string
+  daemonInstanceId: string
+  channel: string | null
+  targetVersion: string | null
+  targetRevision: string | null
+  succeededAt: string
+  acknowledgedAt: string
+}
+
+export interface ManagedDaemonUpgradeSuccessComment extends IssueComment {
+  success: ManagedDaemonUpgradeSuccess
 }
 
 export interface PresenceApiAdapter {
@@ -407,6 +423,24 @@ A managed daemon is backing off repeated self-upgrade retries after consecutive 
 - Alerted at: ${alert.alertedAt}`
 }
 
+export function buildManagedDaemonUpgradeSuccessComment(
+  success: ManagedDaemonUpgradeSuccess,
+): string {
+  return `${MANAGED_DAEMON_UPGRADE_SUCCESS_COMMENT_PREFIX}${JSON.stringify(success)} -->
+## Agent Loop auto-upgrade success
+
+A managed daemon successfully restarted into the upgraded build and is back online.
+
+- Repo: ${success.repo}
+- Machine: ${success.machineId}
+- Daemon: ${success.daemonInstanceId}
+- Channel: ${success.channel ?? 'default'}
+- Target version: ${success.targetVersion ?? 'unknown'}
+- Target revision: ${success.targetRevision ?? 'unknown'}
+- Succeeded at: ${success.succeededAt}
+- Acknowledged at: ${success.acknowledgedAt}`
+}
+
 export function extractManagedDaemonPresenceComment(body: string): ManagedDaemonPresence | null {
   const match = body.match(/<!-- agent-loop:presence (\{.*\}) -->/)
   if (!match?.[1]) return null
@@ -586,6 +620,33 @@ export function extractManagedDaemonUpgradeFailureAlertComment(
   }
 }
 
+export function extractManagedDaemonUpgradeSuccessComment(
+  body: string,
+): ManagedDaemonUpgradeSuccess | null {
+  const match = body.match(/<!-- agent-loop:upgrade-success (\{.*\}) -->/)
+  if (!match?.[1]) return null
+
+  try {
+    const parsed = JSON.parse(match[1]) as Partial<ManagedDaemonUpgradeSuccess>
+    if (!parsed || typeof parsed !== 'object') return null
+    if (typeof parsed.repo !== 'string' || typeof parsed.machineId !== 'string' || typeof parsed.daemonInstanceId !== 'string') return null
+    if (typeof parsed.succeededAt !== 'string' || typeof parsed.acknowledgedAt !== 'string') return null
+
+    return {
+      repo: parsed.repo,
+      machineId: parsed.machineId,
+      daemonInstanceId: parsed.daemonInstanceId,
+      channel: typeof parsed.channel === 'string' && parsed.channel.trim().length > 0 ? parsed.channel : null,
+      targetVersion: typeof parsed.targetVersion === 'string' && parsed.targetVersion.trim().length > 0 ? parsed.targetVersion : null,
+      targetRevision: typeof parsed.targetRevision === 'string' && parsed.targetRevision.trim().length > 0 ? parsed.targetRevision : null,
+      succeededAt: parsed.succeededAt,
+      acknowledgedAt: parsed.acknowledgedAt,
+    }
+  } catch {
+    return null
+  }
+}
+
 export function parseManagedDaemonPresenceComments(
   comments: IssueComment[],
 ): ManagedDaemonPresenceComment[] {
@@ -633,6 +694,22 @@ export function parseManagedDaemonUpgradeFailureAlertComments(
     .filter((comment): comment is ManagedDaemonUpgradeFailureAlertComment => comment !== null)
 }
 
+export function parseManagedDaemonUpgradeSuccessComments(
+  comments: IssueComment[],
+): ManagedDaemonUpgradeSuccessComment[] {
+  return comments
+    .map((comment) => {
+      const success = extractManagedDaemonUpgradeSuccessComment(comment.body)
+      if (!success) return null
+
+      return {
+        ...comment,
+        success,
+      } satisfies ManagedDaemonUpgradeSuccessComment
+    })
+    .filter((comment): comment is ManagedDaemonUpgradeSuccessComment => comment !== null)
+}
+
 export function getLatestManagedDaemonUpgradeAnnouncement(
   comments: IssueComment[],
   repo: string,
@@ -660,6 +737,20 @@ export function getLatestManagedDaemonUpgradeFailureAlert(
     })[0] ?? null
 }
 
+export function getLatestManagedDaemonUpgradeSuccess(
+  comments: IssueComment[],
+  repo: string,
+  machineId: string,
+): ManagedDaemonUpgradeSuccessComment | null {
+  return parseManagedDaemonUpgradeSuccessComments(comments)
+    .filter((comment) => comment.success.repo === repo && comment.success.machineId === machineId)
+    .sort((left, right) => {
+      const ackDiff = Date.parse(right.success.acknowledgedAt) - Date.parse(left.success.acknowledgedAt)
+      if (ackDiff !== 0) return ackDiff
+      return right.commentId - left.commentId
+    })[0] ?? null
+}
+
 export function listActiveManagedDaemonUpgradeFailureAlertComments(
   comments: IssueComment[],
   repo: string,
@@ -681,6 +772,35 @@ export function listActiveManagedDaemonUpgradeFailureAlertComments(
   for (const comment of matches) {
     if (!deduped.has(comment.alert.machineId)) {
       deduped.set(comment.alert.machineId, comment)
+    }
+  }
+
+  return [...deduped.values()]
+}
+
+export function listRecentManagedDaemonUpgradeSuccessComments(
+  comments: IssueComment[],
+  repo: string,
+  now = Date.now(),
+  lookbackMs = 30 * 60 * 1000,
+): ManagedDaemonUpgradeSuccessComment[] {
+  const deduped = new Map<string, ManagedDaemonUpgradeSuccessComment>()
+  const earliest = now - Math.max(0, Math.floor(lookbackMs))
+  const matches = parseManagedDaemonUpgradeSuccessComments(comments)
+    .filter((comment) => comment.success.repo === repo)
+    .filter((comment) => {
+      const acknowledgedAt = Date.parse(comment.success.acknowledgedAt)
+      return Number.isFinite(acknowledgedAt) && acknowledgedAt >= earliest && acknowledgedAt <= now
+    })
+    .sort((left, right) => {
+      const ackDiff = Date.parse(right.success.acknowledgedAt) - Date.parse(left.success.acknowledgedAt)
+      if (ackDiff !== 0) return ackDiff
+      return right.commentId - left.commentId
+    })
+
+  for (const comment of matches) {
+    if (!deduped.has(comment.success.machineId)) {
+      deduped.set(comment.success.machineId, comment)
     }
   }
 
@@ -876,6 +996,18 @@ export async function listActiveManagedDaemonUpgradeFailureAlerts(
   if (issueNumber === null) return []
   const comments = await api.listIssueComments(issueNumber, config)
   return listActiveManagedDaemonUpgradeFailureAlertComments(comments, config.repo, now)
+}
+
+export async function listRecentManagedDaemonUpgradeSuccesses(
+  config: AgentConfig,
+  now = Date.now(),
+  lookbackMs = 30 * 60 * 1000,
+  api: PresenceApiAdapter = defaultPresenceApi,
+): Promise<ManagedDaemonUpgradeSuccessComment[]> {
+  const issueNumber = await findManagedDaemonPresenceIssue(config)
+  if (issueNumber === null) return []
+  const comments = await api.listIssueComments(issueNumber, config)
+  return listRecentManagedDaemonUpgradeSuccessComments(comments, config.repo, now, lookbackMs)
 }
 
 export class ManagedDaemonPresencePublisher {


### PR DESCRIPTION
## Summary
- publish a structured presence-registry success acknowledgement when an upgraded daemon restarts into the new build
- dedupe success acknowledgements per machine, target, and success timestamp to avoid comment spam across restarts
- surface recent confirmed upgrade completions as dashboard notes alongside the existing failure alerts

## Testing
- bun test apps/agent-daemon/src/presence.test.ts apps/agent-daemon/src/daemon.test.ts apps/agent-daemon/src/dashboard.test.ts
- bun run typecheck