### PR TITLE
docs(roadmap): add executable issue system phase 2

### DIFF
--- a/docs/roadmaps/executable-issue-system-phase-2/00-parent-epic.md
+++ b/docs/roadmaps/executable-issue-system-phase-2/00-parent-epic.md
@@ -1,0 +1,80 @@
+## 背景
+
+`agent-loop` 要成为长期有用的自动化开发框架，核心不只是“能跑 issue”，而是“能把需求稳定收敛成 agent 可执行、review 可判定、auto-fix 可修复的合同”。
+
+Anthropic 关于 long-running apps 的文章给我们的直接启发是：长期运行的 agent 系统，可靠性主要来自 harness 设计，而不是某一次 prompt 运气够好。对 `agent-loop` 来说，这个 harness 的最前置边界就是 issue contract：
+
+- 它是 planning 的输入，不是附属文档
+- 它是 review / repair / ready gate 的共享状态面，不是单次 agent 提示词
+- 它必须可观察、可修复、可回写，而不是只在创建那一刻“看起来写得不错”
+
+phase 1 已经把单点能力链补齐：
+
+- issue quality / lint
+- repo-grounded authoring context
+- rewrite 模糊 issue 为 executable contract
+- split tracking parent 为 execution-sized child issues
+- simulate issue 的可执行性，而不只做静态模板检查
+
+phase 2 要做的是把这条能力链变成 issue ops system，也就是 `agent-loop` 的 spec control plane。
+
+## 设计启发
+
+- 长时运行的 agent app 需要 durable、inspectable、repairable 的状态面；issue contract 就是 `agent-loop` 的 durable spec state
+- “先审计、再修复、再同步、再观测”的闭环，比“多调 prompt”更接近工程系统
+- repo / project 的局部规则必须进入 authoring harness；否则开源框架只能停在 generic demo，无法稳定落到真实团队
+- 如果 issue 质量不能持续量化，commercial control plane 也就没有可收费的运营抓手
+
+## 目标
+
+- 把 phase 1 的 authoring primitives 升级为 repo 级 issue operations 闭环
+- 让 maintainer 可以批量审计 issue pool，而不是逐条肉眼判断
+- 让 repo / project 的 issue authoring rules 能稳定注入 rewrite / split / repair 流程
+- 把 lint / simulate findings 转成可执行 repair loop，而不是只能报错
+- 把修好的 contract 安全回写 GitHub，避免“本地改好了、线上 issue 还是旧的”
+- 在 dashboard / metrics 中暴露 issue quality drift，让 issue 质量成为可运营信号
+
+## Open Source 与商业价值
+
+- 开源基线：
+  本地 CLI、repo 规则、repair loop、GitHub 安全回写、dashboard / metrics
+- 商业延展：
+  org 级 policy packs、跨 repo 质量基线、团队审批流、历史趋势、托管控制面
+
+## 成功指标
+
+- `agent:ready` issue 的 invalid / rewrite-before-run 比例持续下降
+- `no commit made` 与 scope 漂移的失败率相对 phase 1 基线继续下降
+- 从模糊 issue 到 ready contract 的中位耗时继续下降
+- repo 能显式声明自己的 issue authoring rules，并被 rewrite / repair 流程消费
+- dashboard / metrics 能直接指出“是 runtime 坏了”还是“issue contract 坏了”
+
+## 子 Issue 规划
+
+- `#50` `[AL-11]` 增加 repo issue audit report CLI 与 JSON 输出
+- `#51` `[AL-12]` 支持 project issue authoring profile / ruleset 注入
+- `#53` `[AL-13]` 增加 issue repair CLI 并消费 lint / simulate findings
+- `#54` `[AL-14]` 增加 issue apply / sync CLI 安全回写 GitHub
+- `#55` `[AL-15]` 在 dashboard / metrics 中暴露 issue ops 信号
+
+## 执行顺序
+
+1. 先完成 `#50`，拿到 repo 级质量视图和机器可读输出
+2. 再完成 `#51`，把 repo / project 规则注入 authoring harness
+3. 再完成 `#53`，把 findings 转成 repair loop
+4. 再完成 `#54`，把本地修好的 contract 安全回写 GitHub
+5. 最后完成 `#55`，把 issue quality drift 变成可观测信号
+
+## 非目标
+
+- 本 epic 不做 hosted SaaS、多租户 RBAC、账单或 org 管理后台
+- 本 epic 不改 daemon 的核心 claim / worktree / merge 主流程
+- 本 epic 不实现完整 parent -> child issue 自动创建流水线
+- 本 epic 不做 browser evaluator 或新的 runtime sandbox
+
+## 验收
+
+- [ ] 五个 child issue 都是 execution-sized，并且 `dependsOn` 最终准确
+- [ ] 每个 child issue 的 happy path 都会自然产出真实代码改动与 commit
+- [ ] phase 2 能形成 issue 审计、修复、同步、观测的闭环
+- [ ] 这组能力既能作为开源版核心价值，也能自然承接商业化控制面

