### PR TITLE
feat: inject project issue authoring rules

### DIFF
--- a/apps/agent-daemon/src/issue-authoring-context.test.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.test.ts
@@ -49,8 +49,8 @@ describe('buildRepoAuthoringContext', () => {
       'apps/example/src/App.tsx',
       'apps/example/src/main.tsx',
     ])
-    expect(context.candidateAllowedFiles.some((value) => value.startsWith(root))).toBe(false)
-    expect(context.candidateValidationCommands.some((value) => value.startsWith(root))).toBe(false)
+    expect(context.candidateAllowedFiles.some((value: string) => value.startsWith(root))).toBe(false)
+    expect(context.candidateValidationCommands.some((value: string) => value.startsWith(root))).toBe(false)
   })
 
   test('keeps validation command ordering stable across root and workspace manifests', async () => {
@@ -131,7 +131,7 @@ describe('buildRepoAuthoringContext', () => {
       'packages/agent-shared/src/project-profile.ts',
       'packages/agent-shared/src/project-profile.test.ts',
     ])
-    expect(context.candidateAllowedFiles.some((value) => value.startsWith('/'))).toBe(false)
+    expect(context.candidateAllowedFiles.some((value: string) => value.startsWith('/'))).toBe(false)
   })
 
   test('keeps allowed and forbidden file ordering stable for unsorted repo-relative inputs', async () => {
@@ -195,6 +195,60 @@ describe('buildRepoAuthoringContext', () => {
         'apps/web/src/router.tsx',
       ],
     })
-    expect(firstContext.candidateForbiddenFiles.some((value) => value.startsWith('/'))).toBe(false)
+    expect(firstContext.candidateForbiddenFiles.some((value: string) => value.startsWith('/'))).toBe(false)
+  })
+
+  test('merges project issue rules into authoring context without dropping repo-grounded candidates', async () => {
+    const context = await buildRepoAuthoringContext({
+      repoRoot: '/repo',
+      issueText: '增加 issue repair CLI',
+      repoRelativeFilePaths: [
+        'apps/agent-daemon/src/issue-repair.ts',
+        'apps/agent-daemon/src/issue-repair.test.ts',
+        'apps/agent-daemon/src/dashboard.ts',
+      ],
+      project: {
+        profile: 'generic',
+        issueAuthoring: {
+          preferredValidationCommands: [
+            'bun test apps/agent-daemon/src/issue-repair.test.ts',
+          ],
+          preferredAllowedFiles: [
+            'apps/agent-daemon/src/issue-repair.ts',
+            'apps/agent-daemon/src/issue-repair.test.ts',
+          ],
+          forbiddenPaths: [
+            'apps/agent-daemon/src/dashboard.ts',
+          ],
+          reviewHints: [
+            '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+          ],
+        },
+      },
+    })
+
+    expect(context.candidateValidationCommands).toContain(
+      'bun test apps/agent-daemon/src/issue-repair.test.ts',
+    )
+    expect(context.candidateAllowedFiles.slice(0, 2)).toEqual([
+      'apps/agent-daemon/src/issue-repair.ts',
+      'apps/agent-daemon/src/issue-repair.test.ts',
+    ])
+    expect(context.candidateForbiddenFiles).toContain('apps/agent-daemon/src/dashboard.ts')
+    expect(context.projectIssueRules).toEqual({
+      preferredValidationCommands: [
+        'bun test apps/agent-daemon/src/issue-repair.test.ts',
+      ],
+      preferredAllowedFiles: [
+        'apps/agent-daemon/src/issue-repair.ts',
+        'apps/agent-daemon/src/issue-repair.test.ts',
+      ],
+      forbiddenPaths: [
+        'apps/agent-daemon/src/dashboard.ts',
+      ],
+      reviewHints: [
+        '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+      ],
+    })
   })
 })

