### PR TITLE
Fix #60: [AL-16] closed PR 不再阻塞 PR 重新提交流程与 recovery

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -36,6 +36,7 @@ import {
   shouldResumeFailedIssueWithLinkedPr,
   getStandaloneIssueTransitionForReviewLabels,
   getIssueRecoveryLinkedPrContext,
+  getOpenLinkedPrForIssueRecovery,
   isRetryableDaemonLoopError,
   isMergeabilityFailure,
   refreshResumableIssueBranchOntoDefault,
@@ -1813,6 +1814,46 @@ describe('daemon merge recovery helpers', () => {
       prState: 'merged',
       prUrl: 'https://example.com/pr/110',
     }, 'agent/110/codex-dev')).toBeNull()
+  })
+
+  test('only uses open linked PRs that are still present in the open PR list during issue recovery', () => {
+    const openPr = {
+      number: 110,
+      url: 'https://example.com/pr/110',
+      headRefName: 'agent/110/codex-dev',
+      labels: [PR_REVIEW_LABELS.HUMAN_NEEDED],
+    }
+
+    expect(getOpenLinkedPrForIssueRecovery({
+      prNumber: 110,
+      prState: 'open',
+      prUrl: 'https://example.com/pr/110',
+    }, 'agent/110/codex-dev', [openPr])).toEqual({
+      pr: openPr,
+      context: {
+        number: 110,
+        url: 'https://example.com/pr/110',
+        branch: 'agent/110/codex-dev',
+      },
+    })
+
+    expect(getOpenLinkedPrForIssueRecovery({
+      prNumber: 110,
+      prState: 'closed',
+      prUrl: 'https://example.com/pr/110',
+    }, 'agent/110/codex-dev', [openPr])).toBeNull()
+
+    expect(getOpenLinkedPrForIssueRecovery({
+      prNumber: 110,
+      prState: 'merged',
+      prUrl: 'https://example.com/pr/110',
+    }, 'agent/110/codex-dev', [openPr])).toBeNull()
+
+    expect(getOpenLinkedPrForIssueRecovery({
+      prNumber: 110,
+      prState: 'open',
+      prUrl: 'https://example.com/pr/110',
+    }, 'agent/110/codex-dev', [])).toBeNull()
   })
 
   test('prefers standalone PR handoff for resumable issues when the branch is already synced', () => {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -35,6 +35,7 @@ import {
   shouldRefreshBlockedHumanNeededPr,
   shouldResumeFailedIssueWithLinkedPr,
   getStandaloneIssueTransitionForReviewLabels,
+  shouldUseOpenPrCheckForRecovery,
   getIssueRecoveryLinkedPrContext,
   getOpenLinkedPrForIssueRecovery,
   isRetryableDaemonLoopError,
@@ -612,6 +613,20 @@ describe('agent-loop upgrade coordination', () => {
         safeToUpgradeNow: true,
         message: 'channel master is newer: local v0.1.0, latest v0.1.2',
       }
+      daemon.autoUpgradeState = {
+        attemptCount: 0,
+        successCount: 0,
+        failureCount: 0,
+        noChangeCount: 0,
+        consecutiveFailureCount: 0,
+        lastTargetVersion: null,
+        lastTargetRevision: null,
+        lastAttemptAt: null,
+        lastSuccessAt: null,
+        lastOutcome: null,
+        lastError: null,
+        pausedUntil: null,
+      }
 
       expect(await daemon.maybeAutoApplyAgentLoopUpgrade()).toBe(false)
       expect(autoUpgradeAttempts).toBe(0)
@@ -1092,98 +1107,98 @@ describe('daemon merge recovery helpers', () => {
     expect(shouldDeferResumableIssueForActiveLinkedPrLease(null, null)).toBe(false)
   })
 
-  test('includes effective concurrency policy and local endpoints in status snapshots', () => {
-    const config: AgentConfig = {
-      machineId: 'codex-dev',
-      repo: 'JamesWuHK/digital-employee',
-      pat: 'test-token',
-      pollIntervalMs: 60_000,
-      idlePollIntervalMs: 300_000,
-      concurrency: 2,
-      requestedConcurrency: 5,
-      concurrencyPolicy: {
-        requested: 5,
-        effective: 2,
-        repoCap: 4,
-        profileCap: 2,
-        projectCap: 3,
-      },
-      scheduling: {
-        concurrencyByRepo: {
-          'JamesWuHK/digital-employee': 4,
+  test('includes effective concurrency policy and local endpoints in status snapshots', async () => {
+    await withRuntimeSupervisor('direct', async () => {
+      const config: AgentConfig = {
+        machineId: 'codex-dev',
+        repo: 'JamesWuHK/digital-employee',
+        pat: 'test-token',
+        pollIntervalMs: 60_000,
+        idlePollIntervalMs: 300_000,
+        concurrency: 2,
+        requestedConcurrency: 5,
+        concurrencyPolicy: {
+          requested: 5,
+          effective: 2,
+          repoCap: 4,
+          profileCap: 2,
+          projectCap: 3,
         },
-        concurrencyByProfile: {
-          'desktop-vite': 2,
+        scheduling: {
+          concurrencyByRepo: {
+            'JamesWuHK/digital-employee': 4,
+          },
+          concurrencyByProfile: {
+            'desktop-vite': 2,
+          },
         },
-      },
-      recovery: {
-        heartbeatIntervalMs: 30_000,
-        leaseTtlMs: 60_000,
-        workerIdleTimeoutMs: 300_000,
-        leaseAdoptionBackoffMs: 5_000,
-        leaseNoProgressTimeoutMs: 360_000,
-      },
-      worktreesBase: '/tmp/worktrees',
-      project: {
-        profile: 'desktop-vite',
-        maxConcurrency: 3,
-      },
-      agent: {
-        primary: 'codex',
-        fallback: 'claude',
-        claudePath: 'claude',
-        codexPath: 'codex',
-        timeoutMs: 60_000,
-      },
-      git: {
-        defaultBranch: 'main',
-        authorName: 'agent-loop',
-        authorEmail: 'agent-loop@local',
-      },
-    }
+        recovery: {
+          heartbeatIntervalMs: 30_000,
+          leaseTtlMs: 60_000,
+          workerIdleTimeoutMs: 300_000,
+          leaseAdoptionBackoffMs: 5_000,
+          leaseNoProgressTimeoutMs: 360_000,
+        },
+        worktreesBase: '/tmp/worktrees',
+        project: {
+          profile: 'desktop-vite',
+          maxConcurrency: 3,
+        },
+        agent: {
+          primary: 'codex',
+          fallback: 'claude',
+          claudePath: 'claude',
+          codexPath: 'codex',
+          timeoutMs: 60_000,
+        },
+        git: {
+          defaultBranch: 'main',
+          authorName: 'agent-loop',
+          authorEmail: 'agent-loop@local',
+        },
+      }
 
-    const daemon = new AgentDaemon(
-      config,
-      console,
-      { host: '127.0.0.1', port: 9311 },
-      9091,
-    )
+      const daemon = new AgentDaemon(
+        config,
+        console,
+        { host: '127.0.0.1', port: 9311 },
+        9091,
+      )
 
-    expect(daemon.getStatus()).toMatchObject({
-      repo: 'JamesWuHK/digital-employee',
-      idlePollIntervalMs: 300_000,
-      concurrency: 2,
-      requestedConcurrency: 5,
-      concurrencyPolicy: {
-        requested: 5,
-        effective: 2,
-        repoCap: 4,
-        profileCap: 2,
-        projectCap: 3,
-      },
-      project: {
-        profile: 'desktop-vite',
-        defaultBranch: 'main',
-        maxConcurrency: 3,
-      },
-      endpoints: {
-        health: {
-          host: '127.0.0.1',
-          port: 9311,
-          path: '/health',
+      expect(daemon.getStatus()).toMatchObject({
+        repo: 'JamesWuHK/digital-employee',
+        idlePollIntervalMs: 300_000,
+        concurrency: 2,
+        requestedConcurrency: 5,
+        concurrencyPolicy: {
+          requested: 5,
+          effective: 2,
+          repoCap: 4,
+          profileCap: 2,
+          projectCap: 3,
         },
-        metrics: {
-          host: '127.0.0.1',
-          port: 9091,
-          path: '/metrics',
+        project: {
+          profile: 'desktop-vite',
+          defaultBranch: 'main',
+          maxConcurrency: 3,
         },
-      },
-      runtime: {
-        supervisor: 'direct',
-        workingDirectory: process.cwd(),
-        runtimeRecordPath: null,
-        logPath: null,
-      },
+        endpoints: {
+          health: {
+            host: '127.0.0.1',
+            port: 9311,
+            path: '/health',
+          },
+          metrics: {
+            host: '127.0.0.1',
+            port: 9091,
+            path: '/metrics',
+          },
+        },
+        runtime: {
+          supervisor: 'direct',
+          workingDirectory: process.cwd(),
+        },
+      })
     })
   })
 
@@ -1790,6 +1805,28 @@ describe('daemon merge recovery helpers', () => {
     expect(shouldResetLinkedPrToRetryOnIssueResume([PR_REVIEW_LABELS.FAILED, PR_REVIEW_LABELS.HUMAN_NEEDED])).toBe(true)
     expect(shouldResetLinkedPrToRetryOnIssueResume([PR_REVIEW_LABELS.RETRY])).toBe(false)
     expect(shouldResetLinkedPrToRetryOnIssueResume([PR_REVIEW_LABELS.APPROVED])).toBe(false)
+  })
+
+  test('uses only open PRs as recovery context', () => {
+    expect(shouldUseOpenPrCheckForRecovery({
+      prNumber: 386,
+      prState: 'open',
+    })).toBe(true)
+
+    expect(shouldUseOpenPrCheckForRecovery({
+      prNumber: 386,
+      prState: 'closed',
+    })).toBe(false)
+
+    expect(shouldUseOpenPrCheckForRecovery({
+      prNumber: 386,
+      prState: 'merged',
+    })).toBe(false)
+
+    expect(shouldUseOpenPrCheckForRecovery({
+      prNumber: null,
+      prState: null,
+    })).toBe(false)
   })
 
   test('only reuses open linked PR context during issue recovery', () => {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -35,6 +35,7 @@ import {
   shouldRefreshBlockedHumanNeededPr,
   shouldResumeFailedIssueWithLinkedPr,
   getStandaloneIssueTransitionForReviewLabels,
+  getIssueRecoveryLinkedPrContext,
   isRetryableDaemonLoopError,
   isMergeabilityFailure,
   refreshResumableIssueBranchOntoDefault,
@@ -1788,6 +1789,30 @@ describe('daemon merge recovery helpers', () => {
     expect(shouldResetLinkedPrToRetryOnIssueResume([PR_REVIEW_LABELS.FAILED, PR_REVIEW_LABELS.HUMAN_NEEDED])).toBe(true)
     expect(shouldResetLinkedPrToRetryOnIssueResume([PR_REVIEW_LABELS.RETRY])).toBe(false)
     expect(shouldResetLinkedPrToRetryOnIssueResume([PR_REVIEW_LABELS.APPROVED])).toBe(false)
+  })
+
+  test('only reuses open linked PR context during issue recovery', () => {
+    expect(getIssueRecoveryLinkedPrContext({
+      prNumber: 110,
+      prState: 'open',
+      prUrl: 'https://example.com/pr/110',
+    }, 'agent/110/codex-dev')).toEqual({
+      number: 110,
+      url: 'https://example.com/pr/110',
+      branch: 'agent/110/codex-dev',
+    })
+
+    expect(getIssueRecoveryLinkedPrContext({
+      prNumber: 110,
+      prState: 'closed',
+      prUrl: 'https://example.com/pr/110',
+    }, 'agent/110/codex-dev')).toBeNull()
+
+    expect(getIssueRecoveryLinkedPrContext({
+      prNumber: 110,
+      prState: 'merged',
+      prUrl: 'https://example.com/pr/110',
+    }, 'agent/110/codex-dev')).toBeNull()
   })
 
   test('prefers standalone PR handoff for resumable issues when the branch is already synced', () => {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -4883,11 +4883,17 @@ export function shouldResetLinkedPrToRetryOnIssueResume(prLabels: string[]): boo
   return labels.has(PR_REVIEW_LABELS.HUMAN_NEEDED) || labels.has(PR_REVIEW_LABELS.FAILED)
 }
 
+export function shouldUseOpenPrCheckForRecovery(
+  prCheck: Pick<PrCheckResult, 'prNumber' | 'prState'>,
+): prCheck is Pick<PrCheckResult, 'prState'> & { prNumber: number; prState: 'open' } {
+  return prCheck.prNumber !== null && prCheck.prState === 'open'
+}
+
 export function getIssueRecoveryLinkedPrContext(
   prCheck: Pick<PrCheckResult, 'prNumber' | 'prState' | 'prUrl'>,
   branch: string,
 ): { number: number; url: string; branch: string } | null {
-  if (prCheck.prNumber === null || prCheck.prState !== 'open' || !prCheck.prUrl) {
+  if (!shouldUseOpenPrCheckForRecovery(prCheck) || !prCheck.prUrl) {
     return null
   }
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -17,6 +17,7 @@ import type {
   ManagedLeaseComment,
   ManagedLeaseScope,
   ManagedPullRequest,
+  PrCheckResult,
   RecoveryActionRuntimeDetail,
   StalledWorkerRuntimeDetail,
   WorktreeInfo,
@@ -2663,8 +2664,9 @@ export class AgentDaemon {
       })
 
       const prCheck = await checkPrExists(branch, this.config)
-      const linkedOpenPr = prCheck.prNumber !== null && prCheck.prState === 'open'
-        ? (await listOpenAgentPullRequests(this.config)).find((pr) => pr.number === prCheck.prNumber) ?? null
+      const linkedPrContext = getIssueRecoveryLinkedPrContext(prCheck, branch)
+      const linkedOpenPr = linkedPrContext
+        ? (await listOpenAgentPullRequests(this.config)).find((pr) => pr.number === linkedPrContext.number) ?? null
         : null
       if (linkedOpenPr && shouldResetLinkedPrToRetryOnIssueResume(linkedOpenPr.labels)) {
         await setManagedPrReviewLabels(linkedOpenPr.number, 'retry', this.config)
@@ -2674,8 +2676,8 @@ export class AgentDaemon {
       }
       const recentBlockingReasons = [
         ...extractAutomatedIssuePreflightReasons(await listIssueComments(issueNumber, this.config)),
-        ...(prCheck.prNumber !== null
-          ? extractAutomatedReviewReasons(await listIssueComments(prCheck.prNumber, this.config))
+        ...(linkedPrContext
+          ? extractAutomatedReviewReasons(await listIssueComments(linkedPrContext.number, this.config))
           : []),
       ]
       const recoveryResult = await runIssueRecovery(
@@ -2685,9 +2687,7 @@ export class AgentDaemon {
         issue.body,
         this.config,
         this.logger,
-        prCheck.prNumber !== null && prCheck.prUrl
-          ? { number: prCheck.prNumber, url: prCheck.prUrl, branch }
-          : null,
+        linkedPrContext,
         recentBlockingReasons,
         monitor,
       )
@@ -4881,6 +4881,21 @@ export function shouldApplyStandaloneIssueTransition(
 export function shouldResetLinkedPrToRetryOnIssueResume(prLabels: string[]): boolean {
   const labels = new Set(prLabels)
   return labels.has(PR_REVIEW_LABELS.HUMAN_NEEDED) || labels.has(PR_REVIEW_LABELS.FAILED)
+}
+
+export function getIssueRecoveryLinkedPrContext(
+  prCheck: Pick<PrCheckResult, 'prNumber' | 'prState' | 'prUrl'>,
+  branch: string,
+): { number: number; url: string; branch: string } | null {
+  if (prCheck.prNumber === null || prCheck.prState !== 'open' || !prCheck.prUrl) {
+    return null
+  }
+
+  return {
+    number: prCheck.prNumber,
+    url: prCheck.prUrl,
+    branch,
+  }
 }
 
 export function shouldCompleteIssueRecoveryOnRemoteClose(

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -2663,21 +2663,21 @@ export class AgentDaemon {
         abortMessage: `Aborted because remote issue #${issueNumber} is already done`,
       })
 
-      const prCheck = await checkPrExists(branch, this.config)
-      const linkedPrContext = getIssueRecoveryLinkedPrContext(prCheck, branch)
-      const linkedOpenPr = linkedPrContext
-        ? (await listOpenAgentPullRequests(this.config)).find((pr) => pr.number === linkedPrContext.number) ?? null
-        : null
-      if (linkedOpenPr && shouldResetLinkedPrToRetryOnIssueResume(linkedOpenPr.labels)) {
-        await setManagedPrReviewLabels(linkedOpenPr.number, 'retry', this.config)
+      const linkedRecoveryPr = getOpenLinkedPrForIssueRecovery(
+        await checkPrExists(branch, this.config),
+        branch,
+        await listOpenAgentPullRequests(this.config),
+      )
+      if (linkedRecoveryPr && shouldResetLinkedPrToRetryOnIssueResume(linkedRecoveryPr.pr.labels)) {
+        await setManagedPrReviewLabels(linkedRecoveryPr.pr.number, 'retry', this.config)
         this.logger.log(
-          `[daemon] marked linked PR #${linkedOpenPr.number} as retry because issue #${issueNumber} resumed local recovery`,
+          `[daemon] marked linked PR #${linkedRecoveryPr.pr.number} as retry because issue #${issueNumber} resumed local recovery`,
         )
       }
       const recentBlockingReasons = [
         ...extractAutomatedIssuePreflightReasons(await listIssueComments(issueNumber, this.config)),
-        ...(linkedPrContext
-          ? extractAutomatedReviewReasons(await listIssueComments(linkedPrContext.number, this.config))
+        ...(linkedRecoveryPr
+          ? extractAutomatedReviewReasons(await listIssueComments(linkedRecoveryPr.pr.number, this.config))
           : []),
       ]
       const recoveryResult = await runIssueRecovery(
@@ -2687,7 +2687,7 @@ export class AgentDaemon {
         issue.body,
         this.config,
         this.logger,
-        linkedPrContext,
+        linkedRecoveryPr?.context ?? null,
         recentBlockingReasons,
         monitor,
       )
@@ -4895,6 +4895,26 @@ export function getIssueRecoveryLinkedPrContext(
     number: prCheck.prNumber,
     url: prCheck.prUrl,
     branch,
+  }
+}
+
+export function getOpenLinkedPrForIssueRecovery(
+  prCheck: Pick<PrCheckResult, 'prNumber' | 'prState' | 'prUrl'>,
+  branch: string,
+  openPrs: Array<Pick<ManagedPullRequest, 'number' | 'url' | 'headRefName' | 'labels'>>,
+): {
+  pr: Pick<ManagedPullRequest, 'number' | 'url' | 'headRefName' | 'labels'>
+  context: { number: number; url: string; branch: string }
+} | null {
+  const context = getIssueRecoveryLinkedPrContext(prCheck, branch)
+  if (!context) return null
+
+  const pr = openPrs.find((candidate) => candidate.number === context.number) ?? null
+  if (!pr) return null
+
+  return {
+    pr,
+    context,
   }
 }
 

--- a/apps/agent-daemon/src/pr-reporter.test.ts
+++ b/apps/agent-daemon/src/pr-reporter.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from 'bun:test'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { isRetryableManagedBranchPushFailure, pushBranch } from './pr-reporter'
+import type { AgentConfig } from '@agent/shared'
+import { createOrFindPr, isRetryableManagedBranchPushFailure, pushBranch } from './pr-reporter'
 
 async function runGit(
   worktreePath: string,
@@ -22,7 +23,138 @@ async function runGit(
   return { exitCode, stdout, stderr }
 }
 
+const TEST_CONFIG: AgentConfig = {
+  machineId: 'codex-dev',
+  repo: 'JamesWuHK/digital-employee',
+  pat: 'test-token',
+  pollIntervalMs: 60_000,
+  idlePollIntervalMs: 300_000,
+  concurrency: 1,
+  requestedConcurrency: 1,
+  concurrencyPolicy: {
+    requested: 1,
+    effective: 1,
+    repoCap: null,
+    profileCap: null,
+    projectCap: null,
+  },
+  scheduling: {
+    concurrencyByRepo: {},
+    concurrencyByProfile: {},
+  },
+  recovery: {
+    heartbeatIntervalMs: 30_000,
+    leaseTtlMs: 60_000,
+    workerIdleTimeoutMs: 300_000,
+    leaseAdoptionBackoffMs: 5_000,
+    leaseNoProgressTimeoutMs: 360_000,
+  },
+  worktreesBase: '/tmp/worktrees',
+  project: {
+    profile: 'desktop-vite',
+  },
+  agent: {
+    primary: 'codex',
+    fallback: 'claude',
+    claudePath: 'claude',
+    codexPath: 'codex',
+    timeoutMs: 60_000,
+  },
+  git: {
+    defaultBranch: 'main',
+    authorName: 'agent-loop',
+    authorEmail: 'agent-loop@local',
+  },
+}
+
 describe('pr reporter push recovery', () => {
+  test('reuses open PRs after pushing the managed branch', async () => {
+    const calls: string[] = []
+
+    const result = await createOrFindPr(
+      '/tmp/worktree',
+      'agent/110/codex-dev',
+      110,
+      'Test issue',
+      TEST_CONFIG,
+      console,
+      {
+        checkPrExists: async () => {
+          calls.push('check')
+          return { prNumber: 41, prUrl: 'https://example.com/pr/41', prState: 'open' }
+        },
+        createPr: async () => {
+          calls.push('create')
+          return { number: 99, url: 'https://example.com/pr/99' }
+        },
+        pushBranch: async () => {
+          calls.push('push')
+        },
+      },
+    )
+
+    expect(result).toEqual({ prNumber: 41, prUrl: 'https://example.com/pr/41' })
+    expect(calls).toEqual(['check', 'push'])
+  })
+
+  test('keeps merged PRs terminal without pushing or recreating', async () => {
+    const calls: string[] = []
+
+    const result = await createOrFindPr(
+      '/tmp/worktree',
+      'agent/111/codex-dev',
+      111,
+      'Merged issue',
+      TEST_CONFIG,
+      console,
+      {
+        checkPrExists: async () => {
+          calls.push('check')
+          return { prNumber: 42, prUrl: 'https://example.com/pr/42', prState: 'merged' }
+        },
+        createPr: async () => {
+          calls.push('create')
+          return { number: 99, url: 'https://example.com/pr/99' }
+        },
+        pushBranch: async () => {
+          calls.push('push')
+        },
+      },
+    )
+
+    expect(result).toEqual({ prNumber: 42, prUrl: 'https://example.com/pr/42' })
+    expect(calls).toEqual(['check'])
+  })
+
+  test('pushes before creating a fresh PR when the previous PR was closed', async () => {
+    const calls: string[] = []
+
+    const result = await createOrFindPr(
+      '/tmp/worktree',
+      'agent/112/codex-dev',
+      112,
+      'Closed issue',
+      TEST_CONFIG,
+      console,
+      {
+        checkPrExists: async () => {
+          calls.push('check')
+          return { prNumber: 43, prUrl: 'https://example.com/pr/43', prState: 'closed' }
+        },
+        createPr: async () => {
+          calls.push('create')
+          return { number: 44, url: 'https://example.com/pr/44' }
+        },
+        pushBranch: async () => {
+          calls.push('push')
+        },
+      },
+    )
+
+    expect(result).toEqual({ prNumber: 44, prUrl: 'https://example.com/pr/44' })
+    expect(calls).toEqual(['check', 'push', 'create'])
+  })
+
   test('detects retryable managed-branch push failures', () => {
     expect(isRetryableManagedBranchPushFailure('! [rejected] agent/78/codex -> agent/78/codex (fetch first)')).toBe(true)
     expect(isRetryableManagedBranchPushFailure('To origin\n ! [rejected] agent/78/codex -> agent/78/codex (stale info)\nerror: failed to push some refs')).toBe(true)

--- a/apps/agent-daemon/src/pr-reporter.test.ts
+++ b/apps/agent-daemon/src/pr-reporter.test.ts
@@ -25,7 +25,7 @@ async function runGit(
 
 const TEST_CONFIG: AgentConfig = {
   machineId: 'codex-dev',
-  repo: 'JamesWuHK/digital-employee',
+  repo: 'JamesWuHK/agent-loop',
   pat: 'test-token',
   pollIntervalMs: 60_000,
   idlePollIntervalMs: 300_000,
@@ -51,7 +51,7 @@ const TEST_CONFIG: AgentConfig = {
   },
   worktreesBase: '/tmp/worktrees',
   project: {
-    profile: 'desktop-vite',
+    profile: 'generic',
   },
   agent: {
     primary: 'codex',
@@ -126,33 +126,45 @@ describe('pr reporter push recovery', () => {
     expect(calls).toEqual(['check'])
   })
 
-  test('pushes before creating a fresh PR when the previous PR was closed', async () => {
-    const calls: string[] = []
+  test('creates a fresh PR when the existing branch PR is closed', async () => {
+    const events: string[] = []
 
-    const result = await createOrFindPr(
+    const created = await createOrFindPr(
       '/tmp/worktree',
-      'agent/112/codex-dev',
-      112,
-      'Closed issue',
+      'agent/350/codex-dev',
+      350,
+      '[AL-16] fixture',
       TEST_CONFIG,
       console,
       {
-        checkPrExists: async () => {
-          calls.push('check')
-          return { prNumber: 43, prUrl: 'https://example.com/pr/43', prState: 'closed' }
+        checkPrExists: async () => ({
+          prNumber: 386,
+          prUrl: 'https://example.test/pr/386',
+          prState: 'closed',
+        }),
+        pushBranch: async (worktreePath, branch) => {
+          events.push(`push:${worktreePath}:${branch}`)
         },
-        createPr: async () => {
-          calls.push('create')
-          return { number: 44, url: 'https://example.com/pr/44' }
-        },
-        pushBranch: async () => {
-          calls.push('push')
+        createPr: async (branch, issueNumber, issueTitle, body) => {
+          events.push(`create:${branch}:${issueNumber}:${issueTitle}`)
+          expect(body).toContain('"issue": 350')
+          expect(body).toContain('"machine": "codex-dev"')
+          return {
+            number: 390,
+            url: 'https://example.test/pr/390',
+          }
         },
       },
     )
 
-    expect(result).toEqual({ prNumber: 44, prUrl: 'https://example.com/pr/44' })
-    expect(calls).toEqual(['check', 'push', 'create'])
+    expect(created).toEqual({
+      prNumber: 390,
+      prUrl: 'https://example.test/pr/390',
+    })
+    expect(events).toEqual([
+      'push:/tmp/worktree:agent/350/codex-dev',
+      'create:agent/350/codex-dev:350:[AL-16] fixture',
+    ])
   })
 
   test('detects retryable managed-branch push failures', () => {

--- a/apps/agent-daemon/src/pr-reporter.ts
+++ b/apps/agent-daemon/src/pr-reporter.ts
@@ -20,6 +20,12 @@ interface PushBranchDependencies {
   }) => Promise<void> | void
 }
 
+interface CreateOrFindPrDependencies {
+  checkPrExists: typeof checkPrExists
+  createPr: typeof createPr
+  pushBranch: typeof pushBranch
+}
+
 const MAX_PUSH_ATTEMPTS = 3
 
 interface ManagedBranchPushPlan {
@@ -181,13 +187,18 @@ export async function createOrFindPr(
   issueTitle: string,
   config: AgentConfig,
   logger = console,
+  dependencies: CreateOrFindPrDependencies = {
+    checkPrExists,
+    createPr,
+    pushBranch,
+  },
 ): Promise<{ prNumber: number; prUrl: string }> {
   // Check idempotency: PR might already exist
-  const existing = await checkPrExists(branch, config)
+  const existing = await dependencies.checkPrExists(branch, config)
 
   if (existing.prNumber !== null && existing.prState === 'open') {
     const url = existing.prUrl ?? ''
-    await pushBranch(worktreePath, branch, logger)
+    await dependencies.pushBranch(worktreePath, branch, logger)
     logger.log(`[pr] PR already exists: #${existing.prNumber} (${url})`)
     return { prNumber: existing.prNumber, prUrl: url }
   }
@@ -199,16 +210,14 @@ export async function createOrFindPr(
   }
 
   if (existing.prNumber !== null && existing.prState === 'closed') {
-    logger.warn(`[pr] PR was closed, not creating new PR`)
-    const url = existing.prUrl ?? ''
-    return { prNumber: existing.prNumber, prUrl: url }
+    logger.warn(`[pr] PR was closed: #${existing.prNumber}; pushing branch and creating a fresh PR`)
   }
 
   // Push branch first if not pushed yet
-  await pushBranch(worktreePath, branch, logger)
+  await dependencies.pushBranch(worktreePath, branch, logger)
 
   const body = PR_BODY_TEMPLATE(issueNumber, config.machineId)
-  const pr = await createPr(branch, issueNumber, issueTitle, body, config)
+  const pr = await dependencies.createPr(branch, issueNumber, issueTitle, body, config)
 
   logger.log(`[pr] created PR #${pr.number}: ${pr.url}`)
   return { prNumber: pr.number, prUrl: pr.url }


### PR DESCRIPTION
## Summary

Fixes #60

## Metadata

```json
{
  "issue": 60,
  "machine": "codex-dev",
  "generated_by": "agent-loop"
}
```

## Test Plan

- [ ] tested locally
- [ ] CI passes