### PR TITLE
fix(pr): ignore closed PRs for reuse and review

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -41,6 +41,7 @@ import {
   rebaseManagedBranchOntoDefault,
   shouldApplyStandaloneIssueTransition,
   shouldResetLinkedPrToRetryOnIssueResume,
+  shouldUseOpenPrCheckForRecovery,
   shouldCompleteIssueRecoveryOnRemoteClose,
   shouldRequeueFailedIssue,
   shouldResumeManagedIssue,
@@ -1788,6 +1789,23 @@ describe('daemon merge recovery helpers', () => {
     expect(shouldResetLinkedPrToRetryOnIssueResume([PR_REVIEW_LABELS.FAILED, PR_REVIEW_LABELS.HUMAN_NEEDED])).toBe(true)
     expect(shouldResetLinkedPrToRetryOnIssueResume([PR_REVIEW_LABELS.RETRY])).toBe(false)
     expect(shouldResetLinkedPrToRetryOnIssueResume([PR_REVIEW_LABELS.APPROVED])).toBe(false)
+  })
+
+  test('only reuses open PR checks for issue recovery context', () => {
+    expect(shouldUseOpenPrCheckForRecovery({
+      prNumber: 386,
+      prState: 'closed',
+    })).toBe(false)
+
+    expect(shouldUseOpenPrCheckForRecovery({
+      prNumber: 387,
+      prState: 'merged',
+    })).toBe(false)
+
+    expect(shouldUseOpenPrCheckForRecovery({
+      prNumber: 388,
+      prState: 'open',
+    })).toBe(true)
   })
 
   test('prefers standalone PR handoff for resumable issues when the branch is already synced', () => {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -2663,8 +2663,11 @@ export class AgentDaemon {
       })
 
       const prCheck = await checkPrExists(branch, this.config)
-      const linkedOpenPr = prCheck.prNumber !== null && prCheck.prState === 'open'
-        ? (await listOpenAgentPullRequests(this.config)).find((pr) => pr.number === prCheck.prNumber) ?? null
+      const hasExistingOpenPr = shouldUseOpenPrCheckForRecovery(prCheck)
+      const existingOpenPrNumber = hasExistingOpenPr ? prCheck.prNumber as number : null
+      const existingOpenPrUrl = hasExistingOpenPr ? prCheck.prUrl : null
+      const linkedOpenPr = hasExistingOpenPr
+        ? (await listOpenAgentPullRequests(this.config)).find((pr) => pr.number === existingOpenPrNumber) ?? null
         : null
       if (linkedOpenPr && shouldResetLinkedPrToRetryOnIssueResume(linkedOpenPr.labels)) {
         await setManagedPrReviewLabels(linkedOpenPr.number, 'retry', this.config)
@@ -2674,8 +2677,8 @@ export class AgentDaemon {
       }
       const recentBlockingReasons = [
         ...extractAutomatedIssuePreflightReasons(await listIssueComments(issueNumber, this.config)),
-        ...(prCheck.prNumber !== null
-          ? extractAutomatedReviewReasons(await listIssueComments(prCheck.prNumber, this.config))
+        ...(existingOpenPrNumber !== null
+          ? extractAutomatedReviewReasons(await listIssueComments(existingOpenPrNumber, this.config))
           : []),
       ]
       const recoveryResult = await runIssueRecovery(
@@ -2685,8 +2688,8 @@ export class AgentDaemon {
         issue.body,
         this.config,
         this.logger,
-        prCheck.prNumber !== null && prCheck.prUrl
-          ? { number: prCheck.prNumber, url: prCheck.prUrl, branch }
+        existingOpenPrNumber !== null && existingOpenPrUrl
+          ? { number: existingOpenPrNumber, url: existingOpenPrUrl, branch }
           : null,
         recentBlockingReasons,
         monitor,
@@ -4881,6 +4884,12 @@ export function shouldApplyStandaloneIssueTransition(
 export function shouldResetLinkedPrToRetryOnIssueResume(prLabels: string[]): boolean {
   const labels = new Set(prLabels)
   return labels.has(PR_REVIEW_LABELS.HUMAN_NEEDED) || labels.has(PR_REVIEW_LABELS.FAILED)
+}
+
+export function shouldUseOpenPrCheckForRecovery(
+  prCheck: Pick<Awaited<ReturnType<typeof checkPrExists>>, 'prNumber' | 'prState'>,
+): boolean {
+  return prCheck.prNumber !== null && prCheck.prState === 'open'
 }
 
 export function shouldCompleteIssueRecoveryOnRemoteClose(

--- a/apps/agent-daemon/src/pr-reporter.test.ts
+++ b/apps/agent-daemon/src/pr-reporter.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { isRetryableManagedBranchPushFailure, pushBranch } from './pr-reporter'
+import { createOrFindPr, isRetryableManagedBranchPushFailure, pushBranch } from './pr-reporter'
 
 async function runGit(
   worktreePath: string,
@@ -140,5 +140,96 @@ describe('pr reporter push recovery', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true })
     }
+  })
+
+  test('reopens a closed PR instead of treating it as terminal', async () => {
+    const calls: string[] = []
+    const logger = {
+      log: () => undefined,
+      warn: () => undefined,
+    }
+
+    const result = await createOrFindPr(
+      '/tmp/worktree',
+      'agent/125/codex',
+      125,
+      'Fix #125',
+      {
+        machineId: 'codex',
+      } as any,
+      logger as Console,
+      {
+        checkPrExists: async () => ({
+          prNumber: 386,
+          prUrl: 'https://github.com/example/repo/pull/386',
+          prState: 'closed',
+        }),
+        pushBranch: async () => {
+          calls.push('push')
+        },
+        reopenPullRequest: async (prNumber) => {
+          calls.push(`reopen:${prNumber}`)
+          return {
+            number: prNumber,
+            url: `https://github.com/example/repo/pull/${prNumber}`,
+          }
+        },
+        createPr: async () => {
+          throw new Error('should not create a fresh PR when reopen succeeds')
+        },
+      },
+    )
+
+    expect(calls).toEqual(['push', 'reopen:386'])
+    expect(result).toEqual({
+      prNumber: 386,
+      prUrl: 'https://github.com/example/repo/pull/386',
+    })
+  })
+
+  test('falls back to creating a fresh PR when reopen fails', async () => {
+    const calls: string[] = []
+    const logger = {
+      log: () => undefined,
+      warn: () => undefined,
+    }
+
+    const result = await createOrFindPr(
+      '/tmp/worktree',
+      'agent/125/codex',
+      125,
+      'Fix #125',
+      {
+        machineId: 'codex',
+      } as any,
+      logger as Console,
+      {
+        checkPrExists: async () => ({
+          prNumber: 386,
+          prUrl: 'https://github.com/example/repo/pull/386',
+          prState: 'closed',
+        }),
+        pushBranch: async () => {
+          calls.push('push')
+        },
+        reopenPullRequest: async () => {
+          calls.push('reopen')
+          throw new Error('cannot reopen closed PR')
+        },
+        createPr: async () => {
+          calls.push('create')
+          return {
+            number: 412,
+            url: 'https://github.com/example/repo/pull/412',
+          }
+        },
+      },
+    )
+
+    expect(calls).toEqual(['push', 'reopen', 'create'])
+    expect(result).toEqual({
+      prNumber: 412,
+      prUrl: 'https://github.com/example/repo/pull/412',
+    })
   })
 })

--- a/apps/agent-daemon/src/pr-reporter.ts
+++ b/apps/agent-daemon/src/pr-reporter.ts
@@ -1,5 +1,5 @@
 import type { AgentConfig } from '@agent/shared'
-import { checkPrExists, createPr } from '@agent/shared'
+import { checkPrExists, createPr, reopenPullRequest } from '@agent/shared'
 
 interface GitCommandResult {
   exitCode: number
@@ -25,6 +25,13 @@ const MAX_PUSH_ATTEMPTS = 3
 interface ManagedBranchPushPlan {
   pushArgs: string[] | null
   detachedHead: boolean
+}
+
+interface CreateOrFindPrDependencies {
+  checkPrExists?: typeof checkPrExists
+  createPr?: typeof createPr
+  reopenPullRequest?: typeof reopenPullRequest
+  pushBranch?: typeof pushBranch
 }
 
 export async function pushBranch(
@@ -181,13 +188,28 @@ export async function createOrFindPr(
   issueTitle: string,
   config: AgentConfig,
   logger = console,
+  dependencies: CreateOrFindPrDependencies = {},
 ): Promise<{ prNumber: number; prUrl: string }> {
+  const checkPrExistsImpl = dependencies.checkPrExists ?? checkPrExists
+  const createPrImpl = dependencies.createPr ?? createPr
+  const reopenPullRequestImpl = dependencies.reopenPullRequest ?? reopenPullRequest
+  const pushBranchImpl = dependencies.pushBranch ?? pushBranch
+  let branchPushed = false
+
+  const ensureBranchPushed = async (): Promise<void> => {
+    if (branchPushed) {
+      return
+    }
+    await pushBranchImpl(worktreePath, branch, logger)
+    branchPushed = true
+  }
+
   // Check idempotency: PR might already exist
-  const existing = await checkPrExists(branch, config)
+  const existing = await checkPrExistsImpl(branch, config)
 
   if (existing.prNumber !== null && existing.prState === 'open') {
     const url = existing.prUrl ?? ''
-    await pushBranch(worktreePath, branch, logger)
+    await ensureBranchPushed()
     logger.log(`[pr] PR already exists: #${existing.prNumber} (${url})`)
     return { prNumber: existing.prNumber, prUrl: url }
   }
@@ -199,17 +221,29 @@ export async function createOrFindPr(
   }
 
   if (existing.prNumber !== null && existing.prState === 'closed') {
-    logger.warn(`[pr] PR was closed, not creating new PR`)
-    const url = existing.prUrl ?? ''
-    return { prNumber: existing.prNumber, prUrl: url }
+    await ensureBranchPushed()
+
+    try {
+      const reopened = await reopenPullRequestImpl(existing.prNumber, config)
+      logger.log(`[pr] reopened closed PR #${reopened.number}: ${reopened.url}`)
+      return { prNumber: reopened.number, prUrl: reopened.url }
+    } catch (error) {
+      logger.warn(
+        `[pr] failed to reopen closed PR #${existing.prNumber}; attempting to create a fresh PR instead: ${formatPrReporterError(error)}`,
+      )
+    }
   }
 
   // Push branch first if not pushed yet
-  await pushBranch(worktreePath, branch, logger)
+  await ensureBranchPushed()
 
   const body = PR_BODY_TEMPLATE(issueNumber, config.machineId)
-  const pr = await createPr(branch, issueNumber, issueTitle, body, config)
+  const pr = await createPrImpl(branch, issueNumber, issueTitle, body, config)
 
   logger.log(`[pr] created PR #${pr.number}: ${pr.url}`)
   return { prNumber: pr.number, prUrl: pr.url }
+}
+
+function formatPrReporterError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -9,6 +9,7 @@ import {
   derivePullRequestStateFromRaw,
   deriveIssueStateFromRaw,
   extractNextPageUrl,
+  mapOpenManagedPullRequest,
   extractRestOpenIssueListPage,
   extractRestPullRequest,
   extractRestPullRequestListPage,
@@ -25,6 +26,7 @@ import {
   parseMergePrResponse,
   qualifyGhApiArgs,
   ghApiRaw,
+  selectPullRequestForBranchReuse,
   setGitHubApiRequestObserver,
   sortClaimableIssuesForScheduling,
   shouldClearIssueAssigneesForStateLabel,
@@ -435,6 +437,98 @@ describe('derivePullRequestStateFromRaw', () => {
 
   test('returns closed when a closed pull request has not merged', () => {
     expect(derivePullRequestStateFromRaw('closed', null)).toBe('closed')
+  })
+})
+
+describe('selectPullRequestForBranchReuse', () => {
+  test('prefers an open PR over older closed PRs on the same branch', () => {
+    const selected = selectPullRequestForBranchReuse([
+      {
+        number: 386,
+        title: 'Fix #125',
+        html_url: 'https://github.com/example/repo/pull/386',
+        state: 'closed',
+        merged_at: null,
+        head: { ref: 'agent/125/codex', sha: 'aaa111' },
+      },
+      {
+        number: 412,
+        title: 'Fix #125',
+        html_url: 'https://github.com/example/repo/pull/412',
+        state: 'open',
+        merged_at: null,
+        head: { ref: 'agent/125/codex', sha: 'bbb222' },
+      },
+    ])
+
+    expect(selected?.number).toBe(412)
+    expect(derivePullRequestStateFromRaw(selected?.state, selected?.merged_at ?? null)).toBe('open')
+  })
+
+  test('picks the newest closed PR when no open PR exists', () => {
+    const selected = selectPullRequestForBranchReuse([
+      {
+        number: 386,
+        title: 'Fix #125',
+        html_url: 'https://github.com/example/repo/pull/386',
+        state: 'closed',
+        merged_at: null,
+        head: { ref: 'agent/125/codex', sha: 'aaa111' },
+      },
+      {
+        number: 390,
+        title: 'Fix #125',
+        html_url: 'https://github.com/example/repo/pull/390',
+        state: 'closed',
+        merged_at: null,
+        head: { ref: 'agent/125/codex', sha: 'bbb222' },
+      },
+    ])
+
+    expect(selected?.number).toBe(390)
+    expect(derivePullRequestStateFromRaw(selected?.state, selected?.merged_at ?? null)).toBe('closed')
+  })
+})
+
+describe('mapOpenManagedPullRequest', () => {
+  test('returns null for closed and merged pull requests', () => {
+    expect(mapOpenManagedPullRequest({
+      number: 386,
+      title: 'Fix #125',
+      html_url: 'https://github.com/example/repo/pull/386',
+      state: 'closed',
+      merged_at: null,
+      draft: false,
+      head: { ref: 'agent/125/codex', sha: 'aaa111' },
+      labels: [{ name: 'agent:review-failed' }],
+    })).toBeNull()
+
+    expect(mapOpenManagedPullRequest({
+      number: 387,
+      title: 'Fix #125',
+      html_url: 'https://github.com/example/repo/pull/387',
+      state: 'closed',
+      merged_at: '2026-04-11T09:00:00Z',
+      draft: false,
+      head: { ref: 'agent/125/codex', sha: 'bbb222' },
+      labels: [{ name: 'agent:review-approved' }],
+    })).toBeNull()
+  })
+
+  test('keeps open managed pull requests reviewable', () => {
+    expect(mapOpenManagedPullRequest({
+      number: 388,
+      title: 'Fix #125',
+      html_url: 'https://github.com/example/repo/pull/388',
+      state: 'open',
+      merged_at: null,
+      draft: false,
+      head: { ref: 'agent/125/codex', sha: 'ccc333' },
+      labels: [{ name: 'agent:review-failed' }],
+    })).toMatchObject({
+      number: 388,
+      headRefName: 'agent/125/codex',
+    })
   })
 })
 

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -1337,7 +1337,7 @@ interface RawPullRequestListItem {
   labels?: Array<{ name: string }>
 }
 
-interface RawRestPullRequest {
+export interface RawRestPullRequest {
   number?: number
   title?: string
   html_url?: string
@@ -1432,6 +1432,45 @@ function mapRawRestPullRequest(pr: RawRestPullRequest): ManagedPullRequest | nul
   }
 }
 
+export function mapOpenManagedPullRequest(
+  pr: RawRestPullRequest,
+): ManagedPullRequest | null {
+  if (derivePullRequestStateFromRaw(pr.state, pr.merged_at ?? null) !== 'open') {
+    return null
+  }
+
+  return mapRawRestPullRequest(pr)
+}
+
+function getBranchPullRequestReusePriority(
+  pr: Pick<RawRestPullRequest, 'state' | 'merged_at'>,
+): number {
+  const state = derivePullRequestStateFromRaw(pr.state, pr.merged_at ?? null)
+  if (state === 'open') return 0
+  if (state === 'closed') return 1
+  if (state === 'merged') return 2
+  return 3
+}
+
+export function selectPullRequestForBranchReuse(
+  pullRequests: RawRestPullRequest[],
+): RawRestPullRequest | null {
+  if (pullRequests.length === 0) {
+    return null
+  }
+
+  return [...pullRequests].sort((left, right) => {
+    const priorityDelta = getBranchPullRequestReusePriority(left) - getBranchPullRequestReusePriority(right)
+    if (priorityDelta !== 0) {
+      return priorityDelta
+    }
+
+    const leftNumber = typeof left.number === 'number' ? left.number : 0
+    const rightNumber = typeof right.number === 'number' ? right.number : 0
+    return rightNumber - leftNumber
+  })[0] ?? null
+}
+
 async function checkPrExistsRest(
   branch: string,
   config: AgentConfig,
@@ -1449,7 +1488,11 @@ async function checkPrExistsRest(
     return { prNumber: null, prUrl: null, prState: null }
   }
 
-  const pr = data[0]!
+  const pr = selectPullRequestForBranchReuse(data)
+  if (!pr) {
+    return { prNumber: null, prUrl: null, prState: null }
+  }
+
   return {
     prNumber: typeof pr.number === 'number' ? pr.number : null,
     prUrl: typeof pr.html_url === 'string' ? pr.html_url : null,
@@ -1478,7 +1521,7 @@ async function listOpenAgentPullRequestsRest(
     const pageItems = extractRestPullRequestListPage(JSON.parse(stdout))
     pullRequests.push(
       ...pageItems
-        .map(mapRawRestPullRequest)
+        .map(mapOpenManagedPullRequest)
         .filter((pr): pr is ManagedPullRequest => pr !== null)
         .filter((pr) => pr.headRefName.startsWith('agent/')),
     )
@@ -1512,7 +1555,7 @@ async function getManagedPullRequestByNumberRest(
     )
   }
 
-  const mapped = mapRawRestPullRequest(extractRestPullRequest(JSON.parse(stdout)) ?? {})
+  const mapped = mapOpenManagedPullRequest(extractRestPullRequest(JSON.parse(stdout)) ?? {})
   if (!mapped) return null
   if (!mapped.headRefName.startsWith('agent/')) return null
   return mapped
@@ -1752,6 +1795,37 @@ export async function createPr(
   const number = typeof created.number === 'number' ? created.number : 0
 
   return { number, url }
+}
+
+export async function reopenPullRequest(
+  prNumber: number,
+  config: AgentConfig,
+): Promise<{ number: number; url: string }> {
+  const response = await withTempJsonFile(
+    'agent-loop-pr-reopen',
+    { state: 'open' },
+    async (path) => ghApiRaw([
+      `repos/${config.repo}/pulls/${prNumber}`,
+      '-X',
+      'PATCH',
+      '--input',
+      path,
+    ], config),
+  )
+
+  if (response.exitCode !== 0) {
+    throw new GhError(`api pulls/${prNumber} reopen`, response.exitCode, parseGhApiErrorMessage(response.stdout, response.stderr))
+  }
+
+  const reopened = mapRawRestPullRequest(extractRestPullRequest(JSON.parse(response.stdout)) ?? {})
+  if (!reopened) {
+    throw new Error(`api pulls/${prNumber} reopen returned an invalid pull request payload`)
+  }
+
+  return {
+    number: reopened.number,
+    url: reopened.url,
+  }
 }
 
 // ─── Worktree: check PR status ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- stop targeted PR wake and direct PR lookups from treating closed or merged PRs as reviewable managed PRs
- prefer open PRs when branch reuse checks find historical PRs, and reopen a closed managed PR instead of refusing to publish
- keep issue recovery prompts and review blocker harvesting scoped to open PR context only

## Testing
- bun test packages/agent-shared/src/github-api.test.ts apps/agent-daemon/src/pr-reporter.test.ts apps/agent-daemon/src/daemon.test.ts
- bun run typecheck