### PR TITLE
feat: add repo issue audit CLI

### DIFF
--- a/apps/agent-daemon/src/audit-issue-contracts.test.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.test.ts
@@ -1,13 +1,51 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  auditIssues,
   buildGhIssueViewArgs,
   buildIssueLintReport,
   fetchRemoteIssueDocument,
+  formatAuditOutput,
   formatAuditLine,
   formatInvalidReadySection,
   formatIssueLintReport,
   formatIssueLintReportJson,
 } from './audit-issue-contracts'
+
+const VALID_CONTRACT = [
+  '## 用户故事',
+  '作为维护者，我希望批量审计 issue contract。',
+  '',
+  '## Context',
+  '### Dependencies',
+  '```json',
+  '{ "dependsOn": [] }',
+  '```',
+  '### AllowedFiles',
+  '- apps/agent-daemon/src/audit-issue-contracts.ts',
+  '### ForbiddenFiles',
+  '- apps/agent-daemon/src/dashboard.ts',
+  '### MustPreserve',
+  '- 默认 human-readable 输出仍可用',
+  '### OutOfScope',
+  '- dashboard 可视化',
+  '### RequiredSemantics',
+  '- 支持 repo-level 审计摘要',
+  '### ReviewHints',
+  '- 检查 JSON 输出是否稳定',
+  '### Validation',
+  '- `bun test apps/agent-daemon/src/audit-issue-contracts.test.ts`',
+  '',
+  '## RED 测试',
+  '```ts',
+  'expect(true).toBe(false)',
+  '```',
+  '',
+  '## 实现步骤',
+  '1. 增加 repo-level summary',
+  '',
+  '## 验收',
+  '- [ ] repo-level summary 可用',
+].join('\n')
 
 describe('audit-issue-contracts', () => {
   test('builds a lint report that keeps warnings separate from hard errors', () => {
@@ -101,6 +139,87 @@ describe('audit-issue-contracts', () => {
     })
   })
 
+  test('returns stable repo summary and issue quality findings in json mode', async () => {
+    const result = await auditIssues({
+      issues: [
+        {
+          number: 71,
+          title: '[AL-X] invalid contract',
+          body: '## 用户故事\n只有用户故事',
+          state: 'ready',
+          labels: ['agent:ready'],
+        },
+        {
+          number: 72,
+          title: '[AL-Y] valid contract',
+          body: VALID_CONTRACT,
+          state: 'ready',
+          labels: ['agent:ready'],
+        },
+      ],
+      includeSimulation: false,
+    })
+
+    expect(result.summary).toEqual({
+      auditedIssueCount: 2,
+      invalidIssueCount: 1,
+      invalidReadyIssueCount: 1,
+      lowScoreIssueCount: 1,
+      warningIssueCount: 0,
+    })
+    expect(result.issues[0]?.contract.errors).toContain('missing ### Dependencies JSON block')
+    const jsonReport = JSON.parse(formatAuditOutput(result, true))
+    expect(jsonReport.summary).toMatchObject({
+      invalidIssueCount: 1,
+    })
+    expect(jsonReport.issues[0]).toMatchObject({
+      number: 71,
+      state: 'ready',
+    })
+  })
+
+  test('includes simulation findings only when requested', async () => {
+    const result = await auditIssues({
+      issues: [
+        {
+          number: 73,
+          title: '[AL-Z] simulate me',
+          body: VALID_CONTRACT,
+          state: 'ready',
+          labels: ['agent:ready'],
+        },
+      ],
+      includeSimulation: true,
+      repoRoot: '/tmp/agent-loop',
+    }, {
+      simulateIssueExecutability: async ({ issueTitle, issueBody, repoRoot }) => {
+        expect(issueTitle).toBe('[AL-Z] simulate me')
+        expect(issueBody).toBe(VALID_CONTRACT)
+        expect(repoRoot).toBe('/tmp/agent-loop')
+
+        return {
+          valid: false,
+          summary: 'simulation failed',
+          failures: ['planning output does not contain commit-shaped subtasks'],
+          findings: [{
+            code: 'planning_not_commit_shaped',
+            stage: 'planner',
+            message: 'planning output does not contain commit-shaped subtasks',
+          }],
+          plannerPrompt: 'prompt',
+          plannerOutput: 'Read the repo',
+          plannedSubtasks: ['Read the repo'],
+        }
+      },
+    })
+
+    expect(result.issues[0]?.simulation).toMatchObject({
+      valid: false,
+      failures: ['planning output does not contain commit-shaped subtasks'],
+    })
+    expect(formatAuditOutput(result)).toContain('simulation=fail')
+  })
+
   test('formats claimability, quality score, and contract errors on one line', () => {
     expect(
       formatAuditLine({
@@ -113,6 +232,11 @@ describe('audit-issue-contracts', () => {
         contractValidationErrors: ['missing ## RED 测试 / RED Tests'],
         qualityScore: 75,
         contractWarnings: ['AllowedFiles should use exact paths or tightly scoped directories: frontend files'],
+        contract: {
+          valid: false,
+          errors: ['missing ## RED 测试 / RED Tests'],
+          warnings: ['AllowedFiles should use exact paths or tightly scoped directories: frontend files'],
+        },
       }),
     ).toBe(
       '#51 state=ready claimable=false contract=false score=75 warnings=1 blockedBy=49,50 errors=missing ## RED 测试 / RED Tests',
@@ -136,6 +260,16 @@ describe('audit-issue-contracts', () => {
         contractWarnings: [
           'AllowedFiles should use exact paths or tightly scoped directories: frontend files',
         ],
+        contract: {
+          valid: false,
+          errors: [
+            'missing ### Dependencies JSON block',
+            'missing executable scope contract (AllowedFiles/ForbiddenFiles/MustPreserve/OutOfScope/RequiredSemantics)',
+          ],
+          warnings: [
+            'AllowedFiles should use exact paths or tightly scoped directories: frontend files',
+          ],
+        },
       },
     ])
 

--- a/apps/agent-daemon/src/audit-issue-contracts.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.ts
@@ -8,6 +8,26 @@ import {
 import { parseIssueContract, summarizeIssueContract } from '../../../packages/agent-shared/src/issue-contract'
 import { buildIssueQualityReport } from '../../../packages/agent-shared/src/issue-quality'
 import { loadConfig, type CliArgs } from './config'
+import {
+  simulateIssueExecutability,
+  type IssueSimulationResult,
+} from './issue-simulate'
+
+const LOW_SCORE_THRESHOLD = 80
+
+type AuditableIssue = Pick<AgentIssue, 'number' | 'title' | 'body' | 'state'> & Partial<Pick<AgentIssue,
+  'labels'
+  | 'isClaimable'
+  | 'hasExecutableContract'
+  | 'claimBlockedBy'
+  | 'contractValidationErrors'
+>>
+
+export interface AuditedIssueContract {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+}
 
 export interface AuditedIssue {
   number: number
@@ -19,15 +39,20 @@ export interface AuditedIssue {
   contractValidationErrors: string[]
   qualityScore: number
   contractWarnings: string[]
+  contract: AuditedIssueContract
+  simulation?: IssueSimulationResult
+}
+
+export interface AuditIssueSummary {
+  auditedIssueCount: number
+  invalidIssueCount: number
+  invalidReadyIssueCount: number
+  lowScoreIssueCount: number
+  warningIssueCount: number
 }
 
 export interface AuditIssueContractsJsonReport {
-  totals: {
-    managedIssues: number
-    readyIssues: number
-    invalidReadyIssues: number
-    issuesWithWarnings: number
-  }
+  summary: AuditIssueSummary
   issues: Array<AuditedIssue & {
     readyGateBlocked: boolean
   }>
@@ -77,12 +102,20 @@ interface RemoteIssueFetchDependencies {
   ) => Promise<RemoteIssueViewCommandResult>
 }
 
+interface AuditIssuesDependencies {
+  simulateIssueExecutability: typeof simulateIssueExecutability
+}
+
 const DEFAULT_REMOTE_ISSUE_FETCH_DEPENDENCIES: RemoteIssueFetchDependencies = {
   runIssueViewCommand: async () => ({
     stdout: '',
     stderr: '',
     exitCode: 1,
   }),
+}
+
+const DEFAULT_AUDIT_ISSUES_DEPENDENCIES: AuditIssuesDependencies = {
+  simulateIssueExecutability,
 }
 
 export function buildIssueLintReport(
@@ -110,25 +143,83 @@ export function buildIssueLintReport(
 }
 
 export function buildAuditedIssue(
-  issue: Pick<AgentIssue, 'number' | 'title' | 'state' | 'isClaimable' | 'hasExecutableContract' | 'claimBlockedBy' | 'contractValidationErrors' | 'body'>,
+  issue: AuditableIssue,
 ): AuditedIssue {
   const report = buildIssueLintReport(issue.body, {
     kind: 'issue',
     issueNumber: issue.number,
     repo: 'unknown',
   }, issue.title)
+  const contractErrors = [...report.errors]
+  const claimBlockedBy = [...(issue.claimBlockedBy ?? [])]
+  const hasExecutableContract = issue.hasExecutableContract ?? report.valid
 
   return {
     number: issue.number,
     title: issue.title,
     state: issue.state,
-    isClaimable: issue.isClaimable,
-    hasExecutableContract: issue.hasExecutableContract,
-    claimBlockedBy: [...issue.claimBlockedBy],
-    contractValidationErrors: [...issue.contractValidationErrors],
+    isClaimable: issue.isClaimable ?? (
+      issue.state === 'ready'
+      && hasExecutableContract
+      && claimBlockedBy.length === 0
+    ),
+    hasExecutableContract,
+    claimBlockedBy,
+    contractValidationErrors: contractErrors,
     qualityScore: report.score,
-    contractWarnings: report.warnings,
+    contractWarnings: [...report.warnings],
+    contract: {
+      valid: report.valid,
+      errors: contractErrors,
+      warnings: [...report.warnings],
+    },
   }
+}
+
+export function buildAuditIssueSummary(issues: AuditedIssue[]): AuditIssueSummary {
+  return {
+    auditedIssueCount: issues.length,
+    invalidIssueCount: issues.filter((issue) => !issue.contract.valid).length,
+    invalidReadyIssueCount: issues.filter((issue) => issue.state === 'ready' && !issue.contract.valid).length,
+    lowScoreIssueCount: issues.filter((issue) => issue.qualityScore < LOW_SCORE_THRESHOLD).length,
+    warningIssueCount: issues.filter((issue) => issue.contract.warnings.length > 0).length,
+  }
+}
+
+export async function auditIssues(
+  input: {
+    issues: AuditableIssue[]
+    includeSimulation: boolean
+    repoRoot?: string
+    config?: AgentConfig
+  },
+  deps: AuditIssuesDependencies = DEFAULT_AUDIT_ISSUES_DEPENDENCIES,
+): Promise<AuditIssueContractsJsonReport> {
+  if (input.includeSimulation && !input.repoRoot) {
+    throw new Error('repoRoot is required when includeSimulation is enabled')
+  }
+
+  const auditedIssues = await Promise.all(input.issues.map(async (issue) => {
+    const audited = buildAuditedIssue(issue)
+
+    if (!input.includeSimulation) {
+      return audited
+    }
+
+    const simulation = await deps.simulateIssueExecutability({
+      issueTitle: issue.title,
+      issueBody: issue.body,
+      repoRoot: input.repoRoot!,
+      config: input.config,
+    })
+
+    return {
+      ...audited,
+      simulation,
+    }
+  }))
+
+  return buildAuditIssueContractsJsonReport(auditedIssues)
 }
 
 export function formatAuditLine(issue: AuditedIssue): string {
@@ -157,21 +248,58 @@ export function buildAuditIssueContractsJsonReport(
   issues: AuditedIssue[],
 ): AuditIssueContractsJsonReport {
   return {
-    totals: {
-      managedIssues: issues.length,
-      readyIssues: issues.filter((issue) => issue.state === 'ready').length,
-      invalidReadyIssues: issues.filter((issue) => issue.state === 'ready' && !issue.hasExecutableContract).length,
-      issuesWithWarnings: issues.filter((issue) => issue.contractWarnings.length > 0).length,
-    },
+    summary: buildAuditIssueSummary(issues),
     issues: issues.map((issue) => ({
       ...issue,
-      readyGateBlocked: issue.contractValidationErrors.length > 0,
+      readyGateBlocked: !issue.contract.valid,
     })),
   }
 }
 
 export function formatAuditJsonReport(issues: AuditedIssue[]): string {
   return JSON.stringify(buildAuditIssueContractsJsonReport(issues), null, 2)
+}
+
+export function formatAuditOutput(
+  report: AuditIssueContractsJsonReport,
+  asJson = false,
+): string {
+  if (asJson) {
+    return JSON.stringify(report, null, 2)
+  }
+
+  const lines = [
+    `audited issues: ${report.summary.auditedIssueCount}`,
+    `summary: invalid=${report.summary.invalidIssueCount} invalidReady=${report.summary.invalidReadyIssueCount} lowScore=${report.summary.lowScoreIssueCount} warnings=${report.summary.warningIssueCount}`,
+    ...report.issues.map(formatAuditLine),
+  ]
+
+  const invalidReadySection = formatInvalidReadySection(
+    report.issues.filter((issue) => issue.state === 'ready' && !issue.contract.valid),
+  )
+  if (invalidReadySection) {
+    lines.push('', invalidReadySection)
+  }
+
+  const simulatedIssues = report.issues.filter((issue) => issue.simulation)
+  if (simulatedIssues.length > 0) {
+    lines.push('', 'simulation results:')
+    for (const issue of simulatedIssues) {
+      lines.push(
+        `#${issue.number} simulation=${issue.simulation!.valid ? 'pass' : 'fail'} summary=${issue.simulation!.summary}`,
+      )
+      lines.push(...issue.simulation!.failures.map((failure) => `- ${failure}`))
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export function resolveAuditExitCode(
+  report: AuditIssueContractsJsonReport,
+  explicitIssueSet: boolean,
+): number {
+  return explicitIssueSet && report.summary.invalidIssueCount > 0 ? 1 : 0
 }
 
 export function formatIssueLintReportJson(report: IssueLintReport): string {
@@ -268,9 +396,20 @@ export async function buildIssueLintReportFromRemoteIssue(input: {
   }, issue.title)
 }
 
-function parseArgs(argv: string[]): CliArgs & { json?: boolean } {
+function parsePositiveIssueNumber(value: string, flagName: string): number {
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flagName} must be a positive integer`)
+  }
+
+  return parsed
+}
+
+function parseArgs(argv: string[]): CliArgs & { json?: boolean; simulate?: boolean; issueNumbers: number[] } {
   let repo: string | undefined
   let json = false
+  let simulate = false
+  const issueNumbers: number[] = []
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
@@ -279,35 +418,46 @@ function parseArgs(argv: string[]): CliArgs & { json?: boolean } {
       index += 1
     } else if (arg === '--json') {
       json = true
+    } else if (arg === '--simulate') {
+      simulate = true
+    } else if (arg === '--issue') {
+      const rawIssueNumber = argv[index + 1]
+      if (!rawIssueNumber) {
+        throw new Error('--issue requires a value')
+      }
+
+      issueNumbers.push(parsePositiveIssueNumber(rawIssueNumber, '--issue'))
+      index += 1
     }
   }
 
-  return { repo, json }
+  return { repo, json, simulate, issueNumbers }
 }
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2))
   const config = loadConfig(args)
-  const issues = await listOpenAgentIssues(config)
-  const managedIssues = issues
-    .filter((issue) => issue.labels.some((label) => label.startsWith('agent:')))
-    .map(buildAuditedIssue)
+  const issues = args.issueNumbers.length > 0
+    ? await Promise.all(args.issueNumbers.map(async (issueNumber) => {
+        const issue = await getAgentIssueByNumber(issueNumber, config)
+        if (!issue) {
+          throw new Error(`Issue #${issueNumber} was not found in ${config.repo}`)
+        }
 
-  if (args.json) {
-    console.log(formatAuditJsonReport(managedIssues))
-    return
-  }
+        return issue
+      }))
+    : await listOpenAgentIssues(config)
+  const report = await auditIssues({
+    issues,
+    includeSimulation: args.simulate ?? false,
+    repoRoot: process.cwd(),
+    config,
+  })
 
-  console.log(`managed issues: ${managedIssues.length}`)
-
-  for (const issue of managedIssues) {
-    console.log(formatAuditLine(issue))
-  }
-
-  const invalidReady = managedIssues.filter((issue) => issue.state === 'ready' && !issue.hasExecutableContract)
-  const invalidReadySection = formatInvalidReadySection(invalidReady)
-  if (invalidReadySection) {
-    console.log(`\n${invalidReadySection}`)
+  console.log(formatAuditOutput(report, args.json))
+  const exitCode = resolveAuditExitCode(report, args.issueNumbers.length > 0)
+  if (exitCode !== 0) {
+    process.exit(exitCode)
   }
 }
 

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -3,10 +3,12 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  executeIssueAuditCommand,
   buildWakeRequestFromCli,
   buildManagedRestartArgs,
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
+  formatIssueAuditOutput,
   executeIssueLintCommand,
   executeIssueRewriteCommand,
   executeIssueSplitCommand,
@@ -16,6 +18,8 @@ import {
   formatIssueLintOutput,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
+  resolveIssueAuditExitCode,
+  resolveIssueAuditTarget,
   resolveIssueLintTarget,
   resolveIssueRewriteTarget,
   resolveIssueSplitTarget,
@@ -66,6 +70,25 @@ describe('index helpers', () => {
       'lint-issue': '36',
       'lint-file': 'docs/issues/ready.md',
     })).toThrow('Only one of --lint-issue or --lint-file can be used at a time')
+  })
+
+  test('resolves audit targets and preserves repeated explicit issue selectors', () => {
+    expect(resolveIssueAuditTarget({
+      'audit-issues': true,
+    })).toEqual({
+      issueNumbers: [],
+    })
+
+    expect(resolveIssueAuditTarget({
+      'audit-issues': true,
+      issue: ['50', '51'],
+    })).toEqual({
+      issueNumbers: [50, 51],
+    })
+
+    expect(resolveIssueAuditTarget({
+      issue: ['50'],
+    })).toBeNull()
   })
 
   test('resolves rewrite targets and rejects empty rewrite paths', () => {
@@ -169,6 +192,137 @@ describe('index helpers', () => {
       valid: true,
       readyGateBlocked: false,
     })
+  })
+
+  test('executes issue audit against explicit issue numbers and includes simulation when requested', async () => {
+    const report = await executeIssueAuditCommand({
+      issueNumbers: [50, 52],
+      includeSimulation: true,
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/repo',
+    }, {
+      loadConfig: (args = {}) => ({
+        repo: args.repo!,
+        pat: args.pat!,
+        concurrency: 1,
+        pollIntervalMs: 60_000,
+        idlePollIntervalMs: 300_000,
+        machineId: 'codex-dev',
+      } as any),
+      listOpenAgentIssues: async () => {
+        throw new Error('should not list open issues for explicit audit')
+      },
+      getAgentIssueByNumber: async (issueNumber, config) => ({
+        number: issueNumber,
+        title: `[AL-${issueNumber}] audit target`,
+        body: issueNumber === 50
+          ? '## 用户故事\n只有用户故事'
+          : [
+              '## 用户故事',
+              '作为维护者，我希望 issue audit 能输出 repo-level JSON。',
+              '',
+              '## Context',
+              '### Dependencies',
+              '```json',
+              '{ "dependsOn": [] }',
+              '```',
+              '### AllowedFiles',
+              '- apps/agent-daemon/src/audit-issue-contracts.ts',
+              '### ForbiddenFiles',
+              '- apps/agent-daemon/src/dashboard.ts',
+              '### MustPreserve',
+              '- human-readable 审计输出',
+              '### OutOfScope',
+              '- dashboard',
+              '### RequiredSemantics',
+              '- JSON 输出稳定',
+              '### ReviewHints',
+              '- 检查 summary',
+              '### Validation',
+              '- `bun test apps/agent-daemon/src/index.test.ts`',
+              '',
+              '## RED 测试',
+              '```ts',
+              'expect(true).toBe(false)',
+              '```',
+              '',
+              '## 实现步骤',
+              '1. 增加 audit command',
+              '',
+              '## 验收',
+              '- [ ] audit command 可用',
+            ].join('\n'),
+        state: 'ready',
+        labels: ['agent:ready'],
+        assignee: null,
+        isClaimable: issueNumber !== 50,
+        updatedAt: '2026-04-11T09:30:00.000Z',
+        dependencyIssueNumbers: [],
+        hasDependencyMetadata: true,
+        dependencyParseError: false,
+        claimBlockedBy: [],
+        hasExecutableContract: issueNumber !== 50,
+        contractValidationErrors: issueNumber === 50
+          ? ['missing ### Dependencies JSON block']
+          : [],
+      } as any),
+      auditIssues: async ({ issues, includeSimulation, repoRoot }) => {
+        expect(issues.map((issue) => issue.number)).toEqual([50, 52])
+        expect(includeSimulation).toBe(true)
+        expect(repoRoot).toBe('/tmp/repo')
+
+        return {
+          summary: {
+            auditedIssueCount: 2,
+            invalidIssueCount: 1,
+            invalidReadyIssueCount: 1,
+            lowScoreIssueCount: 1,
+            warningIssueCount: 0,
+          },
+          issues: issues.map((issue) => ({
+            number: issue.number,
+            title: issue.title,
+            state: issue.state,
+            isClaimable: issue.isClaimable ?? false,
+            hasExecutableContract: issue.hasExecutableContract ?? false,
+            claimBlockedBy: issue.claimBlockedBy ?? [],
+            contractValidationErrors: issue.contractValidationErrors ?? [],
+            qualityScore: issue.number === 50 ? 0 : 100,
+            contractWarnings: [],
+            contract: {
+              valid: issue.number !== 50,
+              errors: issue.number === 50 ? ['missing ### Dependencies JSON block'] : [],
+              warnings: [],
+            },
+            readyGateBlocked: issue.number === 50,
+            simulation: {
+              valid: true,
+              summary: 'simulation passed',
+              failures: [],
+              findings: [],
+              plannerPrompt: 'prompt',
+              plannerOutput: 'Implement audit command',
+              plannedSubtasks: ['Implement audit command'],
+            },
+          })),
+        }
+      },
+    })
+
+    expect(report.summary.invalidIssueCount).toBe(1)
+    const jsonReport = JSON.parse(formatIssueAuditOutput(report, true))
+    expect(jsonReport.summary).toMatchObject({
+      auditedIssueCount: 2,
+    })
+    expect(jsonReport.issues[0]).toMatchObject({
+      number: 50,
+      simulation: {
+        valid: true,
+      },
+    })
+    expect(resolveIssueAuditExitCode(report, true)).toBe(1)
+    expect(resolveIssueAuditExitCode(report, false)).toBe(0)
   })
 
   test('executes local issue rewrite by reading a draft file and returning markdown only', async () => {

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -11,6 +11,10 @@
 
 import { parseArgs } from 'node:util'
 import { existsSync, readFileSync } from 'node:fs'
+import {
+  getAgentIssueByNumber,
+  listOpenAgentIssues,
+} from '@agent/shared'
 import { AgentDaemon, DEFAULT_HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_HOST, type HealthServerConfig } from './daemon'
 import { loadConfig, resolveLocalDaemonIdentity, type CliArgs } from './config'
 import { collectDaemonObservability, formatDoctorReport, formatStatusReport } from './status'
@@ -48,10 +52,14 @@ import {
   startDashboardServer,
 } from './dashboard'
 import {
+  auditIssues,
   buildIssueLintReportFromMarkdownFile,
   buildIssueLintReportFromRemoteIssue,
+  formatAuditOutput,
   formatIssueLintReport,
   formatIssueLintReportJson,
+  resolveAuditExitCode,
+  type AuditIssueContractsJsonReport,
   type IssueLintReport,
 } from './audit-issue-contracts'
 import {
@@ -86,6 +94,10 @@ export interface IssueLintTarget {
   kind: 'file' | 'issue'
   path?: string
   issueNumber?: number
+}
+
+export interface IssueAuditTarget {
+  issueNumbers: number[]
 }
 
 export interface IssueRewriteTarget {
@@ -127,6 +139,14 @@ export interface ExecuteIssueLintInput {
   target: IssueLintTarget
   repo?: string
   pat?: string
+}
+
+export interface ExecuteIssueAuditInput {
+  issueNumbers: number[]
+  includeSimulation: boolean
+  repo?: string
+  pat?: string
+  repoRoot: string
 }
 
 export interface ExecuteIssueRewriteInput {
@@ -227,6 +247,13 @@ interface IssueLintCommandDependencies {
   buildIssueLintReportFromRemoteIssue: typeof buildIssueLintReportFromRemoteIssue
 }
 
+interface IssueAuditCommandDependencies {
+  loadConfig: typeof loadConfig
+  listOpenAgentIssues: typeof listOpenAgentIssues
+  getAgentIssueByNumber: typeof getAgentIssueByNumber
+  auditIssues: typeof auditIssues
+}
+
 interface IssueRewriteCommandDependencies {
   loadConfig: typeof loadConfig
   readTextFile: (path: string) => string
@@ -270,6 +297,13 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
   loadConfig,
   buildIssueLintReportFromMarkdownFile,
   buildIssueLintReportFromRemoteIssue,
+}
+
+const DEFAULT_ISSUE_AUDIT_COMMAND_DEPENDENCIES: IssueAuditCommandDependencies = {
+  loadConfig,
+  listOpenAgentIssues,
+  getAgentIssueByNumber,
+  auditIssues,
 }
 
 const DEFAULT_ISSUE_REWRITE_COMMAND_DEPENDENCIES: IssueRewriteCommandDependencies = {
@@ -328,6 +362,9 @@ async function main() {
       'wake-from-github-event': { type: 'boolean' },
       'github-event-name': { type: 'string' },
       'github-event-path': { type: 'string' },
+      'audit-issues': { type: 'boolean' },
+      issue: { type: 'string', multiple: true },
+      simulate: { type: 'boolean' },
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
       'rewrite-file': { type: 'string' },
@@ -357,6 +394,10 @@ async function main() {
     'wake-issue': args['wake-issue'] as string | undefined,
     'wake-pr': args['wake-pr'] as string | undefined,
   })
+  const issueAuditTarget = resolveIssueAuditTarget({
+    'audit-issues': args['audit-issues'] as boolean | undefined,
+    issue: args.issue as string[] | undefined,
+  })
   const issueLintTarget = resolveIssueLintTarget({
     'lint-issue': args['lint-issue'] as string | undefined,
     'lint-file': args['lint-file'] as string | undefined,
@@ -375,6 +416,14 @@ async function main() {
 
   if (wakeCommand) {
     assertWakeCommandCompatible(args)
+  }
+
+  if (issueAuditTarget) {
+    assertIssueAuditCompatible(args)
+  } else if (Array.isArray(args.issue) && args.issue.length > 0) {
+    throw new Error('--issue can only be used with --audit-issues')
+  } else if (args.simulate) {
+    throw new Error('--simulate can only be used with --audit-issues')
   }
 
   if (issueLintTarget) {
@@ -400,6 +449,9 @@ async function main() {
     if (issueLintTarget) {
       throw new Error('--wake-from-github-event cannot be combined with --lint-issue or --lint-file')
     }
+    if (issueAuditTarget) {
+      throw new Error('--wake-from-github-event cannot be combined with --audit-issues')
+    }
     if (issueRewriteTarget) {
       throw new Error('--wake-from-github-event cannot be combined with --rewrite-file')
     }
@@ -416,8 +468,20 @@ async function main() {
     throw new Error('--lint-issue/--lint-file cannot be combined with wake commands')
   }
 
+  if (wakeCommand && issueAuditTarget) {
+    throw new Error('--audit-issues cannot be combined with wake commands')
+  }
+
+  if (issueAuditTarget && issueLintTarget) {
+    throw new Error('--audit-issues cannot be combined with --lint-issue or --lint-file')
+  }
+
   if (wakeCommand && issueRewriteTarget) {
     throw new Error('--rewrite-file cannot be combined with wake commands')
+  }
+
+  if (issueAuditTarget && issueRewriteTarget) {
+    throw new Error('--rewrite-file cannot be combined with --audit-issues')
   }
 
   if (issueLintTarget && issueRewriteTarget) {
@@ -426,6 +490,10 @@ async function main() {
 
   if (wakeCommand && issueSplitTarget) {
     throw new Error('--split-file cannot be combined with wake commands')
+  }
+
+  if (issueAuditTarget && issueSplitTarget) {
+    throw new Error('--split-file cannot be combined with --audit-issues')
   }
 
   if (issueLintTarget && issueSplitTarget) {
@@ -438,6 +506,10 @@ async function main() {
 
   if (wakeCommand && issueSimulateTarget) {
     throw new Error('--simulate-issue/--simulate-file cannot be combined with wake commands')
+  }
+
+  if (issueAuditTarget && issueSimulateTarget) {
+    throw new Error('--simulate-issue/--simulate-file cannot be combined with --audit-issues')
   }
 
   if (issueLintTarget && issueSimulateTarget) {
@@ -507,6 +579,18 @@ async function main() {
   const runtimeRepoHint = resolveRepoHint(args.repo as string | undefined)
   const runtimeMachineIdHint = args['machine-id'] as string | undefined
   const runtimeHealthPortHint = args['health-port'] ? parseInt(args['health-port'] as string) : undefined
+
+  if (issueAuditTarget) {
+    const report = await executeIssueAuditCommand({
+      issueNumbers: issueAuditTarget.issueNumbers,
+      includeSimulation: args.simulate as boolean | undefined ?? false,
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+      repoRoot: process.cwd(),
+    })
+    console.log(formatIssueAuditOutput(report, args.json as boolean | undefined))
+    process.exit(resolveIssueAuditExitCode(report, issueAuditTarget.issueNumbers.length > 0))
+  }
 
   if (issueLintTarget) {
     const report = await executeIssueLintCommand({
@@ -906,6 +990,7 @@ Usage:
   agent-loop --wake-issue <number> [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
   agent-loop --wake-pr <number> [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
   agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
+  agent-loop --audit-issues [--repo owner/repo --issue <number>... --simulate --json]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
   agent-loop --rewrite-file <path> [--repo owner/repo]
@@ -944,6 +1029,9 @@ Options:
                               Translate the current GitHub Actions event into a local wake request
       --github-event-name     Override the GitHub event name used by --wake-from-github-event
       --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
+      --audit-issues         Audit open managed issues or an explicit repeated --issue set
+      --issue <number>       Explicit issue number to audit; may be repeated with --audit-issues
+      --simulate             Include read-only simulation findings in --audit-issues output
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
       --rewrite-file <path>   Rewrite a local issue draft into canonical executable contract markdown
@@ -993,6 +1081,8 @@ Examples:
   agent-loop --wake-now --repo owner/repo
   agent-loop --wake-issue 374 --repo owner/repo --machine-id macbook-pro-b
   agent-loop --wake-pr 381 --health-port 9311
+  agent-loop --audit-issues --repo owner/repo --json
+  agent-loop --audit-issues --repo owner/repo --issue 50 --issue 52 --simulate --json
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
   agent-loop --rewrite-file docs/issues/ready-gate-draft.md --repo owner/repo
@@ -1124,6 +1214,19 @@ export function resolveIssueLintTarget(args: {
   return targets[0] ?? null
 }
 
+export function resolveIssueAuditTarget(args: {
+  'audit-issues'?: boolean
+  issue?: string[]
+}): IssueAuditTarget | null {
+  if (!args['audit-issues']) {
+    return null
+  }
+
+  return {
+    issueNumbers: (args.issue ?? []).map((value) => parseWakeTargetNumber(value, '--issue')),
+  }
+}
+
 export function resolveIssueRewriteTarget(args: {
   'rewrite-file'?: string
 }): IssueRewriteTarget | null {
@@ -1214,6 +1317,33 @@ export async function executeIssueLintCommand(
   })
 }
 
+export async function executeIssueAuditCommand(
+  input: ExecuteIssueAuditInput,
+  deps: IssueAuditCommandDependencies = DEFAULT_ISSUE_AUDIT_COMMAND_DEPENDENCIES,
+): Promise<AuditIssueContractsJsonReport> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+  const issues = input.issueNumbers.length > 0
+    ? await Promise.all(input.issueNumbers.map(async (issueNumber) => {
+        const issue = await deps.getAgentIssueByNumber(issueNumber, config)
+        if (!issue) {
+          throw new Error(`Issue #${issueNumber} was not found in ${config.repo}`)
+        }
+
+        return issue
+      }))
+    : await deps.listOpenAgentIssues(config)
+
+  return deps.auditIssues({
+    issues,
+    includeSimulation: input.includeSimulation,
+    repoRoot: input.repoRoot,
+    config,
+  })
+}
+
 export async function executeIssueRewriteCommand(
   input: ExecuteIssueRewriteInput,
   deps: IssueRewriteCommandDependencies = DEFAULT_ISSUE_REWRITE_COMMAND_DEPENDENCIES,
@@ -1279,6 +1409,20 @@ export function formatIssueLintOutput(
   asJson = false,
 ): string {
   return asJson ? formatIssueLintReportJson(report) : formatIssueLintReport(report)
+}
+
+export function formatIssueAuditOutput(
+  report: AuditIssueContractsJsonReport,
+  asJson = false,
+): string {
+  return formatAuditOutput(report, asJson)
+}
+
+export function resolveIssueAuditExitCode(
+  report: AuditIssueContractsJsonReport,
+  explicitIssueSet: boolean,
+): number {
+  return resolveAuditExitCode(report, explicitIssueSet)
 }
 
 export function buildWakeRequestFromCli(
@@ -1603,6 +1747,76 @@ function assertIssueLintCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Issue lint cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertIssueAuditCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Issue audit cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 


### PR DESCRIPTION
## Summary
- add repo-level issue audit report builder with summary, JSON output, and optional simulation findings
- wire `agent-loop --audit-issues` to default open managed issues or repeated explicit `--issue` selectors
- keep human-readable audit output and add explicit issue-set exit code semantics for CI/control-plane use

## Testing
- bun test apps/agent-daemon/src/audit-issue-contracts.test.ts apps/agent-daemon/src/index.test.ts packages/agent-shared/src/github-api.test.ts
- bun run --cwd packages/agent-shared typecheck
- bun run apps/agent-daemon/src/index.ts --audit-issues --repo JamesWuHK/agent-loop --issue 50 --json

## Notes
- root `bun run typecheck` is still blocked by pre-existing `issue-authoring-context` / shared export errors on the stacked base branch, unrelated to this PR
- closes #50