--- a/apps/agent-daemon/src/issue-authoring-context.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.ts
@@ -1,6 +1,11 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
-import type { BuildRepoAuthoringContextInput, RepoAuthoringContext } from '@agent/shared'
+import {
+  getProjectIssueAuthoringRules,
+  hasProjectIssueAuthoringRules,
+  type BuildRepoAuthoringContextInput,
+  type RepoAuthoringContext,
+} from '@agent/shared'
 
 interface PackageManifestRecord {
   scripts?: Record<string, unknown>
@@ -57,17 +62,35 @@ export async function buildRepoAuthoringContext(
   const repoFiles = input.repoRelativeFilePaths
     ? sanitizeRepoRelativeFilePaths(repoRoot, input.repoRelativeFilePaths)
     : collectRepoFiles(repoRoot)
-  const candidateAllowedFiles = collectCandidateAllowedFiles(resolveIssueText(input), repoFiles)
-
-  return {
-    candidateValidationCommands: collectCandidateValidationCommands(repoRoot, packageManifests),
-    candidateAllowedFiles,
-    candidateForbiddenFiles: collectCandidateForbiddenFiles(
+  const projectIssueRules = getProjectIssueAuthoringRules(input.project)
+  const scannedValidationCommands = collectCandidateValidationCommands(repoRoot, packageManifests)
+  const scannedAllowedFiles = collectCandidateAllowedFiles(resolveIssueText(input), repoFiles)
+  const candidateAllowedFiles = mergeOrderedAuthoringValues(
+    sanitizeRepoRelativeFilePaths(repoRoot, projectIssueRules.preferredAllowedFiles, true),
+    scannedAllowedFiles,
+  )
+  const candidateForbiddenFiles = mergeOrderedAuthoringValues(
+    sanitizeRepoRelativeFilePaths(repoRoot, projectIssueRules.forbiddenPaths, true),
+    collectCandidateForbiddenFiles(
       repoFiles,
-      candidateAllowedFiles,
+      scannedAllowedFiles,
       packageManifests.map((manifest) => manifest.dir),
     ),
+  )
+  const context: RepoAuthoringContext = {
+    candidateValidationCommands: mergeOrderedAuthoringValues(
+      projectIssueRules.preferredValidationCommands,
+      scannedValidationCommands,
+    ),
+    candidateAllowedFiles,
+    candidateForbiddenFiles,
   }
+
+  if (hasProjectIssueAuthoringRules(projectIssueRules)) {
+    context.projectIssueRules = projectIssueRules
+  }
+
+  return context
 }
 
 function collectCandidateValidationCommands(
@@ -419,9 +442,30 @@ function resolveIssueText(input: BuildRepoAuthoringContextInput): string {
     .join('\n')
 }
 
+function mergeOrderedAuthoringValues(
+  preferredValues: string[],
+  scannedValues: string[],
+): string[] {
+  const mergedValues: string[] = []
+  const seen = new Set<string>()
+
+  for (const value of [...preferredValues, ...scannedValues]) {
+    const normalized = value.trim()
+    if (!normalized || seen.has(normalized)) {
+      continue
+    }
+
+    seen.add(normalized)
+    mergedValues.push(normalized)
+  }
+
+  return mergedValues
+}
+
 function sanitizeRepoRelativeFilePaths(
   repoRoot: string,
   repoRelativeFilePaths: string[],
+  preserveInputOrder = false,
 ): string[] {
   const seen = new Set<string>()
   const sanitized: string[] = []
@@ -446,7 +490,9 @@ function sanitizeRepoRelativeFilePaths(
     sanitized.push(repoRelativePath)
   }
 
-  return sanitized.sort((left, right) => left.localeCompare(right))
+  return preserveInputOrder
+    ? sanitized
+    : sanitized.sort((left, right) => left.localeCompare(right))
 }
 
 function collectPackageManifests(

--- a/apps/agent-daemon/src/issue-authoring.test.ts
+++ b/apps/agent-daemon/src/issue-authoring.test.ts
@@ -194,6 +194,29 @@ describe('issue-authoring helpers', () => {
     expect(prompt).toContain('Candidate Validation Commands')
     expect(prompt).toContain('apps/agent-daemon/src/ready-gate.ts')
     expect(prompt).toContain('### Dependencies')
+    expect(prompt).not.toContain('Preferred Allowed Files')
+  })
+
+  test('buildIssueRewritePrompt renders project issue rules when configured', () => {
+    const prompt = buildIssueRewritePrompt({
+      issueText: '增加 issue repair CLI',
+      authoringContext: {
+        candidateValidationCommands: ['bun test apps/agent-daemon/src/issue-repair.test.ts'],
+        candidateAllowedFiles: ['apps/agent-daemon/src/issue-repair.ts'],
+        candidateForbiddenFiles: ['apps/agent-daemon/src/dashboard.ts'],
+        projectIssueRules: {
+          preferredValidationCommands: ['bun test apps/agent-daemon/src/issue-repair.test.ts'],
+          preferredAllowedFiles: ['apps/agent-daemon/src/issue-repair.ts'],
+          forbiddenPaths: ['apps/agent-daemon/src/dashboard.ts'],
+          reviewHints: ['优先检查 repair 流程是否保留合法的 Dependencies JSON'],
+        },
+      },
+    })
+
+    expect(prompt).toContain('Project Issue Rules')
+    expect(prompt).toContain('Preferred Validation Commands')
+    expect(prompt).toContain('Forbidden Paths')
+    expect(prompt).toContain('优先检查 repair 流程是否保留合法的 Dependencies JSON')
   })
 
   test('normalizeIssueRewriteMarkdown removes one outer fence and trims whitespace', () => {

--- a/apps/agent-daemon/src/issue-authoring.ts
+++ b/apps/agent-daemon/src/issue-authoring.ts
@@ -1,8 +1,10 @@
 import {
   buildIssueQualityReport,
+  hasProjectIssueAuthoringRules,
   parseIssueContract,
   type AgentConfig,
   type IssueQualityReport,
+  type ProjectProfileConfig,
   type RepoAuthoringContext,
 } from '@agent/shared'
 import { runConfiguredAgent } from './cli-agent'
@@ -25,6 +27,7 @@ export interface RewriteIssueDraftInput {
   buildAuthoringContext?: (input: {
     repoRoot: string
     issueText: string
+    project?: ProjectProfileConfig
   }) => Promise<RepoAuthoringContext>
   runAgent?: (
     input: IssueAuthoringAgentRunInput,
@@ -44,6 +47,7 @@ export async function rewriteIssueDraft(
   const authoringContext = await buildContext({
     repoRoot: input.repoRoot,
     issueText: input.issueText,
+    project: input.config?.project,
   })
   const prompt = buildIssueRewritePrompt({
     issueText: input.issueText,
@@ -84,6 +88,7 @@ export function buildIssueRewritePrompt(input: {
     '- 必须使用现有 canonical section 结构，并保留 `### Dependencies` 的 fenced JSON。',
     '- `### Validation` 必须只包含可执行命令。',
     '- 优先使用 repo-grounded authoring context 提供的候选路径和命令，不要猜宽泛 scope。',
+    '- 如果提供了 Project Issue Rules，必须优先遵守其中的 preferred paths、validation commands 与 review concerns。',
     'Canonical section order:',
     '1. `## 用户故事`',
     '2. `## Context`',
@@ -99,6 +104,7 @@ export function buildIssueRewritePrompt(input: {
     '12. `## RED 测试`',
     '13. `## 实现步骤`',
     '14. `## 验收`',
+    renderProjectIssueRulesBlock(input.authoringContext),
     renderSuggestionBlock('Candidate Validation Commands', input.authoringContext.candidateValidationCommands),
     renderSuggestionBlock('Candidate Allowed Files', input.authoringContext.candidateAllowedFiles),
     renderSuggestionBlock('Candidate Forbidden Files', input.authoringContext.candidateForbiddenFiles),
@@ -125,13 +131,34 @@ function renderSuggestionBlock(title: string, values: string[]): string {
   return `${title}:\n${values.map((value) => `- ${value}`).join('\n')}`
 }
 
+function renderProjectIssueRulesBlock(authoringContext: RepoAuthoringContext): string | null {
+  const projectIssueRules = authoringContext.projectIssueRules
+  if (!projectIssueRules || !hasProjectIssueAuthoringRules(projectIssueRules)) {
+    return null
+  }
+
+  const sections = [
+    renderSuggestionBlock('Preferred Validation Commands', projectIssueRules.preferredValidationCommands),
+    renderSuggestionBlock('Preferred Allowed Files', projectIssueRules.preferredAllowedFiles),
+    renderSuggestionBlock('Forbidden Paths', projectIssueRules.forbiddenPaths),
+    renderSuggestionBlock('Review Hints', projectIssueRules.reviewHints),
+  ]
+
+  return [
+    'Project Issue Rules:',
+    ...sections,
+  ].join('\n\n')
+}
+
 async function defaultBuildAuthoringContext(input: {
   repoRoot: string
   issueText: string
+  project?: ProjectProfileConfig
 }): Promise<RepoAuthoringContext> {
   return buildRepoAuthoringContext({
     repoRoot: input.repoRoot,
     issueText: input.issueText,
+    project: input.project,
   })
 }
 

--- a/apps/agent-daemon/src/issue-splitter.test.ts
+++ b/apps/agent-daemon/src/issue-splitter.test.ts
@@ -156,6 +156,31 @@ describe('issue-splitter helpers', () => {
     expect(prompt).toContain('strict JSON object')
     expect(prompt).toContain('Candidate Allowed Files')
     expect(prompt).toContain('apps/agent-daemon/src/issue-splitter.ts')
+    expect(prompt).not.toContain('Preferred Allowed Files')
+  })
+
+  test('buildTrackingIssueSplitPrompt renders project issue rules when configured', () => {
+    const prompt = buildTrackingIssueSplitPrompt({
+      title: '[AL-EPIC] issue repair pipeline',
+      body: '父 issue 负责串起 repair authoring 子线。',
+      issueText: '父 issue 负责串起 repair authoring 子线。',
+      authoringContext: {
+        candidateValidationCommands: ['bun test apps/agent-daemon/src/issue-repair.test.ts'],
+        candidateAllowedFiles: ['apps/agent-daemon/src/issue-repair.ts'],
+        candidateForbiddenFiles: ['apps/agent-daemon/src/dashboard.ts'],
+        projectIssueRules: {
+          preferredValidationCommands: ['bun test apps/agent-daemon/src/issue-repair.test.ts'],
+          preferredAllowedFiles: ['apps/agent-daemon/src/issue-repair.ts'],
+          forbiddenPaths: ['apps/agent-daemon/src/dashboard.ts'],
+          reviewHints: ['优先检查 repair 流程是否保留合法的 Dependencies JSON'],
+        },
+      },
+    })
+
+    expect(prompt).toContain('Project Issue Rules')
+    expect(prompt).toContain('Preferred Allowed Files')
+    expect(prompt).toContain('Forbidden Paths')
+    expect(prompt).toContain('优先检查 repair 流程是否保留合法的 Dependencies JSON')
   })
 
   test('parseTrackingIssueSplitPlan falls back to numbered-list parsing', () => {

--- a/apps/agent-daemon/src/issue-splitter.ts
+++ b/apps/agent-daemon/src/issue-splitter.ts
@@ -1,10 +1,12 @@
 import { existsSync } from 'node:fs'
 import {
   buildIssueQualityReport,
+  hasProjectIssueAuthoringRules,
   parseIssueContract,
   renderIssueContractForPrompt,
   type AgentConfig,
   type IssueQualityReport,
+  type ProjectProfileConfig,
   type RepoAuthoringContext,
 } from '@agent/shared'
 import { runConfiguredAgent } from './cli-agent'
@@ -56,6 +58,7 @@ export interface SplitTrackingIssueInput {
     issueText: string
     issueTitle?: string
     issueBody?: string
+    project?: ProjectProfileConfig
   }) => Promise<RepoAuthoringContext>
   runAgent?: (
     input: IssueSplitterAgentRunInput,
@@ -93,6 +96,7 @@ export async function splitTrackingIssue(
     issueText: source.issueText,
     issueTitle: source.title,
     issueBody: source.body,
+    project: input.config?.project,
   })
   const parentContract = parseIssueContract(source.body)
   const planPrompt = buildTrackingIssueSplitPrompt({
@@ -185,6 +189,7 @@ export function buildTrackingIssueSplitPrompt(input: {
     '- `children` 必须保持执行顺序；每个 child 都必须是 code-producing slice，而不是 investigation-only task。',
     '- `dependsOn` 只能引用更早的 sibling child，优先使用 child `id`；没有依赖就输出 `[]`。',
     '- `allowedFiles`、`outOfScope`、`requiredSemantics` 要尽量具体，能支撑 reviewer 和 auto-fix。',
+    '- 如果提供了 Project Issue Rules，必须显式遵守其中的 preferred paths、validation commands 与 review concerns。',
     '- parent issue 仍然是 tracking-only，不进入 `agent:ready`。',
     'JSON schema:',
     '```json',
@@ -204,6 +209,7 @@ export function buildTrackingIssueSplitPrompt(input: {
       ],
     }, null, 2),
     '```',
+    renderProjectIssueRulesBlock(input.authoringContext),
     renderSuggestionBlock('Candidate Validation Commands', input.authoringContext.candidateValidationCommands),
     renderSuggestionBlock('Candidate Allowed Files', input.authoringContext.candidateAllowedFiles),
     renderSuggestionBlock('Candidate Forbidden Files', input.authoringContext.candidateForbiddenFiles),
@@ -621,11 +627,31 @@ function renderSuggestionBlock(title: string, values: string[]): string {
   return `${title}:\n${values.map((value) => `- ${value}`).join('\n')}`
 }
 
+function renderProjectIssueRulesBlock(authoringContext: RepoAuthoringContext): string | null {
+  const projectIssueRules = authoringContext.projectIssueRules
+  if (!projectIssueRules || !hasProjectIssueAuthoringRules(projectIssueRules)) {
+    return null
+  }
+
+  const sections = [
+    renderSuggestionBlock('Preferred Validation Commands', projectIssueRules.preferredValidationCommands),
+    renderSuggestionBlock('Preferred Allowed Files', projectIssueRules.preferredAllowedFiles),
+    renderSuggestionBlock('Forbidden Paths', projectIssueRules.forbiddenPaths),
+    renderSuggestionBlock('Review Hints', projectIssueRules.reviewHints),
+  ]
+
+  return [
+    'Project Issue Rules:',
+    ...sections,
+  ].join('\n\n')
+}
+
 async function defaultBuildAuthoringContext(input: {
   repoRoot: string
   issueText: string
   issueTitle?: string
   issueBody?: string
+  project?: ProjectProfileConfig
 }): Promise<RepoAuthoringContext> {
   if (!existsSync(input.repoRoot)) {
     return {
@@ -640,6 +666,7 @@ async function defaultBuildAuthoringContext(input: {
     issueText: input.issueText,
     issueTitle: input.issueTitle,
     issueBody: input.issueBody,
+    project: input.project,
   })
 }
 
@@ -714,6 +741,7 @@ function renderDeterministicChildIssue(input: {
   const reviewHints = uniqueStrings([
     '优先检查 AllowedFiles 与 OutOfScope 是否仍然足够具体',
     '优先检查 dependsOn 是否只引用更早 child issues',
+    ...(input.authoringContext.projectIssueRules?.reviewHints ?? []),
     ...input.parentContract.reviewHints,
   ]).slice(0, 8)
   const validationCommands = selectValidationCommands(

--- a/packages/agent-shared/src/project-profile.test.ts
+++ b/packages/agent-shared/src/project-profile.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test'
-import { getProjectPromptGuidance } from './project-profile'
+import {
+  getProjectIssueAuthoringRules,
+  getProjectPromptGuidance,
+  hasProjectIssueAuthoringRules,
+} from './project-profile'
 
 describe('getProjectPromptGuidance', () => {
   it('defaults to generic guidance when no project profile is configured', () => {
@@ -25,5 +29,74 @@ describe('getProjectPromptGuidance', () => {
     }, 'implementation')
 
     expect(guidance.at(-1)).toBe('Run `pytest` instead of inventing a JS harness.')
+  })
+
+  it('normalizes project issue authoring rules without changing prompt guidance order', () => {
+    const guidance = getProjectPromptGuidance({
+      profile: 'desktop-vite',
+      promptGuidance: {
+        implementation: ['Keep desktop validation commands explicit.'],
+      },
+      issueAuthoring: {
+        preferredValidationCommands: [
+          '  bun test apps/agent-daemon/src/issue-repair.test.ts  ',
+          'bun test apps/agent-daemon/src/issue-repair.test.ts',
+        ],
+        preferredAllowedFiles: [
+          'apps/agent-daemon/src/issue-repair.ts',
+          '',
+          'apps/agent-daemon/src/issue-repair.test.ts',
+        ],
+        forbiddenPaths: [
+          'apps/agent-daemon/src/dashboard.ts',
+          'apps/agent-daemon/src/dashboard.ts',
+        ],
+        reviewHints: [
+          '  优先检查 repair 流程是否保留合法的 Dependencies JSON  ',
+        ],
+      },
+    }, 'implementation')
+
+    const rules = getProjectIssueAuthoringRules({
+      profile: 'desktop-vite',
+      issueAuthoring: {
+        preferredValidationCommands: [
+          '  bun test apps/agent-daemon/src/issue-repair.test.ts  ',
+          'bun test apps/agent-daemon/src/issue-repair.test.ts',
+        ],
+        preferredAllowedFiles: [
+          'apps/agent-daemon/src/issue-repair.ts',
+          '',
+          'apps/agent-daemon/src/issue-repair.test.ts',
+        ],
+        forbiddenPaths: [
+          'apps/agent-daemon/src/dashboard.ts',
+          'apps/agent-daemon/src/dashboard.ts',
+        ],
+        reviewHints: [
+          '  优先检查 repair 流程是否保留合法的 Dependencies JSON  ',
+        ],
+      },
+    })
+
+    expect(guidance[0]).toContain('existing Vitest/jsdom setup')
+    expect(guidance.at(-1)).toBe('Keep desktop validation commands explicit.')
+    expect(rules).toEqual({
+      preferredValidationCommands: [
+        'bun test apps/agent-daemon/src/issue-repair.test.ts',
+      ],
+      preferredAllowedFiles: [
+        'apps/agent-daemon/src/issue-repair.ts',
+        'apps/agent-daemon/src/issue-repair.test.ts',
+      ],
+      forbiddenPaths: [
+        'apps/agent-daemon/src/dashboard.ts',
+      ],
+      reviewHints: [
+        '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+      ],
+    })
+    expect(hasProjectIssueAuthoringRules(rules)).toBe(true)
+    expect(hasProjectIssueAuthoringRules(undefined)).toBe(false)
   })
 })

--- a/packages/agent-shared/src/project-profile.ts
+++ b/packages/agent-shared/src/project-profile.ts
@@ -1,7 +1,9 @@
 import type {
+  ProjectIssueAuthoringRules,
   ProjectProfileConfig,
   ProjectProfileName,
   ProjectPromptContext,
+  ResolvedProjectIssueAuthoringRules,
 } from './types'
 
 const BUILTIN_GUIDANCE: Record<ProjectProfileName, Partial<Record<ProjectPromptContext, string[]>>> = {
@@ -45,3 +47,55 @@ export function getProjectPromptGuidance(
   return [...builtin, ...overrides]
 }
 
+export function getProjectIssueAuthoringRules(
+  project: ProjectProfileConfig | undefined,
+): ResolvedProjectIssueAuthoringRules {
+  const configuredRules = project?.issueAuthoring
+
+  return {
+    preferredValidationCommands: normalizeProjectIssueAuthoringValues(
+      configuredRules?.preferredValidationCommands,
+    ),
+    preferredAllowedFiles: normalizeProjectIssueAuthoringValues(
+      configuredRules?.preferredAllowedFiles,
+    ),
+    forbiddenPaths: normalizeProjectIssueAuthoringValues(
+      configuredRules?.forbiddenPaths,
+    ),
+    reviewHints: normalizeProjectIssueAuthoringValues(
+      configuredRules?.reviewHints,
+    ),
+  }
+}
+
+export function hasProjectIssueAuthoringRules(
+  rules: ProjectIssueAuthoringRules | ResolvedProjectIssueAuthoringRules | undefined,
+): boolean {
+  if (!rules) {
+    return false
+  }
+
+  return (
+    (rules.preferredValidationCommands?.length ?? 0) > 0
+    || (rules.preferredAllowedFiles?.length ?? 0) > 0
+    || (rules.forbiddenPaths?.length ?? 0) > 0
+    || (rules.reviewHints?.length ?? 0) > 0
+  )
+}
+
+function normalizeProjectIssueAuthoringValues(values: string[] | undefined): string[] {
+  const normalizedValues: string[] = []
+  const seen = new Set<string>()
+
+  for (const value of values ?? []) {
+    const normalized = value.trim()
+    if (!normalized || seen.has(normalized)) {
+      continue
+    }
+
+    seen.add(normalized)
+    normalizedValues.push(normalized)
+  }
+
+  return normalizedValues
+}

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -110,9 +110,24 @@ export interface ProjectPromptGuidanceOverrides {
   recovery?: string[]
 }
 
+export interface ProjectIssueAuthoringRules {
+  preferredValidationCommands?: string[]
+  preferredAllowedFiles?: string[]
+  forbiddenPaths?: string[]
+  reviewHints?: string[]
+}
+
+export interface ResolvedProjectIssueAuthoringRules {
+  preferredValidationCommands: string[]
+  preferredAllowedFiles: string[]
+  forbiddenPaths: string[]
+  reviewHints: string[]
+}
+
 export interface ProjectProfileConfig {
   profile: ProjectProfileName
   promptGuidance?: ProjectPromptGuidanceOverrides
+  issueAuthoring?: ProjectIssueAuthoringRules
   maxConcurrency?: number
 }
 
@@ -138,6 +153,7 @@ export interface BuildRepoAuthoringContextInput {
   issueText: string
   issueTitle?: string
   issueBody?: string
+  project?: ProjectProfileConfig
   repoRelativeFilePaths?: string[]
   rootPackageJsonPath?: string
   workspacePackageJsonPaths?: string[]
@@ -147,6 +163,7 @@ export interface RepoAuthoringContext {
   candidateValidationCommands: string[]
   candidateAllowedFiles: string[]
   candidateForbiddenFiles: string[]
+  projectIssueRules?: ResolvedProjectIssueAuthoringRules
 }
 
 export interface AgentSchedulingConfig {


### PR DESCRIPTION
## Summary
- add project issue authoring rules schema and normalization helpers to shared project profile config
- merge preferred validation commands, allowed files, forbidden paths, and review hints into repo authoring context without breaking no-config compatibility
- inject project issue rules into rewrite and split prompts so authoring workers see repo-specific constraints explicitly

## Testing
- bun test packages/agent-shared/src/project-profile.test.ts apps/agent-daemon/src/issue-authoring-context.test.ts apps/agent-daemon/src/issue-authoring.test.ts apps/agent-daemon/src/issue-splitter.test.ts
- bun run typecheck
- git diff --stat origin/master...HEAD

## Notes
- this worktree needed local node_modules links for , , , and  so app-side tests/typecheck resolve the current stacked branch correctly
- closes #51