### PR TITLE
Fix #69 add self-bootstrap scenario suite

### DIFF
--- a/apps/agent-daemon/src/fixtures/replay/self-bootstrap-checks-fail.json
+++ b/apps/agent-daemon/src/fixtures/replay/self-bootstrap-checks-fail.json
@@ -1,0 +1,42 @@
+{
+  "name": "self-bootstrap-checks-fail",
+  "openIssues": [
+    {
+      "number": 361,
+      "title": "failed issue after merge checks red path",
+      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 merge checks fail 的场景在 replay 中稳定呈现为 blocked human-needed path。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- replay remains local and deterministic\n\n### OutOfScope\n- live review or merge retries\n\n### RequiredSemantics\n- terminal linked PR blocks automated resume\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap checks fail fixture')\n```\n\n## 实现步骤\n1. add replay fixture\n\n## 验收\n- [ ] blocked failure stays reproducible",
+      "labels": [
+        "agent:failed"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T10:20:00.000Z"
+    }
+  ],
+  "issueComments": [
+    {
+      "issueNumber": 361,
+      "commentId": 1,
+      "body": "<!-- agent-loop:issue-resume-blocked {\"issueNumber\":361,\"prNumber\":461,\"blockedSince\":\"2026-04-11T10:18:00.000Z\",\"escalatedAt\":\"2026-04-11T10:20:00.000Z\",\"thresholdSeconds\":300,\"reason\":\"linked PR #461 is in terminal agent:human-needed after failing merge checks\",\"machineId\":\"codex-dev\",\"daemonInstanceId\":\"daemon-merge-checks\"} -->\n## agent-loop blocked resume escalation",
+      "createdAt": "2026-04-11T10:20:00.000Z",
+      "updatedAt": "2026-04-11T10:20:00.000Z"
+    }
+  ],
+  "openPullRequests": [
+    {
+      "number": 461,
+      "title": "Fix #361: failed issue after merge checks red path",
+      "labels": [
+        "agent:human-needed"
+      ],
+      "isDraft": false,
+      "headRefName": "agent/361/codex-dev",
+      "headRefOid": "def461"
+    }
+  ],
+  "expected": {
+    "claimable": 0,
+    "blocked": 1,
+    "invalid": 0
+  }
+}

--- a/apps/agent-daemon/src/fixtures/replay/self-bootstrap-checks-pending.json
+++ b/apps/agent-daemon/src/fixtures/replay/self-bootstrap-checks-pending.json
@@ -2,32 +2,38 @@
   "name": "self-bootstrap-checks-pending",
   "openIssues": [
     {
-      "number": 351,
-      "title": "upstream blocker still running",
-      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 replay 能稳定表达 pending gate 仍未 ready 的场景。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- supporting issue stays valid\n\n### OutOfScope\n- live merge or review execution\n\n### RequiredSemantics\n- dependency issue remains unfinished\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap pending support fixture')\n```\n\n## 实现步骤\n1. add support issue fixture\n\n## 验收\n- [ ] support issue stays non-terminal",
-      "labels": [
-        "agent:working"
-      ],
-      "assignees": [
-        "codex-dev"
-      ],
-      "state": "open",
-      "updatedAt": "2026-04-11T10:10:00.000Z"
-    },
-    {
       "number": 352,
-      "title": "merge gate still pending downstream work",
-      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 pending merge gate 场景在 replay 里保持 deferred，而不是误判为 pass。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[351]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- scenario remains deterministic\n\n### OutOfScope\n- live GitHub checks API\n\n### RequiredSemantics\n- downstream issue is blocked until dependency resolves\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap checks pending fixture')\n```\n\n## 实现步骤\n1. add replay fixture\n\n## 验收\n- [ ] blocked issue stays non-claimable",
+      "title": "failed issue waiting on linked PR checks to finish",
+      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 self-bootstrap replay 能稳定覆盖 linked PR checks 仍在 pending 的恢复场景。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- scenario stays local and deterministic\n\n### OutOfScope\n- live GitHub checks API or daemon polling\n\n### RequiredSemantics\n- failed issue remains blocked while the linked PR is still waiting on checks\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap checks pending fixture')\n```\n\n## 实现步骤\n1. add replay fixture for pending linked PR checks\n\n## 验收\n- [ ] linked PR checks pending path stays reproducible",
       "labels": [
-        "agent:ready"
+        "agent:failed"
       ],
       "assignees": [],
       "state": "open",
       "updatedAt": "2026-04-11T10:11:00.000Z"
     }
   ],
-  "issueComments": [],
-  "openPullRequests": [],
+  "issueComments": [
+    {
+      "issueNumber": 352,
+      "commentId": 1,
+      "body": "<!-- agent-loop:issue-resume-blocked {\"issueNumber\":352,\"prNumber\":452,\"blockedSince\":\"2026-04-11T10:08:00.000Z\",\"escalatedAt\":\"2026-04-11T10:11:00.000Z\",\"thresholdSeconds\":300,\"reason\":\"linked PR #452 is still waiting for required self-bootstrap checks to finish before merge can resume\",\"machineId\":\"codex-dev\",\"daemonInstanceId\":\"daemon-self-bootstrap\"} -->\n## agent-loop blocked resume escalation",
+      "createdAt": "2026-04-11T10:11:00.000Z",
+      "updatedAt": "2026-04-11T10:11:00.000Z"
+    }
+  ],
+  "openPullRequests": [
+    {
+      "number": 452,
+      "title": "Fix #352: failed issue waiting on linked PR checks to finish",
+      "labels": [
+        "agent:review-approved"
+      ],
+      "isDraft": false,
+      "headRefName": "agent/352/codex-dev",
+      "headRefOid": "abc452"
+    }
+  ],
   "expected": {
     "claimable": 0,
     "blocked": 1,

--- a/apps/agent-daemon/src/fixtures/replay/self-bootstrap-checks-pending.json
+++ b/apps/agent-daemon/src/fixtures/replay/self-bootstrap-checks-pending.json
@@ -1,0 +1,36 @@
+{
+  "name": "self-bootstrap-checks-pending",
+  "openIssues": [
+    {
+      "number": 351,
+      "title": "upstream blocker still running",
+      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 replay 能稳定表达 pending gate 仍未 ready 的场景。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- supporting issue stays valid\n\n### OutOfScope\n- live merge or review execution\n\n### RequiredSemantics\n- dependency issue remains unfinished\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap pending support fixture')\n```\n\n## 实现步骤\n1. add support issue fixture\n\n## 验收\n- [ ] support issue stays non-terminal",
+      "labels": [
+        "agent:working"
+      ],
+      "assignees": [
+        "codex-dev"
+      ],
+      "state": "open",
+      "updatedAt": "2026-04-11T10:10:00.000Z"
+    },
+    {
+      "number": 352,
+      "title": "merge gate still pending downstream work",
+      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 pending merge gate 场景在 replay 里保持 deferred，而不是误判为 pass。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[351]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- scenario remains deterministic\n\n### OutOfScope\n- live GitHub checks API\n\n### RequiredSemantics\n- downstream issue is blocked until dependency resolves\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap checks pending fixture')\n```\n\n## 实现步骤\n1. add replay fixture\n\n## 验收\n- [ ] blocked issue stays non-claimable",
+      "labels": [
+        "agent:ready"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T10:11:00.000Z"
+    }
+  ],
+  "issueComments": [],
+  "openPullRequests": [],
+  "expected": {
+    "claimable": 0,
+    "blocked": 1,
+    "invalid": 0
+  }
+}

--- a/apps/agent-daemon/src/fixtures/replay/self-bootstrap-closed-pr-recreate.json
+++ b/apps/agent-daemon/src/fixtures/replay/self-bootstrap-closed-pr-recreate.json
@@ -1,0 +1,31 @@
+{
+  "name": "self-bootstrap-closed-pr-recreate",
+  "openIssues": [
+    {
+      "number": 321,
+      "title": "ready issue after closed PR recreate path",
+      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 closed PR 历史不会继续阻塞 fresh PR recreate path。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/pr-reporter.ts\n\n### MustPreserve\n- replay remains local and deterministic\n\n### OutOfScope\n- touching live GitHub PR state\n\n### RequiredSemantics\n- issue is still claimable when no open linked PR remains\n\n### ReviewHints\n- verify the case stays green without network access\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap closed pr recreate fixture')\n```\n\n## 实现步骤\n1. add replay fixture\n\n## 验收\n- [ ] ready issue remains claimable",
+      "labels": [
+        "agent:ready"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T10:05:00.000Z"
+    }
+  ],
+  "issueComments": [
+    {
+      "issueNumber": 321,
+      "commentId": 1,
+      "body": "Historical note: a previous linked PR was closed and should not appear in the open PR replay state.",
+      "createdAt": "2026-04-11T10:04:00.000Z",
+      "updatedAt": "2026-04-11T10:04:00.000Z"
+    }
+  ],
+  "openPullRequests": [],
+  "expected": {
+    "claimable": 1,
+    "blocked": 0,
+    "invalid": 0
+  }
+}

--- a/apps/agent-daemon/src/fixtures/replay/self-bootstrap-happy-path.json
+++ b/apps/agent-daemon/src/fixtures/replay/self-bootstrap-happy-path.json
@@ -1,0 +1,23 @@
+{
+  "name": "self-bootstrap-happy-path",
+  "openIssues": [
+    {
+      "number": 301,
+      "title": "self-bootstrap happy path child issue",
+      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 happy path child issue 可以直接进入 claimable 队列。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- scenario stays deterministic\n\n### OutOfScope\n- real GitHub calls\n\n### RequiredSemantics\n- issue remains claimable in replay\n\n### ReviewHints\n- check contract validity\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap happy path fixture')\n```\n\n## 实现步骤\n1. add replay fixture\n\n## 验收\n- [ ] replay case stays claimable",
+      "labels": [
+        "agent:ready"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T10:00:00.000Z"
+    }
+  ],
+  "issueComments": [],
+  "openPullRequests": [],
+  "expected": {
+    "claimable": 1,
+    "blocked": 0,
+    "invalid": 0
+  }
+}

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -391,6 +391,29 @@ describe('index helpers', () => {
     expect(formatBootstrapScenarioOutput(report)).toContain('Bootstrap Scenarios')
   })
 
+  test('resolves the default bootstrap fixture directory from the CLI module location', async () => {
+    const report = await executeBootstrapScenarioCommand({}, {
+      evaluateBootstrapScenarioFixtureDirectory: (fixturesDir) => {
+        expect(fixturesDir).toBe(join(import.meta.dir, 'fixtures', 'replay'))
+
+        return {
+          suite: 'self-bootstrap-v0.2',
+          ok: true,
+          cases: [],
+          failedCases: [],
+          summary: {
+            requiredCases: 4,
+            presentCases: 4,
+            passedCases: 4,
+            failedCases: 0,
+          },
+        }
+      },
+    })
+
+    expect(report.ok).toBe(true)
+  })
+
   test('builds stable wake requests from CLI commands', () => {
     expect(buildWakeRequestFromCli(
       { kind: 'issue', issueNumber: 374 },

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -7,9 +7,11 @@ import {
   buildManagedRestartArgs,
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
+  executeBootstrapScenarioCommand,
   executeIssueLintCommand,
   executeWakeCommand,
   executeWakeRequest,
+  formatBootstrapScenarioOutput,
   formatIssueLintOutput,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
@@ -336,6 +338,57 @@ describe('index helpers', () => {
     })
     expect(report.readyGateBlocked).toBe(true)
     expect(report.errors).toEqual(['missing ## RED 测试 / RED Tests'])
+  })
+
+  test('executes bootstrap scenarios locally and supports json output', async () => {
+    const report = await executeBootstrapScenarioCommand({
+      fixturesDir: '/tmp/self-bootstrap-suite',
+    }, {
+      evaluateBootstrapScenarioFixtureDirectory: (fixturesDir) => {
+        expect(fixturesDir).toBe('/tmp/self-bootstrap-suite')
+
+        return {
+          suite: 'self-bootstrap-v0.2',
+          ok: false,
+          cases: [
+            {
+              name: 'self-bootstrap-happy-path',
+              ok: true,
+              present: true,
+              mismatches: [],
+              actual: { claimable: 1, blocked: 0, invalid: 0 },
+              expected: { claimable: 1, blocked: 0, invalid: 0 },
+            },
+            {
+              name: 'self-bootstrap-checks-fail',
+              ok: false,
+              present: true,
+              mismatches: ['blocked: expected 0, received 1'],
+              actual: { claimable: 0, blocked: 1, invalid: 0 },
+              expected: { claimable: 0, blocked: 0, invalid: 0 },
+            },
+          ],
+          failedCases: ['self-bootstrap-checks-fail'],
+          summary: {
+            requiredCases: 4,
+            presentCases: 2,
+            passedCases: 1,
+            failedCases: 1,
+          },
+        }
+      },
+    })
+
+    expect(report.ok).toBe(false)
+    expect(JSON.parse(formatBootstrapScenarioOutput(report, true))).toMatchObject({
+      suite: 'self-bootstrap-v0.2',
+      ok: false,
+      failedCases: ['self-bootstrap-checks-fail'],
+      summary: {
+        requiredCases: 4,
+      },
+    })
+    expect(formatBootstrapScenarioOutput(report)).toContain('Bootstrap Scenarios')
   })
 
   test('builds stable wake requests from CLI commands', () => {

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -11,6 +11,7 @@
 
 import { parseArgs } from 'node:util'
 import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { AgentDaemon, DEFAULT_HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_HOST, type HealthServerConfig } from './daemon'
 import { loadConfig, resolveLocalDaemonIdentity, type CliArgs } from './config'
 import { collectDaemonObservability, formatDoctorReport, formatStatusReport } from './status'
@@ -218,6 +219,7 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
 const DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES: BootstrapScenarioCommandDependencies = {
   evaluateBootstrapScenarioFixtureDirectory,
 }
+const DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR = join(import.meta.dir, 'fixtures', 'replay')
 
 async function main() {
   const { values: args } = parseArgs({
@@ -989,7 +991,7 @@ export async function executeBootstrapScenarioCommand(
   deps: BootstrapScenarioCommandDependencies = DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES,
 ): Promise<BootstrapScenarioSuiteReport> {
   return deps.evaluateBootstrapScenarioFixtureDirectory(
-    input.fixturesDir ?? 'apps/agent-daemon/src/fixtures/replay',
+    input.fixturesDir ?? DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR,
   )
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -54,6 +54,13 @@ import {
   formatIssueLintReportJson,
   type IssueLintReport,
 } from './audit-issue-contracts'
+import {
+  evaluateBootstrapScenarioFixtureDirectory,
+  formatBootstrapScenarioSuiteReport,
+  formatBootstrapScenarioSuiteReportJson,
+  resolveBootstrapScenarioSuiteExitCode,
+  type BootstrapScenarioSuiteReport,
+} from './replay-eval'
 
 type PartialHealthServerConfig = Partial<HealthServerConfig>
 type LocalDaemonIdentityResolver = typeof resolveLocalDaemonIdentity
@@ -95,6 +102,10 @@ export interface ExecuteIssueLintInput {
   target: IssueLintTarget
   repo?: string
   pat?: string
+}
+
+export interface ExecuteBootstrapScenarioInput {
+  fixturesDir?: string
 }
 
 export interface RestartManagedRuntimeInput {
@@ -174,6 +185,10 @@ interface IssueLintCommandDependencies {
   buildIssueLintReportFromRemoteIssue: typeof buildIssueLintReportFromRemoteIssue
 }
 
+interface BootstrapScenarioCommandDependencies {
+  evaluateBootstrapScenarioFixtureDirectory: typeof evaluateBootstrapScenarioFixtureDirectory
+}
+
 const DEFAULT_RESTART_DEPENDENCIES: RestartManagedRuntimeDependencies = {
   platform: process.platform,
   resolveLocalDaemonIdentity,
@@ -198,6 +213,10 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
   loadConfig,
   buildIssueLintReportFromMarkdownFile,
   buildIssueLintReportFromRemoteIssue,
+}
+
+const DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES: BootstrapScenarioCommandDependencies = {
+  evaluateBootstrapScenarioFixtureDirectory,
 }
 
 async function main() {
@@ -239,6 +258,7 @@ async function main() {
       'github-event-path': { type: 'string' },
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
+      'bootstrap-scenarios': { type: 'boolean' },
       json: { type: 'boolean' },
       help: { type: 'boolean' },
     },
@@ -274,6 +294,10 @@ async function main() {
     assertIssueLintCompatible(args)
   }
 
+  if (args['bootstrap-scenarios']) {
+    assertBootstrapScenarioCompatible(args)
+  }
+
   if (args['wake-from-github-event']) {
     if (wakeCommand) {
       throw new Error('--wake-from-github-event cannot be combined with --wake-now, --wake-issue, or --wake-pr')
@@ -281,11 +305,22 @@ async function main() {
     if (issueLintTarget) {
       throw new Error('--wake-from-github-event cannot be combined with --lint-issue or --lint-file')
     }
+    if (args['bootstrap-scenarios']) {
+      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-scenarios')
+    }
     assertWakeCommandCompatible(args)
   }
 
   if (wakeCommand && issueLintTarget) {
     throw new Error('--lint-issue/--lint-file cannot be combined with wake commands')
+  }
+
+  if (args['bootstrap-scenarios'] && wakeCommand) {
+    throw new Error('--bootstrap-scenarios cannot be combined with wake commands')
+  }
+
+  if (args['bootstrap-scenarios'] && issueLintTarget) {
+    throw new Error('--bootstrap-scenarios cannot be combined with --lint-issue or --lint-file')
   }
 
   if (args['repo-cap'] && !args['join-project']) {
@@ -352,6 +387,12 @@ async function main() {
     })
     console.log(formatIssueLintOutput(report, args.json as boolean | undefined))
     process.exit(report.readyGateBlocked ? 1 : 0)
+  }
+
+  if (args['bootstrap-scenarios']) {
+    const report = await executeBootstrapScenarioCommand()
+    console.log(formatBootstrapScenarioOutput(report, args.json as boolean | undefined))
+    process.exit(resolveBootstrapScenarioSuiteExitCode(report))
   }
 
   if (args['join-project']) {
@@ -711,6 +752,7 @@ Usage:
   agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
+  agent-loop --bootstrap-scenarios [--json]
   agent-loop --reconcile [--health-port 9310]
   agent-loop --start [--health-port 9310]
   agent-loop --dashboard [--dashboard-port 9388]
@@ -745,7 +787,8 @@ Options:
       --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
-      --json                  Print machine-readable JSON for lint commands
+      --bootstrap-scenarios   Evaluate the fixed self-bootstrap replay suite
+      --json                  Print machine-readable JSON for lint and bootstrap scenario commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -789,6 +832,7 @@ Examples:
   agent-loop --wake-pr 381 --health-port 9311
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
+  agent-loop --bootstrap-scenarios --json
   agent-loop --dashboard
   agent-loop --dashboard --dashboard-port 9390
   agent-loop --join-project --machine-id macbook-pro-b --health-port 9312 --metrics-port 9092 --repo-cap 2
@@ -938,6 +982,22 @@ export function formatIssueLintOutput(
   asJson = false,
 ): string {
   return asJson ? formatIssueLintReportJson(report) : formatIssueLintReport(report)
+}
+
+export async function executeBootstrapScenarioCommand(
+  input: ExecuteBootstrapScenarioInput = {},
+  deps: BootstrapScenarioCommandDependencies = DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES,
+): Promise<BootstrapScenarioSuiteReport> {
+  return deps.evaluateBootstrapScenarioFixtureDirectory(
+    input.fixturesDir ?? 'apps/agent-daemon/src/fixtures/replay',
+  )
+}
+
+export function formatBootstrapScenarioOutput(
+  report: BootstrapScenarioSuiteReport,
+  asJson = false,
+): string {
+  return asJson ? formatBootstrapScenarioSuiteReportJson(report) : formatBootstrapScenarioSuiteReport(report)
 }
 
 export function buildWakeRequestFromCli(
@@ -1262,6 +1322,76 @@ function assertIssueLintCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Issue lint cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertBootstrapScenarioCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Bootstrap scenarios cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -377,10 +377,6 @@ async function main() {
     throw new Error('--launchd-status cannot be combined with other control flags')
   }
 
-  const runtimeRepoHint = resolveRepoHint(args.repo as string | undefined)
-  const runtimeMachineIdHint = args['machine-id'] as string | undefined
-  const runtimeHealthPortHint = args['health-port'] ? parseInt(args['health-port'] as string) : undefined
-
   if (issueLintTarget) {
     const report = await executeIssueLintCommand({
       target: issueLintTarget,
@@ -396,6 +392,10 @@ async function main() {
     console.log(formatBootstrapScenarioOutput(report, args.json as boolean | undefined))
     process.exit(resolveBootstrapScenarioSuiteExitCode(report))
   }
+
+  const runtimeRepoHint = resolveRepoHint(args.repo as string | undefined)
+  const runtimeMachineIdHint = args['machine-id'] as string | undefined
+  const runtimeHealthPortHint = args['health-port'] ? parseInt(args['health-port'] as string) : undefined
 
   if (args['join-project']) {
     const result = joinProjectMachine({

--- a/apps/agent-daemon/src/replay-eval.test.ts
+++ b/apps/agent-daemon/src/replay-eval.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   evaluateBootstrapScenarioFixtureDirectory,
@@ -161,5 +163,88 @@ describe('evaluateBootstrapScenarioSuite', () => {
       passedCases: 4,
       failedCases: 0,
     })
+  })
+
+  test('isolates the fixed suite from unrelated replay fixtures', () => {
+    const fixturesDir = mkdtempSync(join(tmpdir(), 'bootstrap-suite-fixtures-'))
+
+    try {
+      for (const fixtureName of [
+        'self-bootstrap-happy-path',
+        'self-bootstrap-closed-pr-recreate',
+        'self-bootstrap-checks-pending',
+        'self-bootstrap-checks-fail',
+      ]) {
+        writeFileSync(
+          join(fixturesDir, `${fixtureName}.json`),
+          readFileSync(join(import.meta.dir, 'fixtures', 'replay', `${fixtureName}.json`), 'utf-8'),
+          'utf-8',
+        )
+      }
+
+      writeFileSync(
+        join(fixturesDir, 'zzz-unrelated-broken.json'),
+        JSON.stringify({
+          name: 'zzz-unrelated-broken',
+          openIssues: 'not-an-array',
+          issueComments: [],
+          openPullRequests: [],
+          expected: {
+            claimable: 0,
+            blocked: 0,
+            invalid: 0,
+          },
+        }, null, 2),
+        'utf-8',
+      )
+
+      const report = evaluateBootstrapScenarioFixtureDirectory(fixturesDir)
+
+      expect(report.ok).toBe(true)
+      expect(report.cases.map((fixture) => fixture.name)).toEqual([
+        'self-bootstrap-happy-path',
+        'self-bootstrap-closed-pr-recreate',
+        'self-bootstrap-checks-pending',
+        'self-bootstrap-checks-fail',
+      ])
+      expect(report.failedCases).toEqual([])
+    } finally {
+      rmSync(fixturesDir, { recursive: true, force: true })
+    }
+  })
+
+  test('reports missing required fixtures without loading unrelated files', () => {
+    const fixturesDir = mkdtempSync(join(tmpdir(), 'bootstrap-suite-missing-'))
+
+    try {
+      mkdirSync(fixturesDir, { recursive: true })
+      writeFileSync(
+        join(fixturesDir, 'self-bootstrap-happy-path.json'),
+        readFileSync(join(import.meta.dir, 'fixtures', 'replay', 'self-bootstrap-happy-path.json'), 'utf-8'),
+        'utf-8',
+      )
+      writeFileSync(
+        join(fixturesDir, 'self-bootstrap-closed-pr-recreate.json'),
+        readFileSync(join(import.meta.dir, 'fixtures', 'replay', 'self-bootstrap-closed-pr-recreate.json'), 'utf-8'),
+        'utf-8',
+      )
+      writeFileSync(
+        join(fixturesDir, 'self-bootstrap-checks-pending.json'),
+        readFileSync(join(import.meta.dir, 'fixtures', 'replay', 'self-bootstrap-checks-pending.json'), 'utf-8'),
+        'utf-8',
+      )
+
+      const report = evaluateBootstrapScenarioFixtureDirectory(fixturesDir)
+
+      expect(report.ok).toBe(false)
+      expect(report.failedCases).toEqual(['self-bootstrap-checks-fail'])
+      expect(report.cases[3]).toMatchObject({
+        name: 'self-bootstrap-checks-fail',
+        ok: false,
+        present: false,
+      })
+    } finally {
+      rmSync(fixturesDir, { recursive: true, force: true })
+    }
   })
 })

--- a/apps/agent-daemon/src/replay-eval.test.ts
+++ b/apps/agent-daemon/src/replay-eval.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import { join } from 'node:path'
 import {
+  evaluateBootstrapScenarioFixtureDirectory,
+  evaluateBootstrapScenarioSuite,
   evaluateReplayFixtureDirectory,
   evaluateReplayFixtures,
 } from './replay-eval'
@@ -108,12 +110,56 @@ throw new Error('fixture red test body')
 
     expect(report.ok).toBe(true)
     expect(report.summary).toMatchObject({
-      totalCases: 2,
-      passedCases: 2,
+      totalCases: 6,
+      passedCases: 6,
       failedCases: 0,
-      claimable: 1,
-      blocked: 1,
+      claimable: 3,
+      blocked: 3,
       invalid: 1,
+    })
+  })
+})
+
+describe('evaluateBootstrapScenarioSuite', () => {
+  test('fails when any required self-bootstrap case is missing or red', () => {
+    const report = evaluateBootstrapScenarioSuite({
+      suite: 'self-bootstrap-v0.2',
+      cases: [
+        { name: 'self-bootstrap-happy-path', ok: true },
+        { name: 'self-bootstrap-closed-pr-recreate', ok: true },
+        { name: 'self-bootstrap-checks-pending', ok: false },
+      ],
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.failedCases).toEqual([
+      'self-bootstrap-checks-pending',
+      'self-bootstrap-checks-fail',
+    ])
+    expect(report.summary).toEqual({
+      requiredCases: 4,
+      presentCases: 3,
+      passedCases: 2,
+      failedCases: 2,
+    })
+  })
+
+  test('loads the fixed self-bootstrap scenario suite from disk', () => {
+    const report = evaluateBootstrapScenarioFixtureDirectory(join(import.meta.dir, 'fixtures', 'replay'))
+
+    expect(report.ok).toBe(true)
+    expect(report.cases.map((fixture) => fixture.name)).toEqual([
+      'self-bootstrap-happy-path',
+      'self-bootstrap-closed-pr-recreate',
+      'self-bootstrap-checks-pending',
+      'self-bootstrap-checks-fail',
+    ])
+    expect(report.failedCases).toEqual([])
+    expect(report.summary).toEqual({
+      requiredCases: 4,
+      presentCases: 4,
+      passedCases: 4,
+      failedCases: 0,
     })
   })
 })

--- a/apps/agent-daemon/src/replay-eval.ts
+++ b/apps/agent-daemon/src/replay-eval.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { readdirSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 import {
   applyDependencyClaimability,
@@ -185,18 +185,19 @@ export function evaluateBootstrapScenarioSuite(input: {
 export function evaluateBootstrapScenarioFixtureDirectory(
   fixturesDir: string,
 ): BootstrapScenarioSuiteReport {
-  const replayReport = evaluateReplayFixtureDirectory(fixturesDir)
-
   return evaluateBootstrapScenarioSuite({
     suite: DEFAULT_BOOTSTRAP_SCENARIO_SUITE,
-    cases: replayReport.cases.map((fixture) => ({
-      name: fixture.name,
-      ok: fixture.ok,
-      present: true,
-      mismatches: fixture.mismatches,
-      actual: fixture.actual,
-      expected: fixture.expected,
-    })),
+    cases: REQUIRED_BOOTSTRAP_SCENARIO_CASES.flatMap((name) => {
+      const fixture = loadReplayFixtureByName(fixturesDir, name)
+      if (fixture === null) {
+        return []
+      }
+
+      return [{
+        ...evaluateReplayFixtureCase(fixture),
+        present: true,
+      }]
+    }),
   })
 }
 
@@ -208,9 +209,22 @@ export function loadReplayFixtures(fixturesDir: string): ReplayFixtureCase[] {
 
   return fixtureFiles.map((entry) => {
     const filePath = join(resolvedDir, entry)
-    const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as Partial<ReplayFixtureCase>
-    return normalizeReplayFixture(parsed, basename(entry, '.json'))
+    return loadReplayFixtureFile(filePath)
   })
+}
+
+function loadReplayFixtureByName(fixturesDir: string, fixtureName: string): ReplayFixtureCase | null {
+  const filePath = join(resolve(fixturesDir), `${fixtureName}.json`)
+  if (!existsSync(filePath)) {
+    return null
+  }
+
+  return loadReplayFixtureFile(filePath)
+}
+
+function loadReplayFixtureFile(filePath: string): ReplayFixtureCase {
+  const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as Partial<ReplayFixtureCase>
+  return normalizeReplayFixture(parsed, basename(filePath, '.json'))
 }
 
 export function formatReplayFixtureReport(report: ReplayFixtureReport): string {

--- a/apps/agent-daemon/src/replay-eval.ts
+++ b/apps/agent-daemon/src/replay-eval.ts
@@ -79,6 +79,37 @@ export interface ReplayFixtureReport {
 }
 
 const DEFAULT_FIXTURES_DIR = 'apps/agent-daemon/src/fixtures/replay'
+export const DEFAULT_BOOTSTRAP_SCENARIO_SUITE = 'self-bootstrap-v0.2'
+export const REQUIRED_BOOTSTRAP_SCENARIO_CASES = [
+  'self-bootstrap-happy-path',
+  'self-bootstrap-closed-pr-recreate',
+  'self-bootstrap-checks-pending',
+  'self-bootstrap-checks-fail',
+] as const
+
+export interface BootstrapScenarioSuiteCaseReport {
+  name: string
+  ok: boolean
+  present: boolean
+  mismatches: string[]
+  actual: ReplayFixtureSummary | null
+  expected: ReplayFixtureSummary | null
+}
+
+export interface BootstrapScenarioSuiteReportSummary {
+  requiredCases: number
+  presentCases: number
+  passedCases: number
+  failedCases: number
+}
+
+export interface BootstrapScenarioSuiteReport {
+  suite: string
+  ok: boolean
+  cases: BootstrapScenarioSuiteCaseReport[]
+  failedCases: string[]
+  summary: BootstrapScenarioSuiteReportSummary
+}
 
 export function evaluateReplayFixtures(fixtures: ReplayFixtureCase[]): ReplayFixtureReport {
   const caseResults = fixtures.map(evaluateReplayFixtureCase)
@@ -99,6 +130,74 @@ export function evaluateReplayFixtures(fixtures: ReplayFixtureCase[]): ReplayFix
 
 export function evaluateReplayFixtureDirectory(fixturesDir: string): ReplayFixtureReport {
   return evaluateReplayFixtures(loadReplayFixtures(fixturesDir))
+}
+
+export function evaluateBootstrapScenarioSuite(input: {
+  suite?: string
+  cases: Array<{
+    name: string
+    ok: boolean
+    present?: boolean
+    mismatches?: string[]
+    actual?: ReplayFixtureSummary | null
+    expected?: ReplayFixtureSummary | null
+  }>
+}): BootstrapScenarioSuiteReport {
+  const reportedCases = new Map(input.cases.map((fixture) => [fixture.name, fixture]))
+  const cases = REQUIRED_BOOTSTRAP_SCENARIO_CASES.map<BootstrapScenarioSuiteCaseReport>((name) => {
+    const reportedCase = reportedCases.get(name)
+    if (!reportedCase) {
+      return {
+        name,
+        ok: false,
+        present: false,
+        mismatches: ['required self-bootstrap scenario is missing'],
+        actual: null,
+        expected: null,
+      }
+    }
+
+    return {
+      name,
+      ok: reportedCase.ok,
+      present: reportedCase.present ?? true,
+      mismatches: [...(reportedCase.mismatches ?? [])],
+      actual: reportedCase.actual ?? null,
+      expected: reportedCase.expected ?? null,
+    }
+  })
+  const failedCases = cases.filter((fixture) => !fixture.ok).map((fixture) => fixture.name)
+
+  return {
+    suite: input.suite ?? DEFAULT_BOOTSTRAP_SCENARIO_SUITE,
+    ok: failedCases.length === 0,
+    cases,
+    failedCases,
+    summary: {
+      requiredCases: REQUIRED_BOOTSTRAP_SCENARIO_CASES.length,
+      presentCases: cases.filter((fixture) => fixture.present).length,
+      passedCases: cases.filter((fixture) => fixture.ok).length,
+      failedCases: failedCases.length,
+    },
+  }
+}
+
+export function evaluateBootstrapScenarioFixtureDirectory(
+  fixturesDir: string,
+): BootstrapScenarioSuiteReport {
+  const replayReport = evaluateReplayFixtureDirectory(fixturesDir)
+
+  return evaluateBootstrapScenarioSuite({
+    suite: DEFAULT_BOOTSTRAP_SCENARIO_SUITE,
+    cases: replayReport.cases.map((fixture) => ({
+      name: fixture.name,
+      ok: fixture.ok,
+      present: true,
+      mismatches: fixture.mismatches,
+      actual: fixture.actual,
+      expected: fixture.expected,
+    })),
+  })
 }
 
 export function loadReplayFixtures(fixturesDir: string): ReplayFixtureCase[] {
@@ -132,6 +231,38 @@ export function formatReplayFixtureReport(report: ReplayFixtureReport): string {
   )
 
   return lines.join('\n')
+}
+
+export function formatBootstrapScenarioSuiteReport(
+  report: BootstrapScenarioSuiteReport,
+): string {
+  return [
+    'Bootstrap Scenarios',
+    `suite=${report.suite}`,
+    `ok=${report.ok}`,
+    'cases:',
+    ...report.cases.map((fixture) => {
+      const status = fixture.ok ? 'ok' : fixture.present ? 'failed' : 'missing'
+      const mismatchSuffix = fixture.mismatches.length > 0
+        ? ` mismatches=${fixture.mismatches.join(' | ')}`
+        : ''
+      return `- ${fixture.name}: ${status}${mismatchSuffix}`
+    }),
+    `failedCases=${report.failedCases.join(',') || '-'}`,
+    `summary: required=${report.summary.requiredCases} present=${report.summary.presentCases} passed=${report.summary.passedCases} failed=${report.summary.failedCases}`,
+  ].join('\n')
+}
+
+export function formatBootstrapScenarioSuiteReportJson(
+  report: BootstrapScenarioSuiteReport,
+): string {
+  return JSON.stringify(report, null, 2)
+}
+
+export function resolveBootstrapScenarioSuiteExitCode(
+  report: Pick<BootstrapScenarioSuiteReport, 'ok'>,
+): number {
+  return report.ok ? 0 : 1
 }
 
 function evaluateReplayFixtureCase(fixture: ReplayFixtureCase): ReplayFixtureCaseResult {


### PR DESCRIPTION
## Summary
- add a fixed `self-bootstrap-v0.2` replay suite on top of the existing replay evaluator with deterministic required cases
- expose the suite through `agent-loop --bootstrap-scenarios [--json]` with stable `suite`, `ok`, `cases`, `failedCases`, and `summary` output
- add four local replay fixtures covering happy path, closed PR recreate, checks pending, and checks fail scenarios

## Testing
- bun test apps/agent-daemon/src/replay-eval.test.ts apps/agent-daemon/src/index.test.ts
- bun run typecheck
- bun apps/agent-daemon/src/index.ts --bootstrap-scenarios --json
- git diff --stat origin/master...HEAD

Closes #69