--- a/docs/roadmaps/executable-issue-system-phase-2/01-al-11-repo-issue-audit-report.md
+++ b/docs/roadmaps/executable-issue-system-phase-2/01-al-11-repo-issue-audit-report.md
@@ -1,0 +1,162 @@
+## 用户故事
+
+作为仓库维护者，我希望用一个统一的 `agent-loop` CLI 批量审计 repo 内的 issue contract，并输出机器可读的质量报告，从而在 issue 进入 `agent:ready` 或进入商业化控制面之前，先拿到稳定的 repo-level 基线。
+
+## Context
+
+### Dependencies
+```json
+{
+  "dependsOn": [36, 40]
+}
+```
+
+### Constraints
+- 复用 phase 1 已有的 quality / simulate 能力，不要重新发明另一套评分或 findings 逻辑
+- 默认行为继续服务本地维护者排查，不要把现有 human-readable audit 输出直接删掉
+- 审计命令本身必须只读，不能修改 issue body、label、comment 或 ready 状态
+
+### AllowedFiles
+- apps/agent-daemon/src/audit-issue-contracts.ts
+- apps/agent-daemon/src/audit-issue-contracts.test.ts
+- apps/agent-daemon/src/index.ts
+- apps/agent-daemon/src/index.test.ts
+- packages/agent-shared/src/github-api.ts
+- packages/agent-shared/src/github-api.test.ts
+- packages/agent-shared/src/types.ts
+
+### ForbiddenFiles
+- apps/agent-daemon/src/ready-gate.ts
+- apps/agent-daemon/src/issue-authoring.ts
+- apps/agent-daemon/src/issue-splitter.ts
+- apps/agent-daemon/src/dashboard.ts
+
+### MustPreserve
+- 不带新参数时，现有审计命令仍然能以 human-readable 方式列出 managed issue 的 claimability 与 contract 问题
+- 现有 `ready-gate` 的拦截语义不变；本 issue 只增加审计视图，不做状态变更
+- issue quality score、warnings、simulation findings 必须来自已有共享逻辑，而不是第二套分叉实现
+
+### OutOfScope
+- 自动修复 issue contract
+- 把审计结果直接写回 GitHub comment 或 label
+- dashboard / metrics 可视化
+- 历史趋势存储或 hosted analytics backend
+
+### RequiredSemantics
+- `agent-loop --audit-issues` 可以审计默认 open managed issues，也可以通过重复 `--issue <number>` 只审计显式 issue 集合
+- `--json` 输出必须是稳定的单一 JSON 对象，包含 top-level summary 和 per-issue results，不能混入额外 human prose
+- 审计结果必须暴露每条 issue 的 quality score、errors、warnings，以及在显式开启 `--simulate` 时附带的 simulation findings
+- top-level summary 至少包含 audited issue 总数、invalid issue 数、invalid ready issue 数、low score issue 数、warning issue 数
+- 当命令收到显式 issue 集合且其中存在 invalid contract 时，进程退出码必须非 0，便于 CI / control plane 直接消费
+
+### ReviewHints
+- 优先检查 CLI 是否真正复用了已有 quality / simulate 逻辑，避免 score 与 findings 在不同入口出现漂移
+- 优先检查 `--json` 模式是否完全可机器解析，尤其不要混入日志前缀或 human-readable 段落
+- 优先检查默认行为是否仍然对维护者友好，而不是只剩 JSON
+
+### Validation
+- `bun test apps/agent-daemon/src/audit-issue-contracts.test.ts apps/agent-daemon/src/index.test.ts packages/agent-shared/src/github-api.test.ts`
+- `bun run typecheck`
+- `git diff --stat origin/master...HEAD`
+
+## RED 测试
+
+```ts
+import { describe, expect, test } from 'bun:test'
+import { auditIssues, formatAuditOutput } from './audit-issue-contracts'
+
+const VALID_CONTRACT = [
+  '## 用户故事',
+  '作为维护者，我希望批量审计 issue contract。',
+  '',
+  '## Context',
+  '### Dependencies',
+  '```json',
+  '{ "dependsOn": [] }',
+  '```',
+  '### AllowedFiles',
+  '- apps/agent-daemon/src/audit-issue-contracts.ts',
+  '### ForbiddenFiles',
+  '- apps/agent-daemon/src/dashboard.ts',
+  '### MustPreserve',
+  '- 默认 human-readable 输出仍可用',
+  '### OutOfScope',
+  '- dashboard 可视化',
+  '### RequiredSemantics',
+  '- 支持 repo-level 审计摘要',
+  '### ReviewHints',
+  '- 检查 JSON 输出是否稳定',
+  '### Validation',
+  '- `bun test apps/agent-daemon/src/audit-issue-contracts.test.ts`',
+  '',
+  '## RED 测试',
+  '```ts',
+  'expect(true).toBe(false)',
+  '```',
+  '',
+  '## 实现步骤',
+  '1. 增加 repo-level summary',
+  '',
+  '## 验收',
+  '- [ ] repo-level summary 可用',
+].join('\\n')
+
+describe('auditIssues', () => {
+  test('returns stable repo summary and issue quality findings in json mode', async () => {
+    const result = await auditIssues({
+      issues: [
+        {
+          number: 71,
+          title: '[AL-X] invalid contract',
+          body: '## 用户故事\\n只有用户故事',
+          state: 'ready',
+          labels: ['agent:ready'],
+        },
+        {
+          number: 72,
+          title: '[AL-Y] valid contract',
+          body: VALID_CONTRACT,
+          state: 'ready',
+          labels: ['agent:ready'],
+        },
+      ],
+      includeSimulation: false,
+    })
+
+    expect(result.summary).toEqual({
+      auditedIssueCount: 2,
+      invalidIssueCount: 1,
+      invalidReadyIssueCount: 1,
+      lowScoreIssueCount: 1,
+      warningIssueCount: 0,
+    })
+    expect(result.issues[0]?.contract.errors).toContain('missing ### Dependencies JSON block')
+    expect(JSON.parse(formatAuditOutput(result, true))).toMatchObject({
+      summary: {
+        invalidIssueCount: 1,
+      },
+      issues: [
+        {
+          number: 71,
+          state: 'ready',
+        },
+      ],
+    })
+  })
+})
+```
+
+## 实现步骤
+
+1. 先把当前 audit 逻辑提炼成可复用的 repo-level report builder，并让测试先描述 summary / per-issue JSON 结构
+2. 再补 `agent-loop --audit-issues` 的参数解析，支持默认 open managed issues、重复 `--issue` 过滤、`--json` 与可选 `--simulate`
+3. 最后串好退出码、human-readable 输出兼容性与 typecheck
+
+## 验收
+
+- [ ] 只修改 `AllowedFiles` 内文件
+- [ ] 默认 human-readable 审计输出仍可用
+- [ ] `--json` 输出是稳定单一 JSON 对象
+- [ ] phase 1 的 quality / simulate 逻辑被复用，没有平行分叉实现
+- [ ] RED 测试转绿
+- [ ] 完成 `Validation` 中要求的验证

--- a/docs/roadmaps/executable-issue-system-phase-2/02-al-12-project-authoring-ruleset.md
+++ b/docs/roadmaps/executable-issue-system-phase-2/02-al-12-project-authoring-ruleset.md
@@ -1,0 +1,132 @@
+## 用户故事
+
+作为项目维护者，我希望为当前 repo 声明 issue authoring rules，并让 rewrite / split 等 authoring 流程稳定消费这些规则，从而把 `agent-loop` 从 generic demo 提升成真正能落地到不同项目的自动化开发框架。
+
+## Context
+
+### Dependencies
+```json
+{
+  "dependsOn": [37, 38, 39]
+}
+```
+
+### Constraints
+- 这次切片只做 project issue authoring rules 的 schema、聚合与 prompt 注入，不要顺手扩成 hosted profile registry
+- repo 没有配置 ruleset 时，现有 rewrite / split 行为必须保持兼容
+- 规则注入必须是 deterministic text / candidate merge，不能引入额外网络依赖
+
+### AllowedFiles
+- packages/agent-shared/src/types.ts
+- packages/agent-shared/src/project-profile.ts
+- packages/agent-shared/src/project-profile.test.ts
+- apps/agent-daemon/src/issue-authoring-context.ts
+- apps/agent-daemon/src/issue-authoring-context.test.ts
+- apps/agent-daemon/src/issue-authoring.ts
+- apps/agent-daemon/src/issue-authoring.test.ts
+- apps/agent-daemon/src/issue-splitter.ts
+- apps/agent-daemon/src/issue-splitter.test.ts
+
+### ForbiddenFiles
+- apps/agent-daemon/src/issue-simulate.ts
+- apps/agent-daemon/src/ready-gate.ts
+- apps/agent-daemon/src/dashboard.ts
+- packages/agent-shared/src/github-api.ts
+
+### MustPreserve
+- 现有 built-in project prompt guidance 顺序和默认行为不变
+- repo 没有 issue authoring ruleset 配置时，candidate validation commands / allowed files / forbidden files 的扫描逻辑保持现状
+- rewrite / split 依旧必须对 agent 输出做本地 contract 校验，不能因为加入 ruleset 就放宽
+
+### OutOfScope
+- hosted policy marketplace
+- 可视化编辑 ruleset 的 UI
+- issue repair / apply CLI
+- runtime dashboard / metrics 集成
+
+### RequiredSemantics
+- `ProjectProfileConfig` 可以声明 issue authoring rules，至少覆盖 preferred validation commands、preferred allowed files、forbidden paths、review hints
+- `buildRepoAuthoringContext` 会把 project rules 与 repo 扫描结果合并成稳定输出，且不会丢掉 repo-grounded candidates
+- rewrite / split prompts 必须显式展示 project issue rules，让 agent 知道哪些路径、命令、review concerns 属于 repo 约束
+- 当 ruleset 未配置时，authoring context 与 prompt 内容应保持当前兼容，不出现空标题或占位噪音
+
+### ReviewHints
+- 优先检查 ruleset merge 是否 deterministic，避免同一 repo 在不同机器或不同顺序下得到不稳定 prompt
+- 优先检查无配置路径的兼容性，尤其不要让 prompt 注入一堆空 section
+- 优先检查 preferred / forbidden path 是否真正进入 prompt，而不是只停留在 config types
+
+### Validation
+- `bun test packages/agent-shared/src/project-profile.test.ts apps/agent-daemon/src/issue-authoring-context.test.ts apps/agent-daemon/src/issue-authoring.test.ts apps/agent-daemon/src/issue-splitter.test.ts`
+- `bun run typecheck`
+- `git diff --stat origin/master...HEAD`
+
+## RED 测试
+
+```ts
+import { describe, expect, test } from 'bun:test'
+import { buildRepoAuthoringContext } from './issue-authoring-context'
+import { buildIssueRewritePrompt } from './issue-authoring'
+
+describe('project issue authoring rules', () => {
+  test('merges project rules into authoring context and rewrite prompts', async () => {
+    const context = await buildRepoAuthoringContext({
+      repoRoot: '/repo',
+      issueText: '增加 issue repair CLI',
+      repoRelativeFilePaths: [
+        'apps/agent-daemon/src/issue-repair.ts',
+        'apps/agent-daemon/src/issue-repair.test.ts',
+        'apps/agent-daemon/src/dashboard.ts',
+      ],
+      project: {
+        profile: 'generic',
+        issueAuthoring: {
+          preferredValidationCommands: [
+            'bun test apps/agent-daemon/src/issue-repair.test.ts',
+          ],
+          preferredAllowedFiles: [
+            'apps/agent-daemon/src/issue-repair.ts',
+            'apps/agent-daemon/src/issue-repair.test.ts',
+          ],
+          forbiddenPaths: [
+            'apps/agent-daemon/src/dashboard.ts',
+          ],
+          reviewHints: [
+            '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+          ],
+        },
+      },
+    })
+
+    const prompt = buildIssueRewritePrompt({
+      issueText: '增加 issue repair CLI',
+      authoringContext: context,
+    })
+
+    expect(context.candidateValidationCommands).toContain(
+      'bun test apps/agent-daemon/src/issue-repair.test.ts',
+    )
+    expect(context.candidateAllowedFiles.slice(0, 2)).toEqual([
+      'apps/agent-daemon/src/issue-repair.ts',
+      'apps/agent-daemon/src/issue-repair.test.ts',
+    ])
+    expect(context.candidateForbiddenFiles).toContain('apps/agent-daemon/src/dashboard.ts')
+    expect(prompt).toContain('Project Issue Rules')
+    expect(prompt).toContain('优先检查 repair 流程是否保留合法的 Dependencies JSON')
+  })
+})
+```
+
+## 实现步骤
+
+1. 先在 shared types / project profile 中定义最小 issue authoring rules schema，并让测试先约束 merge 后的 authoring context 结果
+2. 再让 `buildRepoAuthoringContext` 把 preferred validation commands、preferred allowed files、forbidden paths、review hints 合并进稳定候选集
+3. 最后更新 rewrite / split prompt builder，让 project issue rules 明确进入 prompt，并验证无配置路径兼容
+
+## 验收
+
+- [ ] 只修改 `AllowedFiles` 内文件
+- [ ] 无 ruleset 配置时的 rewrite / split 行为保持兼容
+- [ ] project issue rules 会稳定进入 authoring context 与 prompt
+- [ ] repo-grounded candidates 没有因为 ruleset 注入而丢失
+- [ ] RED 测试转绿
+- [ ] 完成 `Validation` 中要求的验证

--- a/docs/roadmaps/executable-issue-system-phase-2/03-al-13-issue-repair-cli.md
+++ b/docs/roadmaps/executable-issue-system-phase-2/03-al-13-issue-repair-cli.md
@@ -1,0 +1,217 @@
+## 用户故事
+
+作为仓库维护者，我希望 `agent-loop` 能把一条“接近可执行但仍有 lint / simulate 问题”的 issue contract 自动修成可执行合同，从而让高质量 issue 不只是靠第一次写对，还能进入持续 repair loop。
+
+## Context
+
+### Dependencies
+```json
+{
+  "dependsOn": [50, 51]
+}
+```
+
+### Constraints
+- repair 必须复用现有 lint / simulate / repo-grounded authoring 能力，不要再造第三套 findings 或评分模型
+- 本次切片只做本地 repair loop 与 CLI 输出，不写 GitHub issue body、不改 label、不触发 ready gate 状态变更
+- repair 的 happy path 应该是“最小修正文案合同”，不是重写需求、拆 issue 或扩 scope
+
+### AllowedFiles
+- apps/agent-daemon/src/index.ts
+- apps/agent-daemon/src/index.test.ts
+- apps/agent-daemon/src/issue-authoring.ts
+- apps/agent-daemon/src/issue-authoring.test.ts
+- apps/agent-daemon/src/issue-repair.ts
+- apps/agent-daemon/src/issue-repair.test.ts
+- apps/agent-daemon/src/issue-simulate.ts
+- apps/agent-daemon/src/issue-simulate.test.ts
+
+### ForbiddenFiles
+- packages/agent-shared/src/github-api.ts
+- apps/agent-daemon/src/issue-splitter.ts
+- apps/agent-daemon/src/ready-gate.ts
+- apps/agent-daemon/src/dashboard.ts
+
+### MustPreserve
+- repair 成功后的输出仍然必须是 canonical executable contract markdown，而不是解释性 prose 或 JSON-only 结果
+- 没有被 findings 指向的关键 metadata 不得被静默改坏，尤其是 `### Dependencies` fenced JSON、标题语义与已有 narrow scope
+- repair 成功前必须再次经过本地 contract 校验；不能把“修了但仍不合法”的草稿当成功返回
+- CLI 保持只读；本 issue 不得对 GitHub 远端 issue 做任何写操作
+
+### OutOfScope
+- 把 repair 结果写回 GitHub issue
+- 自动创建 child issue 或回写 parent / child 拆分图
+- dashboard / metrics 集成
+- 自动恢复 `agent:ready` 或修改 daemon 调度状态
+
+### RequiredSemantics
+- `agent-loop --repair-file <path>` 会读取本地 issue markdown，先做 lint，再在显式传入 `--simulate` 时叠加 simulate findings，然后生成 repaired canonical markdown
+- repair prompt 必须显式消费当前 issue body、lint errors / warnings、simulate findings、repo-grounded authoring context 与 project issue rules
+- 当 repair 输出仍然失败本地 contract 校验，或在要求 `--simulate` 时仍失败 simulate，命令必须非 0 退出并暴露 blocking findings
+- 默认 stdout 输出应是 repaired markdown 本体，便于后续人工审阅或交给 apply/sync CLI；`--json` 时输出稳定结果对象，至少包含 before/after validation、applied finding codes、final markdown
+- repair 过程必须优先做最小修正，不能为了“修过 lint”而删除 `Dependencies`、宽化 `AllowedFiles`、或把具体 validation 改成泛泛描述
+
+### ReviewHints
+- 优先检查 repair 是否真正消费现有 lint / simulate findings，而不是重新猜问题
+- 优先检查 repair 成功后的 markdown 是否仍保留 canonical section order 与机器可解析的 `Dependencies` JSON
+- 优先检查 `--json` 是否既保留 final markdown，又暴露 before/after 结果，避免后续 apply/sync 无法复用
+
+### Validation
+- `bun test apps/agent-daemon/src/issue-repair.test.ts apps/agent-daemon/src/issue-authoring.test.ts apps/agent-daemon/src/issue-simulate.test.ts apps/agent-daemon/src/index.test.ts`
+- `bun run typecheck`
+- `git diff --stat origin/master...HEAD`
+
+## RED 测试
+
+```ts
+import { describe, expect, test } from 'bun:test'
+import { repairIssueDraft } from './issue-repair'
+
+const BROKEN_ISSUE = [
+  '## 用户故事',
+  '作为维护者，我希望修复 issue contract。',
+  '',
+  '## Context',
+  '### Dependencies',
+  '```json',
+  '{ "dependsOn": [50, 51] }',
+  '```',
+  '### AllowedFiles',
+  '- frontend files',
+  '### ForbiddenFiles',
+  '- apps/agent-daemon/src/dashboard.ts',
+  '### MustPreserve',
+  '- `dependsOn` JSON 必须保持机器可解析',
+  '### OutOfScope',
+  '- GitHub 远端写回',
+  '### RequiredSemantics',
+  '- repair 结果必须仍然是 canonical markdown',
+  '### ReviewHints',
+  '- 优先检查是否偷偷删掉 Dependencies',
+  '### Validation',
+  '- 观察一下 issue 看起来是否更清楚',
+  '',
+  '## RED 测试',
+  '```ts',
+  'expect(true).toBe(false)',
+  '```',
+  '',
+  '## 实现步骤',
+  '1. 修一下',
+  '',
+  '## 验收',
+  '- [ ] issue 更好一些',
+].join('\\n')
+
+const REPAIRED_ISSUE = [
+  '## 用户故事',
+  '作为维护者，我希望修复 issue contract，从而让 agent-loop 可以稳定消费高质量 issue。',
+  '',
+  '## Context',
+  '### Dependencies',
+  '```json',
+  '{ "dependsOn": [50, 51] }',
+  '```',
+  '### Constraints',
+  '- 只修 contract 本身，不写 GitHub 远端',
+  '### AllowedFiles',
+  '- apps/agent-daemon/src/issue-repair.ts',
+  '- apps/agent-daemon/src/issue-repair.test.ts',
+  '### ForbiddenFiles',
+  '- apps/agent-daemon/src/dashboard.ts',
+  '### MustPreserve',
+  '- `dependsOn` JSON 必须保持机器可解析',
+  '### OutOfScope',
+  '- GitHub 远端写回',
+  '### RequiredSemantics',
+  '- repair 结果必须仍然是 canonical markdown',
+  '### ReviewHints',
+  '- 优先检查是否偷偷删掉 Dependencies',
+  '### Validation',
+  '- `bun test apps/agent-daemon/src/issue-repair.test.ts`',
+  '- `git diff --stat origin/master...HEAD`',
+  '',
+  '## RED 测试',
+  '```ts',
+  'expect(true).toBe(false)',
+  '```',
+  '',
+  '## 实现步骤',
+  '1. 先让 repair flow 消费 findings',
+  '',
+  '## 验收',
+  '- [ ] repair 输出通过本地 contract 校验',
+].join('\\n')
+
+describe('repairIssueDraft', () => {
+  test('preserves dependency metadata while repairing lint and simulate findings', async () => {
+    const result = await repairIssueDraft({
+      issueText: BROKEN_ISSUE,
+      repoRoot: '/repo',
+      includeSimulation: true,
+      lintReport: {
+        valid: true,
+        readyGateBlocked: false,
+        readyGateStatus: 'pass',
+        readyGateSummary: 'ok',
+        score: 70,
+        errors: [],
+        warnings: [
+          'AllowedFiles should use exact paths or tightly scoped directories: frontend files',
+        ],
+        source: { kind: 'file', path: 'broken.md' },
+        contract: {} as never,
+      },
+      simulationResult: {
+        valid: false,
+        summary: 'simulation failed',
+        failures: [
+          'allowed file scope is too broad for reliable review/auto-fix: frontend files',
+          'validation commands are too generic to confirm issue-specific semantics',
+        ],
+        findings: [
+          {
+            code: 'allowed_files_too_broad',
+            stage: 'reviewer',
+            message: 'allowed file scope is too broad for reliable review/auto-fix: frontend files',
+          },
+          {
+            code: 'validation_too_generic',
+            stage: 'reviewer',
+            message: 'validation commands are too generic to confirm issue-specific semantics',
+          },
+        ],
+        plannerPrompt: '',
+        plannerOutput: '',
+        plannedSubtasks: [],
+      },
+      runAgent: async () => ({
+        responseText: REPAIRED_ISSUE,
+      }),
+    })
+
+    expect(result.repairedMarkdown).toContain('{ "dependsOn": [50, 51] }')
+    expect(result.appliedFindingCodes).toEqual([
+      'allowed_files_too_broad',
+      'validation_too_generic',
+    ])
+    expect(result.after.validation.valid).toBe(true)
+    expect(result.after.simulation?.valid).toBe(true)
+  })
+})
+```
+
+## 实现步骤
+
+1. 先新增 `issue-repair.ts` 与对应测试，定义 repair input/output、before/after report，以及基于 findings 的 repair prompt 生成
+2. 再把 repair flow 接到现有 lint / simulate / authoring primitives 上，确保输出再次经过本地 validation，且在 `--simulate` 时补做 after-simulate
+3. 最后在 CLI 中增加 `--repair-file`、`--simulate`、`--json` 的执行路径与退出码语义
+
+## 验收
+
+- [ ] 只修改 `AllowedFiles` 内文件
+- [ ] repair 复用了现有 lint / simulate / authoring 能力，没有平行分叉实现
+- [ ] repair 输出保留 canonical section order 和 `Dependencies` JSON
+- [ ] CLI 仍是只读，不会写 GitHub issue 或 label
+- [ ] RED 测试转绿
+- [ ] 完成 `Validation` 中要求的验证

--- a/docs/roadmaps/executable-issue-system-phase-2/04-al-14-issue-apply-sync-cli.md
+++ b/docs/roadmaps/executable-issue-system-phase-2/04-al-14-issue-apply-sync-cli.md
@@ -1,0 +1,175 @@
+## 用户故事
+
+作为仓库维护者，我希望把本地修好的 executable issue contract 安全回写到 GitHub 现有 issue，从而让 rewrite / repair 的结果真正进入远端事实状态，而不是停留在本地草稿。
+
+## Context
+
+### Dependencies
+```json
+{
+  "dependsOn": [53]
+}
+```
+
+### Constraints
+- 本次切片只更新现有 GitHub issue body，不自动创建 issue、不自动拆 child issue、不自动改 label
+- 回写前必须先做本地 contract 校验，拒绝把 invalid markdown 写到远端
+- 远端写入必须带并发保护；不能在远端 issue 已经被别人更新后还静默覆盖
+
+### AllowedFiles
+- apps/agent-daemon/src/index.ts
+- apps/agent-daemon/src/index.test.ts
+- apps/agent-daemon/src/issue-apply.ts
+- apps/agent-daemon/src/issue-apply.test.ts
+- packages/agent-shared/src/github-api.ts
+- packages/agent-shared/src/github-api.test.ts
+
+### ForbiddenFiles
+- apps/agent-daemon/src/daemon.ts
+- apps/agent-daemon/src/ready-gate.ts
+- apps/agent-daemon/src/dashboard.ts
+- apps/agent-daemon/src/issue-splitter.ts
+
+### MustPreserve
+- 当远端 issue body 已与目标 markdown 完全一致时，apply 必须是 no-op，而不是重复 PATCH
+- apply 成功前必须验证本地 markdown 是 executable contract；不能为“方便同步”放宽 contract 规则
+- 本 issue 不得顺手改 `agent:*` labels、assignee、comment 或 ready gate 行为
+- 发生并发冲突时必须显式失败并保留远端现状，不能静默覆盖
+
+### OutOfScope
+- 自动创建 parent / child issues
+- 自动加 `agent:ready` 或自动触发 ready gate
+- dashboard / metrics 观测
+- review / repair 自动循环
+
+### RequiredSemantics
+- `agent-loop --apply-file <path> --issue <number> --repo owner/repo --expected-updated-at <iso>` 会先读取本地 markdown、做 contract 校验、再读取远端 issue snapshot，并在 `updatedAt` 与预期不一致时以 conflict 非 0 退出
+- `--force` 可以显式绕过 `--expected-updated-at` 并发检查，但仍然必须保留本地 contract 校验
+- 当远端 body 与本地 markdown 一致时，命令返回 `noop` 结果且不发出 PATCH
+- 成功更新时，命令返回包含 issue number、issue url、old updatedAt、new updatedAt、status=`updated` 的稳定结果；`--json` 时必须输出单一 JSON 对象
+- 回写实现必须走共享 GitHub API helper，而不是散落在 CLI 中直接拼 gh 命令
+
+### ReviewHints
+- 优先检查 apply 是否在 PATCH 前严格校验本地 markdown，而不是把远端当实验场
+- 优先检查并发保护是否真的阻止了 stale write，而不是只打印 warning 继续覆盖
+- 优先检查 no-op 路径是否跳过了 PATCH，避免无意义更新远端 `updatedAt`
+
+### Validation
+- `bun test apps/agent-daemon/src/issue-apply.test.ts apps/agent-daemon/src/index.test.ts packages/agent-shared/src/github-api.test.ts`
+- `bun run typecheck`
+- `git diff --stat origin/master...HEAD`
+
+## RED 测试
+
+```ts
+import { describe, expect, test } from 'bun:test'
+import { applyIssueBodyUpdate } from './issue-apply'
+
+const VALID_MARKDOWN = [
+  '## 用户故事',
+  '作为维护者，我希望安全回写 issue contract。',
+  '',
+  '## Context',
+  '### Dependencies',
+  '```json',
+  '{ "dependsOn": [53] }',
+  '```',
+  '### Constraints',
+  '- 只更新 issue body',
+  '### AllowedFiles',
+  '- apps/agent-daemon/src/issue-apply.ts',
+  '### ForbiddenFiles',
+  '- apps/agent-daemon/src/dashboard.ts',
+  '### MustPreserve',
+  '- stale write 必须失败',
+  '### OutOfScope',
+  '- 自动加 label',
+  '### RequiredSemantics',
+  '- apply 只回写 canonical markdown',
+  '### ReviewHints',
+  '- 优先检查并发保护',
+  '### Validation',
+  '- `bun test apps/agent-daemon/src/issue-apply.test.ts`',
+  '',
+  '## RED 测试',
+  '```ts',
+  'expect(true).toBe(false)',
+  '```',
+  '',
+  '## 实现步骤',
+  '1. 先做远端并发保护',
+  '',
+  '## 验收',
+  '- [ ] stale write 被阻止',
+].join('\\n')
+
+describe('applyIssueBodyUpdate', () => {
+  test('returns conflict when the remote issue changed after the expected timestamp', async () => {
+    const result = await applyIssueBodyUpdate({
+      issueNumber: 54,
+      markdown: VALID_MARKDOWN,
+      expectedUpdatedAt: '2026-04-11T10:00:00.000Z',
+      config: { repo: 'owner/repo' } as never,
+      fetchIssue: async () => ({
+        number: 54,
+        title: '[AL-14] apply',
+        body: 'remote body',
+        url: 'https://github.com/owner/repo/issues/54',
+        updatedAt: '2026-04-11T10:05:00.000Z',
+      }),
+      updateIssueBody: async () => {
+        throw new Error('should not patch on conflict')
+      },
+    })
+
+    expect(result.status).toBe('conflict')
+    expect(result.updated).toBe(false)
+  })
+
+  test('patches the remote issue only when the snapshot still matches expectations', async () => {
+    const calls: string[] = []
+    const result = await applyIssueBodyUpdate({
+      issueNumber: 54,
+      markdown: VALID_MARKDOWN,
+      expectedUpdatedAt: '2026-04-11T10:00:00.000Z',
+      config: { repo: 'owner/repo' } as never,
+      fetchIssue: async () => ({
+        number: 54,
+        title: '[AL-14] apply',
+        body: 'older body',
+        url: 'https://github.com/owner/repo/issues/54',
+        updatedAt: '2026-04-11T10:00:00.000Z',
+      }),
+      updateIssueBody: async ({ issueNumber, body }) => {
+        calls.push(`patch:${issueNumber}`)
+        expect(body).toBe(VALID_MARKDOWN)
+        return {
+          number: issueNumber,
+          url: 'https://github.com/owner/repo/issues/54',
+          updatedAt: '2026-04-11T10:06:00.000Z',
+        }
+      },
+    })
+
+    expect(calls).toEqual(['patch:54'])
+    expect(result.status).toBe('updated')
+    expect(result.updated).toBe(true)
+    expect(result.newUpdatedAt).toBe('2026-04-11T10:06:00.000Z')
+  })
+})
+```
+
+## 实现步骤
+
+1. 先新增 `issue-apply.ts` 和测试，定义远端 snapshot 获取、stale-write 检查、no-op 判定与 body PATCH helper
+2. 再在 shared GitHub API 层补共享的 issue body update primitive，并保证 CLI 不直接散落 gh PATCH 逻辑
+3. 最后把 `--apply-file`、`--issue`、`--expected-updated-at`、`--force`、`--json` 接入 CLI，并串好退出码与结果输出
+
+## 验收
+
+- [ ] 只修改 `AllowedFiles` 内文件
+- [ ] invalid markdown 不会被写回 GitHub
+- [ ] stale write 会以 conflict 显式失败
+- [ ] no-op 路径不会发出 PATCH
+- [ ] RED 测试转绿
+- [ ] 完成 `Validation` 中要求的验证

--- a/docs/roadmaps/executable-issue-system-phase-2/05-al-15-issue-ops-dashboard-metrics.md
+++ b/docs/roadmaps/executable-issue-system-phase-2/05-al-15-issue-ops-dashboard-metrics.md
@@ -1,0 +1,125 @@
+## 用户故事
+
+作为维护者或团队负责人，我希望在 dashboard 和 metrics 里直接看到 issue contract 质量信号，从而区分“daemon / runtime 出问题”和“issue harness 本身在积累质量债”。
+
+## Context
+
+### Dependencies
+```json
+{
+  "dependsOn": [50]
+}
+```
+
+### Constraints
+- 复用已有 audit / quality 报告逻辑，不要在 dashboard 或 metrics 里重算另一套 score 规则
+- 不能把 planner simulate 放进 daemon 热路径；issue ops 观测必须基于已有 issue body 数据与静态质量检查
+- 新增观测不能破坏现有 dashboard 的 machine / lease / PR 视图，也不能让 metrics endpoint 因 issue 质量采集失败而不可抓取
+
+### AllowedFiles
+- apps/agent-daemon/src/audit-issue-contracts.ts
+- apps/agent-daemon/src/dashboard.ts
+- apps/agent-daemon/src/dashboard.test.ts
+- apps/agent-daemon/src/daemon.ts
+- apps/agent-daemon/src/daemon.test.ts
+- apps/agent-daemon/src/metrics.ts
+- apps/agent-daemon/src/metrics.test.ts
+
+### ForbiddenFiles
+- apps/agent-daemon/src/issue-authoring.ts
+- apps/agent-daemon/src/issue-repair.ts
+- apps/agent-daemon/src/issue-apply.ts
+- packages/agent-shared/src/github-api.ts
+
+### MustPreserve
+- 现有 dashboard summary、machine cards、PR 视图与 runtime observability 语义不变
+- metrics endpoint 在 issue ops 数据暂时不可用时仍必须正常暴露其他指标
+- issue ops 计数必须来自已有 issue quality report / managed issue 列表，而不是额外逐条 GitHub 请求
+- 本 issue 不得顺手加入 GitHub 写操作、auto-fix、repair 或 apply 行为
+
+### OutOfScope
+- hosted analytics、历史趋势图、团队级报表
+- 自动修 issue 或自动回写 GitHub
+- per-issue planner simulate dashboard
+- 告警路由、值班集成或商业计费逻辑
+
+### RequiredSemantics
+- dashboard summary 必须新增至少三类 issue ops 计数：`invalidReadyIssueCount`、`lowScoreIssueCount`、`warningIssueCount`
+- dashboard 的 issue 视图必须暴露每条 issue 的 quality score、warning count，以及 ready gate 是否会因为 hard validation 被阻塞
+- daemon metrics 必须新增对应 gauges，至少覆盖 invalid ready、low score、warning issue 三类 repo-level 计数
+- 这些 gauges 必须在 daemon 现有 open issue poll / reconcile 路径中更新，且只基于已拿到的 issue body 做静态质量计算，不额外跑 simulate planner
+- 当某次 issue ops 数据刷新失败时，dashboard 应把失败写进 notes / errors，而不是整页不可用；metrics 刷新失败不应影响其他指标输出
+
+### ReviewHints
+- 优先检查 dashboard 与 metrics 是否复用了同一套 quality summary，避免两个入口的数字漂移
+- 优先检查 daemon 热路径是否没有偷偷加进昂贵的 simulate / planner 调用
+- 优先检查 issue 视图新增字段是否真的帮助定位“是 issue 质量差还是 runtime 坏了”
+
+### Validation
+- `bun test apps/agent-daemon/src/dashboard.test.ts apps/agent-daemon/src/daemon.test.ts apps/agent-daemon/src/metrics.test.ts`
+- `bun run typecheck`
+- `git diff --stat origin/master...HEAD`
+
+## RED 测试
+
+```ts
+import { describe, expect, test } from 'bun:test'
+import { buildDashboardIssueOpsSummary } from './dashboard'
+import { registry, setIssueOpsSummaryMetrics } from './metrics'
+
+describe('issue ops observability', () => {
+  test('derives dashboard summary counts from audited issue quality data', async () => {
+    const summary = buildDashboardIssueOpsSummary([
+      {
+        number: 50,
+        title: '[AL-11] audit',
+        state: 'ready',
+        isClaimable: true,
+        hasExecutableContract: false,
+        claimBlockedBy: [],
+        contractValidationErrors: ['missing ## RED 测试 / RED Tests'],
+        qualityScore: 40,
+        contractWarnings: [],
+      },
+      {
+        number: 53,
+        title: '[AL-13] repair',
+        state: 'ready',
+        isClaimable: true,
+        hasExecutableContract: true,
+        claimBlockedBy: [],
+        contractValidationErrors: [],
+        qualityScore: 75,
+        contractWarnings: ['AllowedFiles should use exact paths or tightly scoped directories: frontend files'],
+      },
+    ])
+
+    expect(summary).toEqual({
+      invalidReadyIssueCount: 1,
+      lowScoreIssueCount: 2,
+      warningIssueCount: 1,
+    })
+
+    setIssueOpsSummaryMetrics(summary)
+    const metrics = await registry.metrics()
+    expect(metrics).toContain('agent_loop_issue_contract_invalid_ready 1')
+    expect(metrics).toContain('agent_loop_issue_contract_warning_issues 1')
+    expect(metrics).toContain('agent_loop_issue_contract_low_score_issues 2')
+  })
+})
+```
+
+## 实现步骤
+
+1. 先把 issue quality summary 提炼成 dashboard / daemon / metrics 可复用的轻量 helper，并让测试先固定 summary 计数语义
+2. 再把这些 summary 字段接入 dashboard summary 和 issue 视图，保证页面在 issue ops 数据失败时仍然能显示其他 runtime 内容
+3. 最后在 daemon 现有 issue poll / reconcile 路径中更新 Prometheus gauges，并完成 metrics / daemon 回归测试
+
+## 验收
+
+- [ ] 只修改 `AllowedFiles` 内文件
+- [ ] dashboard 与 metrics 复用了同一套 issue quality summary
+- [ ] daemon 热路径没有新增 planner simulate 调用
+- [ ] dashboard 可以直接看出 invalid ready、low score、warning issue 的 repo-level 状态
+- [ ] RED 测试转绿
+- [ ] 完成 `Validation` 中要求的验证

--- a/docs/roadmaps/executable-issue-system-phase-2/README.md
+++ b/docs/roadmaps/executable-issue-system-phase-2/README.md
@@ -1,0 +1,43 @@
+# Executable Issue System Phase 2
+
+这组文件把 phase 2 roadmap 拆成可直接提交到 GitHub 的独立 issue body。
+
+创建这组 issue 时，GitHub 实际分配的编号是：
+
+- `#49` `[AL-EPIC] Executable Issue System Phase 2`
+- `#50` `[AL-11] 增加 repo issue audit report CLI 与 JSON 输出`
+- `#51` `[AL-12] 支持 project issue authoring profile / ruleset 注入`
+- `#53` `[AL-13] 增加 issue repair CLI 并消费 lint / simulate findings`
+- `#54` `[AL-14] 增加 issue apply / sync CLI 安全回写 GitHub`
+- `#55` `[AL-15] 在 dashboard / metrics 中暴露 issue ops 信号`
+
+注意：
+
+- GitHub 的 issue 编号与 PR 共用同一套序号
+- 因此 phase 2 的 issue 编号中跳过了 `#52`，因为它已经被 PR `#52` 占用
+- 这份目录里的 markdown 现在已经按真实 issue 编号写好，可以继续作为 roadmap source of truth 维护
+
+文件说明：
+
+- [00-parent-epic.md](/Users/wujames/.agent-worktrees/JamesWuHK-agent-loop/roadmap-phase2-codex-dev/docs/roadmaps/executable-issue-system-phase-2/00-parent-epic.md)
+- [01-al-11-repo-issue-audit-report.md](/Users/wujames/.agent-worktrees/JamesWuHK-agent-loop/roadmap-phase2-codex-dev/docs/roadmaps/executable-issue-system-phase-2/01-al-11-repo-issue-audit-report.md)
+- [02-al-12-project-authoring-ruleset.md](/Users/wujames/.agent-worktrees/JamesWuHK-agent-loop/roadmap-phase2-codex-dev/docs/roadmaps/executable-issue-system-phase-2/02-al-12-project-authoring-ruleset.md)
+- [03-al-13-issue-repair-cli.md](/Users/wujames/.agent-worktrees/JamesWuHK-agent-loop/roadmap-phase2-codex-dev/docs/roadmaps/executable-issue-system-phase-2/03-al-13-issue-repair-cli.md)
+- [04-al-14-issue-apply-sync-cli.md](/Users/wujames/.agent-worktrees/JamesWuHK-agent-loop/roadmap-phase2-codex-dev/docs/roadmaps/executable-issue-system-phase-2/04-al-14-issue-apply-sync-cli.md)
+- [05-al-15-issue-ops-dashboard-metrics.md](/Users/wujames/.agent-worktrees/JamesWuHK-agent-loop/roadmap-phase2-codex-dev/docs/roadmaps/executable-issue-system-phase-2/05-al-15-issue-ops-dashboard-metrics.md)
+
+建议执行顺序：
+
+1. `#50` `AL-11`
+2. `#51` `AL-12`
+3. `#53` `AL-13`
+4. `#54` `AL-14`
+5. `#55` `AL-15`
+
+依赖提示：
+
+- `#53` 依赖 `#50` 与 `#51`
+- `#54` 依赖 `#53`
+- `#55` 只依赖 `#50`
+
+这意味着 `#55` 在依赖图上可以与 `#51` / `#53` / `#54` 并行推进；如果想保持 phase 2 叙事更集中，仍然建议把它放在后面执行。


### PR DESCRIPTION
## Summary
- add the phase 2 executable-issue-system roadmap docs and README
- create and sync the parent epic plus AL-11 through AL-15 issue bodies with real GitHub issue numbers
- capture the accurate dependency graph for audit, ruleset injection, repair, apply, and issue-ops observability

## Linked Issues
- #49
- #50
- #51
- #53
- #54
- #55

## Testing
- docs only; no code tests run