### PR TITLE
Fix #61 gate approved PR merges on check status

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -2136,7 +2136,7 @@ describe('daemon merge recovery helpers', () => {
       })
     })
 
-    test('skips merge calls when checks fail and keeps the linked issue recoverable', async () => {
+    test('skips merge calls when checks fail and keeps the linked issue on the terminal path', async () => {
       const daemon = createTestDaemon()
       const comments: string[] = []
       const reviewStates: string[] = []
@@ -2174,7 +2174,7 @@ describe('daemon merge recovery helpers', () => {
         checksBlocked: true,
       })
       expect(classifyLinkedIssueApprovedMergeOutcome(mergeResult)).toEqual({
-        status: 'recoverable',
+        status: 'failed',
         reason: 'PR checks failed: build-and-test is fail',
       })
     })

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -2125,6 +2125,17 @@ describe('daemon merge recovery helpers', () => {
       })
     })
 
+    test('keeps pending checks on the recoverable linked-issue path', () => {
+      expect(classifyLinkedIssueApprovedMergeOutcome({
+        merged: false,
+        message: 'PR checks not ready for merge: build-and-test is pending',
+        recoverable: true,
+      })).toEqual({
+        status: 'recoverable',
+        reason: 'PR checks not ready for merge: build-and-test is pending',
+      })
+    })
+
     test('routes failing checks to human-needed', () => {
       expect(classifyApprovedPrMergeChecksGate({
         state: 'fail',
@@ -2186,6 +2197,17 @@ describe('daemon merge recovery helpers', () => {
       })).toEqual({
         outcome: 'defer',
         recoverable: true,
+        reason: 'Merge gate could not confirm PR checks: gh pr checks exited with code 4',
+      })
+    })
+
+    test('keeps checks lookup errors on the recoverable linked-issue path', () => {
+      expect(classifyLinkedIssueApprovedMergeOutcome({
+        merged: false,
+        message: 'Merge gate could not confirm PR checks: gh pr checks exited with code 4',
+        recoverable: true,
+      })).toEqual({
+        status: 'recoverable',
         reason: 'Merge gate could not confirm PR checks: gh pr checks exited with code 4',
       })
     })

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -31,6 +31,7 @@ import {
   shouldDeferResumableIssueForActiveLinkedPrTask,
   shouldDeferResumableIssueForActiveLinkedPrLease,
   shouldClearFailedIssueResumeTrackingAfterFinalize,
+  classifyApprovedPrMergeChecksGate,
   shouldEscalateBlockedIssueResume,
   shouldRefreshBlockedHumanNeededPr,
   shouldResumeFailedIssueWithLinkedPr,
@@ -2109,6 +2110,41 @@ describe('daemon merge recovery helpers', () => {
     expect(isMergeabilityFailure('Pull Request is not mergeable')).toBe(true)
     expect(isMergeabilityFailure('Merge conflict between base and head')).toBe(true)
     expect(isMergeabilityFailure('Required status check "test" is failing')).toBe(false)
+  })
+
+  describe('approved PR merge checks gate', () => {
+    test('defers pending checks without forcing the linked issue into failed', () => {
+      expect(classifyApprovedPrMergeChecksGate({
+        state: 'pending',
+        summary: 'build-and-test is pending',
+      })).toEqual({
+        outcome: 'defer',
+        recoverable: true,
+        reason: 'PR checks not ready for merge: build-and-test is pending',
+      })
+    })
+
+    test('routes failing checks to human-needed', () => {
+      expect(classifyApprovedPrMergeChecksGate({
+        state: 'fail',
+        summary: 'build-and-test is fail',
+      })).toEqual({
+        outcome: 'human-needed',
+        recoverable: false,
+        reason: 'PR checks failed: build-and-test is fail',
+      })
+    })
+
+    test('treats check lookup errors as recoverable deferrals', () => {
+      expect(classifyApprovedPrMergeChecksGate({
+        state: 'error',
+        summary: 'gh pr checks exited with code 4',
+      })).toEqual({
+        outcome: 'defer',
+        recoverable: true,
+        reason: 'Merge gate could not confirm PR checks: gh pr checks exited with code 4',
+      })
+    })
   })
 
   test('builds a merge retry comment with recovery details', () => {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -32,6 +32,7 @@ import {
   shouldDeferResumableIssueForActiveLinkedPrLease,
   shouldClearFailedIssueResumeTrackingAfterFinalize,
   classifyApprovedPrMergeChecksGate,
+  classifyLinkedIssueApprovedMergeOutcome,
   shouldEscalateBlockedIssueResume,
   shouldRefreshBlockedHumanNeededPr,
   shouldResumeFailedIssueWithLinkedPr,
@@ -2135,6 +2136,49 @@ describe('daemon merge recovery helpers', () => {
       })
     })
 
+    test('skips merge calls when checks fail and keeps the linked issue recoverable', async () => {
+      const daemon = createTestDaemon()
+      const comments: string[] = []
+      const reviewStates: string[] = []
+      let mergeCalls = 0
+
+      ;(daemon as any).getPullRequestChecksStatus = async () => ({
+        state: 'fail',
+        summary: 'build-and-test is fail',
+      })
+      ;(daemon as any).commentOnManagedPr = async (_prNumber: number, body: string) => {
+        comments.push(body)
+      }
+      ;(daemon as any).setManagedPrReviewState = async (_prNumber: number, state: string) => {
+        reviewStates.push(state)
+      }
+      ;(daemon as any).mergeManagedPullRequest = async () => {
+        mergeCalls += 1
+        return { merged: true, message: 'unexpected merge' }
+      }
+
+      const mergeResult = await (daemon as any).attemptApprovedPrMergeWithRecovery(
+        110,
+        'https://github.com/JamesWuHK/agent-loop/pull/110',
+        'agent/61/codex-dev',
+        '/tmp/worktrees/issue-61-codex-dev',
+      )
+
+      expect(mergeCalls).toBe(0)
+      expect(reviewStates).toEqual(['human-needed'])
+      expect(comments).toHaveLength(1)
+      expect(comments[0]).toContain('PR checks failed: build-and-test is fail')
+      expect(mergeResult).toMatchObject({
+        merged: false,
+        message: 'PR checks failed: build-and-test is fail',
+        checksBlocked: true,
+      })
+      expect(classifyLinkedIssueApprovedMergeOutcome(mergeResult)).toEqual({
+        status: 'recoverable',
+        reason: 'PR checks failed: build-and-test is fail',
+      })
+    })
+
     test('treats check lookup errors as recoverable deferrals', () => {
       expect(classifyApprovedPrMergeChecksGate({
         state: 'error',
@@ -2143,6 +2187,16 @@ describe('daemon merge recovery helpers', () => {
         outcome: 'defer',
         recoverable: true,
         reason: 'Merge gate could not confirm PR checks: gh pr checks exited with code 4',
+      })
+    })
+
+    test('keeps true merge failures on the failed linked-issue path', () => {
+      expect(classifyLinkedIssueApprovedMergeOutcome({
+        merged: false,
+        message: 'Pull Request is not mergeable',
+      })).toEqual({
+        status: 'failed',
+        reason: 'Pull Request is not mergeable',
       })
     })
   })

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -2212,6 +2212,37 @@ describe('daemon merge recovery helpers', () => {
       })
     })
 
+    test('treats thrown check lookups as recoverable deferrals without calling merge', async () => {
+      const daemon = createTestDaemon()
+      let mergeCalls = 0
+
+      ;(daemon as any).getPullRequestChecksStatus = async () => {
+        throw new Error('gh pr checks timed out')
+      }
+      ;(daemon as any).mergeManagedPullRequest = async () => {
+        mergeCalls += 1
+        return { merged: true, message: 'unexpected merge' }
+      }
+
+      const mergeResult = await (daemon as any).attemptApprovedPrMergeWithRecovery(
+        110,
+        'https://github.com/JamesWuHK/agent-loop/pull/110',
+        'agent/61/codex-dev',
+        '/tmp/worktrees/issue-61-codex-dev',
+      )
+
+      expect(mergeCalls).toBe(0)
+      expect(mergeResult).toMatchObject({
+        merged: false,
+        message: 'Merge gate could not confirm PR checks: gh pr checks timed out',
+        recoverable: true,
+      })
+      expect(classifyLinkedIssueApprovedMergeOutcome(mergeResult)).toEqual({
+        status: 'recoverable',
+        reason: 'Merge gate could not confirm PR checks: gh pr checks timed out',
+      })
+    })
+
     test('keeps true merge failures on the failed linked-issue path', () => {
       expect(classifyLinkedIssueApprovedMergeOutcome({
         merged: false,

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -5135,6 +5135,13 @@ export function classifyApprovedPrMergeChecksGate(
 export function classifyLinkedIssueApprovedMergeOutcome(
   mergeResult: ApprovedPrMergeAttemptResult,
 ): { status: 'failed' | 'recoverable'; reason: string } {
+  if (mergeResult.recoverable) {
+    return {
+      status: 'recoverable',
+      reason: mergeResult.message,
+    }
+  }
+
   if (mergeResult.checksBlocked) {
     return {
       status: 'failed',

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -18,11 +18,12 @@ import type {
   ManagedLeaseScope,
   ManagedPullRequest,
   PrCheckResult,
+  PullRequestChecksStatus,
   RecoveryActionRuntimeDetail,
   StalledWorkerRuntimeDetail,
   WorktreeInfo,
 } from '@agent/shared'
-import { ISSUE_LABELS, PR_REVIEW_LABELS, canDaemonAdoptManagedLease, getActiveManagedLease, getLatestManagedLease, listOpenAgentIssues, listOpenAgentPullRequests, transitionIssueState, commentOnIssue, commentOnPr, setManagedPrReviewLabels, mergePullRequest, checkPrExists, listIssueComments, resolveActiveClaimMachine, getAgentIssueByNumber, getManagedPullRequestByNumber, setGitHubApiRequestObserver } from '@agent/shared'
+import { ISSUE_LABELS, PR_REVIEW_LABELS, canDaemonAdoptManagedLease, getActiveManagedLease, getLatestManagedLease, listOpenAgentIssues, listOpenAgentPullRequests, transitionIssueState, commentOnIssue, commentOnPr, setManagedPrReviewLabels, mergePullRequest, checkPrExists, listIssueComments, resolveActiveClaimMachine, getAgentIssueByNumber, getManagedPullRequestByNumber, setGitHubApiRequestObserver, getPullRequestChecksStatus } from '@agent/shared'
 import { claimSpecificIssue, pollAndClaim } from './claimer'
 import { createWorktree, removeWorktree, cleanupOrphanedWorktrees, hasWorktreeForIssue } from './worktree-manager'
 import { runIssueBranchPreflight, runSubtaskExecutor, runReviewAutoFix, runIssueRecovery } from './subtask-executor'
@@ -248,6 +249,12 @@ export interface IssueResumeResolutionComment {
 
 export interface IssueResumeResolutionRecord extends IssueComment {
   resolutionComment: IssueResumeResolutionComment
+}
+
+export interface ApprovedPrMergeChecksGateResult {
+  outcome: 'allow' | 'defer' | 'human-needed'
+  recoverable: boolean
+  reason: string | null
 }
 
 export class AgentDaemon {
@@ -2821,6 +2828,21 @@ export class AgentDaemon {
     worktreePath: string,
     monitor?: TaskExecutionMonitor,
   ): Promise<{ merged: boolean; message: string; sha?: string; review?: PrReviewResult; recoverable?: boolean }> {
+    const initialChecksGate = await this.runApprovedPrMergeChecksGate(prNumber)
+    if (initialChecksGate.outcome === 'defer') {
+      return {
+        merged: false,
+        message: initialChecksGate.reason ?? 'PR checks not ready for merge',
+        recoverable: true,
+      }
+    }
+    if (initialChecksGate.outcome === 'human-needed') {
+      return {
+        merged: false,
+        message: initialChecksGate.reason ?? 'PR checks failed',
+      }
+    }
+
     const mergeResult = await mergePullRequest(prNumber, this.config)
     if (mergeResult.merged) {
       recordPrMergeRecoveryOutcome('merged_initial')
@@ -2896,6 +2918,23 @@ export class AgentDaemon {
     await commentOnPr(prNumber, buildPrReviewComment(prNumber, review, 2, 'approved'), this.config)
     await setManagedPrReviewLabels(prNumber, 'approved', this.config)
 
+    const retriedChecksGate = await this.runApprovedPrMergeChecksGate(prNumber)
+    if (retriedChecksGate.outcome === 'defer') {
+      return {
+        merged: false,
+        message: retriedChecksGate.reason ?? 'PR checks not ready for merge',
+        review,
+        recoverable: true,
+      }
+    }
+    if (retriedChecksGate.outcome === 'human-needed') {
+      return {
+        merged: false,
+        message: retriedChecksGate.reason ?? 'PR checks failed',
+        review,
+      }
+    }
+
     const retriedMergeResult = await mergePullRequest(prNumber, this.config)
     if (retriedMergeResult.merged) {
       recordPrMergeRecoveryOutcome('merged_after_refresh')
@@ -2912,6 +2951,20 @@ export class AgentDaemon {
       ...retriedMergeResult,
       review,
     }
+  }
+
+  private async runApprovedPrMergeChecksGate(
+    prNumber: number,
+  ): Promise<ApprovedPrMergeChecksGateResult> {
+    const checksStatus = await getPullRequestChecksStatus(prNumber, this.config)
+    const gate = classifyApprovedPrMergeChecksGate(checksStatus)
+
+    if (gate.outcome === 'human-needed' && gate.reason) {
+      await commentOnPr(prNumber, buildPrMergeBlockedComment(prNumber, gate.reason), this.config)
+      await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+    }
+
+    return gate
   }
 
   private registerFailedIssueResume(issueNumber: number): void {
@@ -5005,6 +5058,41 @@ function buildAutoFixPushFailedReview(error: unknown): PrReviewResult {
 export function isMergeabilityFailure(message: string): boolean {
   const normalized = message.toLowerCase()
   return normalized.includes('not mergeable') || normalized.includes('merge conflict')
+}
+
+export function classifyApprovedPrMergeChecksGate(
+  status: PullRequestChecksStatus,
+): ApprovedPrMergeChecksGateResult {
+  switch (status.state) {
+    case 'pass':
+      return {
+        outcome: 'allow',
+        recoverable: false,
+        reason: null,
+      }
+    case 'pending':
+      return {
+        outcome: 'defer',
+        recoverable: true,
+        reason: `PR checks not ready for merge: ${status.summary}`,
+      }
+    case 'fail':
+      return {
+        outcome: 'human-needed',
+        recoverable: false,
+        reason: `PR checks failed: ${status.summary}`,
+      }
+    case 'error':
+      return {
+        outcome: 'defer',
+        recoverable: true,
+        reason: `Merge gate could not confirm PR checks: ${status.summary}`,
+      }
+    default: {
+      const exhaustiveStatus: never = status.state
+      throw new Error(`Unhandled PR checks gate state: ${exhaustiveStatus}`)
+    }
+  }
 }
 
 export function isMissingRemoteBranchGitOutput(

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -2966,7 +2966,15 @@ export class AgentDaemon {
   private async runApprovedPrMergeChecksGate(
     prNumber: number,
   ): Promise<ApprovedPrMergeChecksGateResult> {
-    const checksStatus = await this.getPullRequestChecksStatus(prNumber)
+    let checksStatus: PullRequestChecksStatus
+    try {
+      checksStatus = await this.getPullRequestChecksStatus(prNumber)
+    } catch (error) {
+      checksStatus = {
+        state: 'error',
+        summary: formatDaemonError(error),
+      }
+    }
     const gate = classifyApprovedPrMergeChecksGate(checksStatus)
 
     if (gate.outcome === 'human-needed' && gate.reason) {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -257,6 +257,15 @@ export interface ApprovedPrMergeChecksGateResult {
   reason: string | null
 }
 
+interface ApprovedPrMergeAttemptResult {
+  merged: boolean
+  message: string
+  sha?: string
+  review?: PrReviewResult
+  recoverable?: boolean
+  checksBlocked?: boolean
+}
+
 export class AgentDaemon {
   private static readonly MAX_AUTOMATED_PR_REVIEW_ATTEMPTS = 3
   private running = false
@@ -2827,7 +2836,7 @@ export class AgentDaemon {
     branch: string,
     worktreePath: string,
     monitor?: TaskExecutionMonitor,
-  ): Promise<{ merged: boolean; message: string; sha?: string; review?: PrReviewResult; recoverable?: boolean }> {
+  ): Promise<ApprovedPrMergeAttemptResult> {
     const initialChecksGate = await this.runApprovedPrMergeChecksGate(prNumber)
     if (initialChecksGate.outcome === 'defer') {
       return {
@@ -2840,10 +2849,11 @@ export class AgentDaemon {
       return {
         merged: false,
         message: initialChecksGate.reason ?? 'PR checks failed',
+        checksBlocked: true,
       }
     }
 
-    const mergeResult = await mergePullRequest(prNumber, this.config)
+    const mergeResult = await this.mergeManagedPullRequest(prNumber)
     if (mergeResult.merged) {
       recordPrMergeRecoveryOutcome('merged_initial')
       return mergeResult
@@ -2851,15 +2861,14 @@ export class AgentDaemon {
 
     if (!isMergeabilityFailure(mergeResult.message)) {
       recordPrMergeRecoveryOutcome('blocked_non_mergeable')
-      await commentOnPr(prNumber, buildPrMergeBlockedComment(prNumber, mergeResult.message), this.config)
-      await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+      await this.commentOnManagedPr(prNumber, buildPrMergeBlockedComment(prNumber, mergeResult.message))
+      await this.setManagedPrReviewState(prNumber, 'human-needed')
       return mergeResult
     }
 
-    await commentOnPr(
+    await this.commentOnManagedPr(
       prNumber,
       buildPrMergeRetryComment(prNumber, branch, this.config.git.defaultBranch, mergeResult.message),
-      this.config,
     )
 
     const refreshResult = await rebaseManagedBranchOntoDefault(
@@ -2874,8 +2883,8 @@ export class AgentDaemon {
         merged: false,
         message: `Branch refresh failed: ${refreshResult.message}`,
       }
-      await commentOnPr(prNumber, buildPrMergeBlockedComment(prNumber, blockedResult.message), this.config)
-      await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+      await this.commentOnManagedPr(prNumber, buildPrMergeBlockedComment(prNumber, blockedResult.message))
+      await this.setManagedPrReviewState(prNumber, 'human-needed')
       return blockedResult
     }
 
@@ -2887,8 +2896,8 @@ export class AgentDaemon {
         merged: false,
         message: `Branch refresh push failed: ${formatDaemonError(err)}`,
       }
-      await commentOnPr(prNumber, buildPrMergeBlockedComment(prNumber, blockedResult.message), this.config)
-      await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+      await this.commentOnManagedPr(prNumber, buildPrMergeBlockedComment(prNumber, blockedResult.message))
+      await this.setManagedPrReviewState(prNumber, 'human-needed')
       return blockedResult
     }
 
@@ -2906,8 +2915,8 @@ export class AgentDaemon {
 
     if (!(review.approved && review.canMerge)) {
       recordPrMergeRecoveryOutcome('refresh_review_blocked')
-      await commentOnPr(prNumber, buildPrReviewComment(prNumber, review, 2, 'human-needed'), this.config)
-      await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+      await this.commentOnManagedPr(prNumber, buildPrReviewComment(prNumber, review, 2, 'human-needed'))
+      await this.setManagedPrReviewState(prNumber, 'human-needed')
       return {
         merged: false,
         message: review.reason,
@@ -2915,8 +2924,8 @@ export class AgentDaemon {
       }
     }
 
-    await commentOnPr(prNumber, buildPrReviewComment(prNumber, review, 2, 'approved'), this.config)
-    await setManagedPrReviewLabels(prNumber, 'approved', this.config)
+    await this.commentOnManagedPr(prNumber, buildPrReviewComment(prNumber, review, 2, 'approved'))
+    await this.setManagedPrReviewState(prNumber, 'approved')
 
     const retriedChecksGate = await this.runApprovedPrMergeChecksGate(prNumber)
     if (retriedChecksGate.outcome === 'defer') {
@@ -2932,10 +2941,11 @@ export class AgentDaemon {
         merged: false,
         message: retriedChecksGate.reason ?? 'PR checks failed',
         review,
+        checksBlocked: true,
       }
     }
 
-    const retriedMergeResult = await mergePullRequest(prNumber, this.config)
+    const retriedMergeResult = await this.mergeManagedPullRequest(prNumber)
     if (retriedMergeResult.merged) {
       recordPrMergeRecoveryOutcome('merged_after_refresh')
       return {
@@ -2945,8 +2955,8 @@ export class AgentDaemon {
     }
 
     recordPrMergeRecoveryOutcome('retry_merge_failed')
-    await commentOnPr(prNumber, buildPrMergeBlockedComment(prNumber, retriedMergeResult.message), this.config)
-    await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+    await this.commentOnManagedPr(prNumber, buildPrMergeBlockedComment(prNumber, retriedMergeResult.message))
+    await this.setManagedPrReviewState(prNumber, 'human-needed')
     return {
       ...retriedMergeResult,
       review,
@@ -2956,15 +2966,34 @@ export class AgentDaemon {
   private async runApprovedPrMergeChecksGate(
     prNumber: number,
   ): Promise<ApprovedPrMergeChecksGateResult> {
-    const checksStatus = await getPullRequestChecksStatus(prNumber, this.config)
+    const checksStatus = await this.getPullRequestChecksStatus(prNumber)
     const gate = classifyApprovedPrMergeChecksGate(checksStatus)
 
     if (gate.outcome === 'human-needed' && gate.reason) {
-      await commentOnPr(prNumber, buildPrMergeBlockedComment(prNumber, gate.reason), this.config)
-      await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+      await this.commentOnManagedPr(prNumber, buildPrMergeBlockedComment(prNumber, gate.reason))
+      await this.setManagedPrReviewState(prNumber, 'human-needed')
     }
 
     return gate
+  }
+
+  private async getPullRequestChecksStatus(prNumber: number): Promise<PullRequestChecksStatus> {
+    return getPullRequestChecksStatus(prNumber, this.config)
+  }
+
+  private async mergeManagedPullRequest(prNumber: number) {
+    return mergePullRequest(prNumber, this.config)
+  }
+
+  private async commentOnManagedPr(prNumber: number, body: string): Promise<void> {
+    await commentOnPr(prNumber, body, this.config)
+  }
+
+  private async setManagedPrReviewState(
+    prNumber: number,
+    state: 'approved' | 'failed' | 'retry' | 'human-needed',
+  ): Promise<void> {
+    await setManagedPrReviewLabels(prNumber, state, this.config)
   }
 
   private registerFailedIssueResume(issueNumber: number): void {
@@ -3269,6 +3298,14 @@ export class AgentDaemon {
       await this.completeManagedLease('pr-merge', pr.prNumber, mergeLease.handle, 'completed')
 
       if (!mergeResult.merged) {
+        const linkedIssueOutcome = classifyLinkedIssueApprovedMergeOutcome(mergeResult)
+        if (linkedIssueOutcome.status === 'recoverable') {
+          this.logger.warn(`[daemon] issue #${issue.number} approved PR #${pr.prNumber} is blocked pending human follow-up: ${mergeResult.message}`)
+          this.activeWorktrees.delete(issue.number)
+          this.syncRuntimeMetrics()
+          return linkedIssueOutcome
+        }
+
         await transitionIssueState(
           issue.number,
           ISSUE_LABELS.FAILED,
@@ -5092,6 +5129,22 @@ export function classifyApprovedPrMergeChecksGate(
       const exhaustiveStatus: never = status.state
       throw new Error(`Unhandled PR checks gate state: ${exhaustiveStatus}`)
     }
+  }
+}
+
+export function classifyLinkedIssueApprovedMergeOutcome(
+  mergeResult: ApprovedPrMergeAttemptResult,
+): { status: 'failed' | 'recoverable'; reason: string } {
+  if (mergeResult.checksBlocked) {
+    return {
+      status: 'recoverable',
+      reason: mergeResult.message,
+    }
+  }
+
+  return {
+    status: 'failed',
+    reason: mergeResult.message,
   }
 }
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -5137,7 +5137,7 @@ export function classifyLinkedIssueApprovedMergeOutcome(
 ): { status: 'failed' | 'recoverable'; reason: string } {
   if (mergeResult.checksBlocked) {
     return {
-      status: 'recoverable',
+      status: 'failed',
       reason: mergeResult.message,
     }
   }

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -16,6 +16,8 @@ import {
   extractManagedLeaseComment,
   getActiveManagedLease,
   getLatestManagedLease,
+  getPullRequestChecksStatus,
+  interpretPullRequestChecksResult,
   isGraphQlRateLimitErrorMessage,
   isManagedLeaseExpired,
   isManagedLeaseProgressStale,
@@ -261,6 +263,76 @@ describe('parseMergePrResponse', () => {
       message: 'Pull Request is not mergeable',
       sha: undefined,
     })
+  })
+})
+
+describe('interpretPullRequestChecksResult', () => {
+  test('treats failing checks as a merge blocker', () => {
+    expect(interpretPullRequestChecksResult({
+      stdout: 'build-and-test\tfail\t2m46s\thttps://example.test/run/1',
+      stderr: '',
+      exitCode: 1,
+      timedOut: false,
+    })).toEqual({
+      state: 'fail',
+      summary: 'build-and-test is fail',
+    })
+  })
+
+  test('treats pending checks as not ready yet', () => {
+    expect(interpretPullRequestChecksResult({
+      stdout: 'build-and-test\tpending\t0\thttps://example.test/run/1',
+      stderr: '',
+      exitCode: 8,
+      timedOut: false,
+    })).toEqual({
+      state: 'pending',
+      summary: 'build-and-test is pending',
+    })
+  })
+
+  test('allows merge when GitHub reports that no checks exist', () => {
+    expect(interpretPullRequestChecksResult({
+      stdout: "no checks reported on the 'agent/350/codex-dev-r1' branch",
+      stderr: '',
+      exitCode: 1,
+      timedOut: false,
+    })).toEqual({
+      state: 'pass',
+      summary: 'No checks reported',
+    })
+  })
+})
+
+describe('getPullRequestChecksStatus', () => {
+  test('runs gh pr checks against the configured repository', async () => {
+    const calls: Array<{ args: string[]; pat: string }> = []
+
+    const status = await getPullRequestChecksStatus(
+      390,
+      {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+      async (args, config) => {
+        calls.push({ args, pat: config.pat })
+        return {
+          stdout: 'build-and-test\tpass\t2m43s\thttps://example.test/run/1',
+          stderr: '',
+          exitCode: 0,
+          timedOut: false,
+        }
+      },
+    )
+
+    expect(status).toEqual({
+      state: 'pass',
+      summary: '1 check(s) passed',
+    })
+    expect(calls).toEqual([{
+      args: ['pr', 'checks', '390', '-R', 'JamesWuHK/agent-loop'],
+      pat: 'test-token',
+    }])
   })
 })
 

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -1321,10 +1321,110 @@ export interface PrCheckResult {
   prState: 'open' | 'merged' | 'closed' | null
 }
 
+export interface PullRequestChecksStatus {
+  state: 'pass' | 'pending' | 'fail' | 'error'
+  summary: string
+}
+
 export interface MergePrResult {
   merged: boolean
   message: string
   sha?: string
+}
+
+const PASSING_PR_CHECK_STATES = new Set(['pass', 'success', 'neutral', 'skipping', 'skipped'])
+const PENDING_PR_CHECK_STATES = new Set(['pending', 'queued', 'waiting', 'in_progress'])
+const FAILING_PR_CHECK_STATES = new Set([
+  'fail',
+  'failure',
+  'failing',
+  'cancel',
+  'cancelled',
+  'timed_out',
+  'startup_failure',
+  'action_required',
+  'error',
+])
+
+function parsePullRequestChecksRows(stdout: string): Array<{ name: string; state: string }> {
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split('\t'))
+    .filter((parts) => parts.length >= 2)
+    .map((parts) => ({
+      name: parts[0]?.trim() ?? '',
+      state: parts[1]?.trim().toLowerCase() ?? '',
+    }))
+    .filter((row) => row.name.length > 0 && row.state.length > 0)
+}
+
+function formatPullRequestChecksError(result: Pick<GhCommandResult, 'stdout' | 'stderr' | 'exitCode' | 'timedOut'>): string {
+  const stdout = result.stdout.trim()
+  const stderr = result.stderr.trim()
+
+  if (result.timedOut) {
+    return stderr || stdout || 'gh pr checks timed out'
+  }
+
+  return stderr || stdout || `gh pr checks exited with code ${result.exitCode}`
+}
+
+export function interpretPullRequestChecksResult(
+  result: Pick<GhCommandResult, 'stdout' | 'stderr' | 'exitCode' | 'timedOut'>,
+): PullRequestChecksStatus {
+  const stdout = result.stdout.trim()
+
+  if (/no checks reported/i.test(stdout)) {
+    return {
+      state: 'pass',
+      summary: 'No checks reported',
+    }
+  }
+
+  const rows = parsePullRequestChecksRows(stdout)
+  const firstFailing = rows.find((row) => FAILING_PR_CHECK_STATES.has(row.state))
+  if (firstFailing) {
+    return {
+      state: 'fail',
+      summary: `${firstFailing.name} is ${firstFailing.state}`,
+    }
+  }
+
+  const firstPending = rows.find((row) => PENDING_PR_CHECK_STATES.has(row.state))
+  if (firstPending) {
+    return {
+      state: 'pending',
+      summary: `${firstPending.name} is ${firstPending.state}`,
+    }
+  }
+
+  if (rows.length > 0 && rows.every((row) => PASSING_PR_CHECK_STATES.has(row.state))) {
+    return {
+      state: 'pass',
+      summary: `${rows.length} check(s) passed`,
+    }
+  }
+
+  if (result.exitCode !== 0 || result.timedOut) {
+    return {
+      state: 'error',
+      summary: formatPullRequestChecksError(result),
+    }
+  }
+
+  if (rows.length > 0) {
+    return {
+      state: 'pass',
+      summary: `${rows.length} check(s) passed`,
+    }
+  }
+
+  return {
+    state: 'error',
+    summary: formatPullRequestChecksError(result),
+  }
 }
 
 interface RawPullRequestListItem {
@@ -1853,6 +1953,18 @@ export async function mergePullRequest(
   }
 
   return parseMergePrResponse(stdout)
+}
+
+export async function getPullRequestChecksStatus(
+  prNumber: number,
+  config: Pick<AgentConfig, 'repo' | 'pat'>,
+  runner: (
+    args: string[],
+    config: Pick<AgentConfig, 'repo' | 'pat'>,
+  ) => Promise<Pick<GhCommandResult, 'stdout' | 'stderr' | 'exitCode' | 'timedOut'>> = runBoundedGhCommand,
+): Promise<PullRequestChecksStatus> {
+  const result = await runner(['pr', 'checks', String(prNumber), '-R', config.repo], config)
+  return interpretPullRequestChecksResult(result)
 }
 
 export async function addPrLabels(

--- a/packages/agent-shared/src/index.ts
+++ b/packages/agent-shared/src/index.ts
@@ -1,6 +1,12 @@
 export * from './types'
 export * from './state-machine'
 export * from './github-api'
+export {
+  getPullRequestChecksStatus,
+  interpretPullRequestChecksResult,
+  parseMergePrResponse,
+  type PullRequestChecksStatus,
+} from './github-api'
 export * from './subtask-parser'
 export * from './issue-contract'
 export * from './issue-contract-validator'


### PR DESCRIPTION
## Summary
- add shared `gh pr checks` parsing and a small helper to read PR check status before merge
- gate approved PR merges before both the initial merge attempt and the post-refresh retry
- defer pending or lookup-error states, and route failing checks to `human-needed` without calling merge

## Testing
- bun test packages/agent-shared/src/github-api.test.ts
- bun test ./src/daemon.test.ts
- bun run typecheck

Closes #61