### PR TITLE
Fix #70 add bootstrap scorecard taxonomy report

### DIFF
--- a/apps/agent-daemon/src/audit-issue-contracts.test.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  buildAuditIssueSummary,
   buildGhIssueViewArgs,
   buildIssueLintReport,
   fetchRemoteIssueDocument,
@@ -143,6 +144,41 @@ describe('audit-issue-contracts', () => {
     expect(section).toContain('#52 [CI-A2] Sprint A 发布前最小检查清单')
     expect(section).toContain('- missing ### Dependencies JSON block')
     expect(section).toContain('- warning: AllowedFiles should use exact paths or tightly scoped directories: frontend files')
+  })
+
+  test('builds stable audit summary counts for scorecard consumers', () => {
+    const summary = buildAuditIssueSummary([
+      {
+        number: 50,
+        title: '[AL-11] repo issue audit report',
+        state: 'ready',
+        isClaimable: false,
+        hasExecutableContract: false,
+        claimBlockedBy: [],
+        contractValidationErrors: ['missing ## RED 测试 / RED Tests'],
+        qualityScore: 72,
+        contractWarnings: ['AllowedFiles should use exact paths or tightly scoped directories: frontend files'],
+      },
+      {
+        number: 51,
+        title: '[AL-12] project profile injection',
+        state: 'working',
+        isClaimable: false,
+        hasExecutableContract: true,
+        claimBlockedBy: [],
+        contractValidationErrors: [],
+        qualityScore: 95,
+        contractWarnings: [],
+      },
+    ])
+
+    expect(summary).toEqual({
+      managedIssueCount: 2,
+      readyIssueCount: 1,
+      invalidReadyIssueCount: 1,
+      lowScoreIssueCount: 1,
+      warningIssueCount: 1,
+    })
   })
 
   test('fetches remote issue bodies through gh issue view', async () => {

--- a/apps/agent-daemon/src/audit-issue-contracts.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.ts
@@ -26,12 +26,24 @@ export interface AuditIssueContractsJsonReport {
     managedIssues: number
     readyIssues: number
     invalidReadyIssues: number
+    lowScoreIssueCount: number
+    warningIssueCount: number
     issuesWithWarnings: number
   }
   issues: Array<AuditedIssue & {
     readyGateBlocked: boolean
   }>
 }
+
+export interface AuditIssueSummary {
+  managedIssueCount: number
+  readyIssueCount: number
+  invalidReadyIssueCount: number
+  lowScoreIssueCount: number
+  warningIssueCount: number
+}
+
+export const DEFAULT_AUDIT_LOW_SCORE_THRESHOLD = 80
 
 export type IssueLintSource =
   | {
@@ -156,17 +168,38 @@ export function formatInvalidReadySection(issues: AuditedIssue[]): string {
 export function buildAuditIssueContractsJsonReport(
   issues: AuditedIssue[],
 ): AuditIssueContractsJsonReport {
+  const summary = buildAuditIssueSummary(issues)
+
   return {
     totals: {
-      managedIssues: issues.length,
-      readyIssues: issues.filter((issue) => issue.state === 'ready').length,
-      invalidReadyIssues: issues.filter((issue) => issue.state === 'ready' && !issue.hasExecutableContract).length,
-      issuesWithWarnings: issues.filter((issue) => issue.contractWarnings.length > 0).length,
+      managedIssues: summary.managedIssueCount,
+      readyIssues: summary.readyIssueCount,
+      invalidReadyIssues: summary.invalidReadyIssueCount,
+      lowScoreIssueCount: summary.lowScoreIssueCount,
+      warningIssueCount: summary.warningIssueCount,
+      issuesWithWarnings: summary.warningIssueCount,
     },
     issues: issues.map((issue) => ({
       ...issue,
       readyGateBlocked: issue.contractValidationErrors.length > 0,
     })),
+  }
+}
+
+export function buildAuditIssueSummary(
+  issues: AuditedIssue[],
+  options: {
+    lowScoreThreshold?: number
+  } = {},
+): AuditIssueSummary {
+  const lowScoreThreshold = options.lowScoreThreshold ?? DEFAULT_AUDIT_LOW_SCORE_THRESHOLD
+
+  return {
+    managedIssueCount: issues.length,
+    readyIssueCount: issues.filter((issue) => issue.state === 'ready').length,
+    invalidReadyIssueCount: issues.filter((issue) => issue.state === 'ready' && !issue.hasExecutableContract).length,
+    lowScoreIssueCount: issues.filter((issue) => issue.qualityScore < lowScoreThreshold).length,
+    warningIssueCount: issues.filter((issue) => issue.contractWarnings.length > 0).length,
   }
 }
 

--- a/apps/agent-daemon/src/bootstrap-scorecard.test.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.test.ts
@@ -1,0 +1,514 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildBootstrapScorecard,
+  buildBootstrapScorecardForRepo,
+  classifyBootstrapFailureKind,
+  formatBootstrapScorecard,
+  resolveBootstrapScorecardExitCode,
+} from './bootstrap-scorecard'
+
+function buildStructuredReviewBlockerComment(
+  prNumber: number,
+  reason: string,
+  options: {
+    attempt?: number
+    headRefOid?: string
+  } = {},
+): string {
+  const metadata = {
+    pr: prNumber,
+    attempt: options.attempt ?? 9,
+    approved: false,
+    canMerge: false,
+    ...(options.headRefOid ? { headRefOid: options.headRefOid } : {}),
+  }
+
+  return `<!-- agent-loop:pr-review ${JSON.stringify(metadata)} -->
+<!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":${JSON.stringify(reason)},"findings":[{"severity":"high","file":"apps/agent-daemon/src/bootstrap-scorecard.ts","summary":"scorecard signal mismatch","mustFix":["reuse authoritative blocker signals"],"mustNotDo":["do not infer blockers from labels alone"],"validation":["bun test apps/agent-daemon/src/bootstrap-scorecard.test.ts"],"scopeRationale":"issue #70 requires stable taxonomy output"}]} -->
+## Automated review still failing — human intervention required`
+}
+
+function buildExecutionFailureReviewComment(
+  prNumber: number,
+  headRefOid: string,
+): string {
+  return `<!-- agent-loop:pr-review {"pr":${prNumber},"attempt":2,"approved":false,"canMerge":false,"headRefOid":"${headRefOid}"} -->
+## Automated review still failing — human intervention required
+
+- Attempt: 2
+- Merge ready: no
+- Reason: Review failed: ReviewAgentExecutionError: Agent exited with code 1`
+}
+
+function buildBlockedResumeEscalationComment(
+  issueNumber: number,
+  reason: string,
+  options: {
+    prNumber?: number | null
+    escalatedAt?: string
+  } = {},
+): string {
+  return `<!-- agent-loop:issue-resume-blocked ${JSON.stringify({
+    issueNumber,
+    prNumber: options.prNumber ?? null,
+    blockedSince: '2026-04-11T09:00:00.000Z',
+    escalatedAt: options.escalatedAt ?? '2026-04-11T09:05:00.000Z',
+    thresholdSeconds: 300,
+    reason,
+    machineId: 'codex-dev',
+    daemonInstanceId: 'daemon-1',
+  })} -->
+## agent-loop blocked resume escalation`
+}
+
+function buildReleaseEvidenceIssueBody(): string {
+  return [
+    '## 用户故事',
+    '',
+    '作为维护者，我希望 self-bootstrap suite 变成稳定 release evidence。',
+    '',
+    '## Context',
+    '',
+    '### Dependencies',
+    '```json',
+    '{"dependsOn":[]}',
+    '```',
+    '',
+    '### RequiredSemantics',
+    '- `agent-loop --bootstrap-scenarios` 执行固定 self-bootstrap suite',
+    '',
+    '### Validation',
+    '- `bun test apps/agent-daemon/src/replay-eval.test.ts apps/agent-daemon/src/index.test.ts`',
+    '',
+    '## RED 测试',
+    '```ts',
+    'throw new Error("red")',
+    '```',
+    '',
+    '## 实现步骤',
+    '1. add suite',
+    '',
+    '## 验收',
+    '- [ ] suite green',
+  ].join('\n')
+}
+
+describe('buildBootstrapScorecard', () => {
+  test('groups blockers into stable failure taxonomy buckets', () => {
+    expect(classifyBootstrapFailureKind('closed PR blocked fresh PR creation')).toBe('pr_lifecycle_failure')
+    expect(classifyBootstrapFailureKind('missing executable test/build/check command in ### Validation')).toBe('contract_failure')
+
+    const scorecard = buildBootstrapScorecard({
+      audit: { managedIssueCount: 8, readyIssueCount: 3, invalidReadyIssueCount: 2, lowScoreIssueCount: 3, warningIssueCount: 1 },
+      prBlockers: [{ issueNumber: 60, reason: 'closed PR blocked fresh PR creation' }],
+      reviewBlockers: [{ issueNumber: 61, reason: 'agent:human-needed review blocker remains open' }],
+      releaseEvidenceMissing: ['self_bootstrap_suite_green'],
+    })
+
+    expect(scorecard.ready).toBe(false)
+    expect(scorecard.categoryCounts.pr_lifecycle_failure).toBe(1)
+    expect(scorecard.categoryCounts.release_process_failure).toBe(1)
+    expect(scorecard.categoryCounts.contract_failure).toBe(2)
+    expect(resolveBootstrapScorecardExitCode(scorecard)).toBe(1)
+    expect(formatBootstrapScorecard(scorecard)).toContain('Bootstrap Scorecard')
+  })
+})
+
+describe('buildBootstrapScorecardForRepo', () => {
+  test('reuses repo-native issue and pull request signals without hardcoded bootstrap issue numbers', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 50,
+          title: '[AL-11] issue audit',
+          body: '## 用户故事\n\n作为维护者，我希望 scorecard 统计 invalid ready issue。\n\n## Context\n\n### Dependencies\n```json\n{"dependsOn":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/bootstrap-scorecard.ts\n\n### Validation\n- `bun test apps/agent-daemon/src/bootstrap-scorecard.test.ts`\n\n## RED 测试\n```ts\nthrow new Error("red")\n```\n\n## 实现步骤\n1. add scorecard\n\n## 验收\n- [ ] valid',
+          state: 'ready',
+          labels: ['agent:ready'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: false,
+          contractValidationErrors: ['missing ### RequiredSemantics section'],
+        },
+        {
+          number: 61,
+          title: 'issue recovery remains blocked',
+          body: '',
+          state: 'failed',
+          labels: ['agent:failed'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+        {
+          number: 69,
+          title: 'self_bootstrap_suite_green release evidence still missing',
+          body: buildReleaseEvidenceIssueBody(),
+          state: 'working',
+          labels: ['agent:working'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [
+        {
+          number: 91,
+          title: 'Fix lifecycle blocker',
+          url: 'https://example.test/pr/91',
+          headRefName: 'agent/61/codex-dev',
+          headRefOid: 'abc123',
+          isDraft: false,
+          labels: ['agent:human-needed'],
+        },
+      ],
+      listIssueComments: async (number) => {
+        if (number === 61) return []
+        if (number === 91) {
+          return [{
+            commentId: 9101,
+            body: buildStructuredReviewBlockerComment(91, 'Approval bar flow regressed', {
+              headRefOid: 'abc123',
+            }),
+            createdAt: '2026-04-11T09:00:00.000Z',
+            updatedAt: '2026-04-11T09:05:00.000Z',
+          }]
+        }
+        return []
+      },
+      getAgentIssueByNumber: async (issueNumber) => ({
+        number: issueNumber,
+        title: `Issue ${issueNumber}`,
+        body: '',
+        state: 'working',
+        labels: ['agent:working'],
+        assignee: null,
+        isClaimable: false,
+        updatedAt: '2026-04-11T10:00:00.000Z',
+        dependencyIssueNumbers: [],
+        hasDependencyMetadata: false,
+        dependencyParseError: false,
+        claimBlockedBy: [],
+        hasExecutableContract: true,
+        contractValidationErrors: [],
+      }),
+    })
+
+    expect(scorecard.categoryCounts).toMatchObject({
+      contract_failure: 1,
+      pr_lifecycle_failure: 1,
+      review_failure: 1,
+      release_process_failure: 1,
+      runtime_failure: 0,
+      github_transport_failure: 0,
+    })
+    expect(scorecard.topBlockers).toEqual([
+      expect.objectContaining({
+        category: 'contract_failure',
+        reason: '1 invalid ready issue(s) require executable contracts',
+      }),
+      expect.objectContaining({
+        category: 'pr_lifecycle_failure',
+        issueNumber: 61,
+        prNumber: 91,
+      }),
+      expect.objectContaining({
+        category: 'review_failure',
+        issueNumber: 61,
+        prNumber: 91,
+        reason: 'Approval bar flow regressed',
+      }),
+      expect.objectContaining({
+        category: 'release_process_failure',
+        reason: 'missing required evidence: self_bootstrap_suite_green',
+      }),
+    ])
+  })
+
+  test('does not derive release blockers from issue titles alone', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 70,
+          title: 'add bootstrap scorecard taxonomy report',
+          body: '',
+          state: 'working',
+          labels: ['agent:working'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [],
+      listIssueComments: async () => [],
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.categoryCounts.release_process_failure).toBe(0)
+    expect(scorecard.categoryCounts.runtime_failure).toBe(0)
+  })
+
+  test('surfaces closed-pr lifecycle blockers from blocked-resume escalation comments without an open linked PR', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 60,
+          title: 'issue recovery remains blocked',
+          body: '',
+          state: 'failed',
+          labels: ['agent:failed'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [],
+      listIssueComments: async (number) => {
+        if (number !== 60) {
+          return []
+        }
+
+        return [{
+          commentId: 6001,
+          body: buildBlockedResumeEscalationComment(60, 'closed PR blocked fresh PR creation', {
+            prNumber: 88,
+          }),
+          createdAt: '2026-04-11T09:00:00.000Z',
+          updatedAt: '2026-04-11T09:05:00.000Z',
+        }]
+      },
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.categoryCounts.pr_lifecycle_failure).toBe(1)
+    expect(scorecard.topBlockers).toContainEqual(expect.objectContaining({
+      category: 'pr_lifecycle_failure',
+      issueNumber: 60,
+      prNumber: 88,
+      reason: 'closed PR blocked fresh PR creation',
+    }))
+  })
+
+  test('does not synthesize lifecycle or release blockers for another repo when unrelated issue numbers are missing', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'someone-else/example',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [],
+      listOpenAgentPullRequests: async () => [],
+      listIssueComments: async () => [],
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.ready).toBe(true)
+    expect(scorecard.categoryCounts).toEqual({
+      contract_failure: 0,
+      runtime_failure: 0,
+      pr_lifecycle_failure: 0,
+      review_failure: 0,
+      github_transport_failure: 0,
+      release_process_failure: 0,
+    })
+    expect(scorecard.topBlockers).toEqual([])
+  })
+
+  test('suppresses review blockers for resumable human-needed pull requests', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 61,
+          title: 'review follow-up',
+          body: '',
+          state: 'working',
+          labels: ['agent:working'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [
+        {
+          number: 91,
+          title: 'Fix lifecycle blocker',
+          url: 'https://example.test/pr/91',
+          headRefName: 'agent/61/codex-dev',
+          headRefOid: 'abc123',
+          isDraft: false,
+          labels: ['agent:human-needed'],
+        },
+      ],
+      listIssueComments: async (number) => {
+        if (number === 91) {
+          return [{
+            commentId: 9101,
+            body: buildExecutionFailureReviewComment(91, 'abc123'),
+            createdAt: '2026-04-11T09:00:00.000Z',
+            updatedAt: '2026-04-11T09:05:00.000Z',
+          }]
+        }
+        return []
+      },
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.categoryCounts.review_failure).toBe(0)
+    expect(scorecard.categoryCounts.github_transport_failure).toBe(0)
+  })
+
+  test('preserves successful signals when a linked GitHub lookup fails', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 50,
+          title: '[AL-11] issue audit',
+          body: '## 用户故事\n\n作为维护者，我希望 scorecard 统计 invalid ready issue。\n\n## Context\n\n### Dependencies\n```json\n{"dependsOn":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/bootstrap-scorecard.ts\n\n### Validation\n- `bun test apps/agent-daemon/src/bootstrap-scorecard.test.ts`\n\n## RED 测试\n```ts\nthrow new Error("red")\n```\n\n## 实现步骤\n1. add scorecard\n\n## 验收\n- [ ] valid',
+          state: 'ready',
+          labels: ['agent:ready'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: false,
+          contractValidationErrors: ['missing ### RequiredSemantics section'],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [
+        {
+          number: 91,
+          title: 'Fix lifecycle blocker',
+          url: 'https://example.test/pr/91',
+          headRefName: 'agent/61/codex-dev',
+          headRefOid: 'abc123',
+          isDraft: false,
+          labels: ['agent:human-needed'],
+        },
+      ],
+      listIssueComments: async (number) => {
+        if (number === 91) {
+          return [{
+            commentId: 9101,
+            body: buildStructuredReviewBlockerComment(91, 'Approval bar flow regressed', {
+              headRefOid: 'abc123',
+            }),
+            createdAt: '2026-04-11T09:00:00.000Z',
+            updatedAt: '2026-04-11T09:05:00.000Z',
+          }]
+        }
+        return []
+      },
+      getAgentIssueByNumber: async () => {
+        throw new Error('The socket connection was closed unexpectedly.')
+      },
+    })
+
+    expect(scorecard.ready).toBe(false)
+    expect(scorecard.categoryCounts).toMatchObject({
+      contract_failure: 1,
+      review_failure: 1,
+      github_transport_failure: 1,
+      runtime_failure: 0,
+      pr_lifecycle_failure: 0,
+      release_process_failure: 0,
+    })
+    expect(scorecard.topBlockers).toEqual([
+      expect.objectContaining({
+        category: 'contract_failure',
+      }),
+      expect.objectContaining({
+        category: 'review_failure',
+        prNumber: 91,
+      }),
+      expect.objectContaining({
+        category: 'github_transport_failure',
+      }),
+    ])
+  })
+
+  test('downgrades repo fetch failures into transport blockers instead of throwing', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => {
+        throw new Error('The socket connection was closed unexpectedly.')
+      },
+      listOpenAgentPullRequests: async () => [],
+      listIssueComments: async () => [],
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.ready).toBe(false)
+    expect(scorecard.categoryCounts.github_transport_failure).toBe(1)
+    expect(scorecard.topBlockers).toEqual([
+      expect.objectContaining({
+        category: 'github_transport_failure',
+      }),
+    ])
+  })
+})

--- a/apps/agent-daemon/src/bootstrap-scorecard.test.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.test.ts
@@ -61,38 +61,6 @@ function buildBlockedResumeEscalationComment(
 ## agent-loop blocked resume escalation`
 }
 
-function buildReleaseEvidenceIssueBody(): string {
-  return [
-    '## 用户故事',
-    '',
-    '作为维护者，我希望 self-bootstrap suite 变成稳定 release evidence。',
-    '',
-    '## Context',
-    '',
-    '### Dependencies',
-    '```json',
-    '{"dependsOn":[]}',
-    '```',
-    '',
-    '### RequiredSemantics',
-    '- `agent-loop --bootstrap-scenarios` 执行固定 self-bootstrap suite',
-    '',
-    '### Validation',
-    '- `bun test apps/agent-daemon/src/replay-eval.test.ts apps/agent-daemon/src/index.test.ts`',
-    '',
-    '## RED 测试',
-    '```ts',
-    'throw new Error("red")',
-    '```',
-    '',
-    '## 实现步骤',
-    '1. add suite',
-    '',
-    '## 验收',
-    '- [ ] suite green',
-  ].join('\n')
-}
-
 describe('buildBootstrapScorecard', () => {
   test('groups blockers into stable failure taxonomy buckets', () => {
     expect(classifyBootstrapFailureKind('closed PR blocked fresh PR creation')).toBe('pr_lifecycle_failure')
@@ -115,7 +83,7 @@ describe('buildBootstrapScorecard', () => {
 })
 
 describe('buildBootstrapScorecardForRepo', () => {
-  test('reuses repo-native issue and pull request signals without hardcoded bootstrap issue numbers', async () => {
+  test('keeps terminal human-needed review blockers out of pr lifecycle failures', async () => {
     const scorecard = await buildBootstrapScorecardForRepo({
       config: {
         repo: 'JamesWuHK/agent-loop',
@@ -145,22 +113,6 @@ describe('buildBootstrapScorecardForRepo', () => {
           body: '',
           state: 'failed',
           labels: ['agent:failed'],
-          assignee: null,
-          isClaimable: false,
-          updatedAt: '2026-04-11T10:00:00.000Z',
-          dependencyIssueNumbers: [],
-          hasDependencyMetadata: false,
-          dependencyParseError: false,
-          claimBlockedBy: [],
-          hasExecutableContract: true,
-          contractValidationErrors: [],
-        },
-        {
-          number: 69,
-          title: 'self_bootstrap_suite_green release evidence still missing',
-          body: buildReleaseEvidenceIssueBody(),
-          state: 'working',
-          labels: ['agent:working'],
           assignee: null,
           isClaimable: false,
           updatedAt: '2026-04-11T10:00:00.000Z',
@@ -201,8 +153,8 @@ describe('buildBootstrapScorecardForRepo', () => {
         number: issueNumber,
         title: `Issue ${issueNumber}`,
         body: '',
-        state: 'working',
-        labels: ['agent:working'],
+        state: issueNumber === 69 ? 'done' : 'working',
+        labels: issueNumber === 69 ? ['agent:done'] : ['agent:working'],
         assignee: null,
         isClaimable: false,
         updatedAt: '2026-04-11T10:00:00.000Z',
@@ -217,7 +169,7 @@ describe('buildBootstrapScorecardForRepo', () => {
 
     expect(scorecard.categoryCounts).toMatchObject({
       contract_failure: 1,
-      pr_lifecycle_failure: 1,
+      pr_lifecycle_failure: 0,
       review_failure: 1,
       release_process_failure: 1,
       runtime_failure: 0,
@@ -229,11 +181,6 @@ describe('buildBootstrapScorecardForRepo', () => {
         reason: '1 invalid ready issue(s) require executable contracts',
       }),
       expect.objectContaining({
-        category: 'pr_lifecycle_failure',
-        issueNumber: 61,
-        prNumber: 91,
-      }),
-      expect.objectContaining({
         category: 'review_failure',
         issueNumber: 61,
         prNumber: 91,
@@ -241,12 +188,12 @@ describe('buildBootstrapScorecardForRepo', () => {
       }),
       expect.objectContaining({
         category: 'release_process_failure',
-        reason: 'missing required evidence: self_bootstrap_suite_green',
+        reason: 'missing required evidence: bootstrap_scorecard_green',
       }),
     ])
   })
 
-  test('does not derive release blockers from issue titles alone', async () => {
+  test('sources release blockers from bootstrap gate required evidence instead of open-issue body scans', async () => {
     const scorecard = await buildBootstrapScorecardForRepo({
       config: {
         repo: 'JamesWuHK/agent-loop',
@@ -255,8 +202,8 @@ describe('buildBootstrapScorecardForRepo', () => {
     }, {
       listOpenAgentIssues: async () => [
         {
-          number: 70,
-          title: 'add bootstrap scorecard taxonomy report',
+          number: 69,
+          title: 'self_bootstrap_suite_green release evidence tracking',
           body: '',
           state: 'working',
           labels: ['agent:working'],
@@ -273,10 +220,29 @@ describe('buildBootstrapScorecardForRepo', () => {
       ],
       listOpenAgentPullRequests: async () => [],
       listIssueComments: async () => [],
-      getAgentIssueByNumber: async () => null,
+      getAgentIssueByNumber: async (issueNumber) => ({
+        number: issueNumber,
+        title: `Issue ${issueNumber}`,
+        body: '',
+        state: issueNumber === 69 ? 'done' : 'working',
+        labels: issueNumber === 69 ? ['agent:done'] : ['agent:working'],
+        assignee: null,
+        isClaimable: false,
+        updatedAt: '2026-04-11T10:00:00.000Z',
+        dependencyIssueNumbers: [],
+        hasDependencyMetadata: false,
+        dependencyParseError: false,
+        claimBlockedBy: [],
+        hasExecutableContract: true,
+        contractValidationErrors: [],
+      }),
     })
 
-    expect(scorecard.categoryCounts.release_process_failure).toBe(0)
+    expect(scorecard.categoryCounts.release_process_failure).toBe(1)
+    expect(scorecard.topBlockers).toContainEqual(expect.objectContaining({
+      category: 'release_process_failure',
+      reason: 'missing required evidence: bootstrap_scorecard_green',
+    }))
     expect(scorecard.categoryCounts.runtime_failure).toBe(0)
   })
 
@@ -332,29 +298,42 @@ describe('buildBootstrapScorecardForRepo', () => {
     }))
   })
 
-  test('does not synthesize lifecycle or release blockers for another repo when unrelated issue numbers are missing', async () => {
+  test('mirrors bootstrap gate release evidence codes even when open issues are empty', async () => {
     const scorecard = await buildBootstrapScorecardForRepo({
       config: {
-        repo: 'someone-else/example',
+        repo: 'JamesWuHK/agent-loop',
         pat: 'test-token',
       } as never,
     }, {
       listOpenAgentIssues: async () => [],
       listOpenAgentPullRequests: async () => [],
       listIssueComments: async () => [],
-      getAgentIssueByNumber: async () => null,
+      getAgentIssueByNumber: async (issueNumber) => ({
+        number: issueNumber,
+        title: `Issue ${issueNumber}`,
+        body: '',
+        state: issueNumber === 69 ? 'done' : 'working',
+        labels: issueNumber === 69 ? ['agent:done'] : ['agent:working'],
+        assignee: null,
+        isClaimable: false,
+        updatedAt: '2026-04-11T10:00:00.000Z',
+        dependencyIssueNumbers: [],
+        hasDependencyMetadata: false,
+        dependencyParseError: false,
+        claimBlockedBy: [],
+        hasExecutableContract: true,
+        contractValidationErrors: [],
+      }),
     })
 
-    expect(scorecard.ready).toBe(true)
-    expect(scorecard.categoryCounts).toEqual({
-      contract_failure: 0,
-      runtime_failure: 0,
-      pr_lifecycle_failure: 0,
-      review_failure: 0,
-      github_transport_failure: 0,
-      release_process_failure: 0,
-    })
-    expect(scorecard.topBlockers).toEqual([])
+    expect(scorecard.ready).toBe(false)
+    expect(scorecard.categoryCounts.release_process_failure).toBe(1)
+    expect(scorecard.topBlockers).toEqual([
+      expect.objectContaining({
+        category: 'release_process_failure',
+        reason: 'missing required evidence: bootstrap_scorecard_green',
+      }),
+    ])
   })
 
   test('suppresses review blockers for resumable human-needed pull requests', async () => {
@@ -469,7 +448,7 @@ describe('buildBootstrapScorecardForRepo', () => {
     expect(scorecard.categoryCounts).toMatchObject({
       contract_failure: 1,
       review_failure: 1,
-      github_transport_failure: 1,
+      github_transport_failure: 2,
       runtime_failure: 0,
       pr_lifecycle_failure: 0,
       release_process_failure: 0,
@@ -508,6 +487,10 @@ describe('buildBootstrapScorecardForRepo', () => {
     expect(scorecard.topBlockers).toEqual([
       expect.objectContaining({
         category: 'github_transport_failure',
+      }),
+      expect.objectContaining({
+        category: 'release_process_failure',
+        reason: 'missing required evidence: self_bootstrap_suite_green',
       }),
     ])
   })

--- a/apps/agent-daemon/src/bootstrap-scorecard.test.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.test.ts
@@ -85,7 +85,7 @@ describe('buildBootstrapScorecard', () => {
 })
 
 describe('buildBootstrapScorecardForRepo', () => {
-  test('reuses repo-native issue and pull request signals without hardcoded bootstrap issue numbers', async () => {
+  test('assigns a failed issue and linked human-needed pr to one taxonomy bucket when review feedback overlaps', async () => {
     const scorecard = await buildBootstrapScorecardForRepo({
       config: {
         repo: 'JamesWuHK/agent-loop',
@@ -188,7 +188,7 @@ describe('buildBootstrapScorecardForRepo', () => {
     expect(scorecard.categoryCounts).toMatchObject({
       contract_failure: 1,
       pr_lifecycle_failure: 1,
-      review_failure: 1,
+      review_failure: 0,
       release_process_failure: 2,
       runtime_failure: 0,
       github_transport_failure: 0,
@@ -204,14 +204,15 @@ describe('buildBootstrapScorecardForRepo', () => {
         prNumber: 91,
       }),
       expect.objectContaining({
-        category: 'review_failure',
-        issueNumber: 61,
-        prNumber: 91,
-        reason: 'Approval bar flow regressed',
-      }),
-      expect.objectContaining({
         category: 'release_process_failure',
         reason: 'missing required evidence: self_bootstrap_suite_green',
+      }),
+    ])
+    expect(scorecard.topBlockers.filter((blocker) => blocker.issueNumber === 61 && blocker.prNumber === 91)).toEqual([
+      expect.objectContaining({
+        category: 'pr_lifecycle_failure',
+        issueNumber: 61,
+        prNumber: 91,
       }),
     ])
   })

--- a/apps/agent-daemon/src/bootstrap-scorecard.test.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.test.ts
@@ -246,6 +246,56 @@ describe('buildBootstrapScorecardForRepo', () => {
     expect(scorecard.categoryCounts.runtime_failure).toBe(0)
   })
 
+  test('surfaces runtime blockers from unresolved blocked-resume escalation comments', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 63,
+          title: 'issue recovery is blocked by daemon runtime failure',
+          body: '',
+          state: 'failed',
+          labels: ['agent:failed'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [],
+      listIssueComments: async (number) => {
+        if (number !== 63) {
+          return []
+        }
+
+        return [{
+          commentId: 6301,
+          body: buildBlockedResumeEscalationComment(63, 'daemon runtime failure: startup recovery deferred by local runtime health failure'),
+          createdAt: '2026-04-11T09:00:00.000Z',
+          updatedAt: '2026-04-11T09:05:00.000Z',
+        }]
+      },
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.categoryCounts.runtime_failure).toBe(1)
+    expect(scorecard.topBlockers).toContainEqual(expect.objectContaining({
+      category: 'runtime_failure',
+      issueNumber: 63,
+      prNumber: null,
+      reason: 'daemon runtime failure: startup recovery deferred by local runtime health failure',
+    }))
+  })
+
   test('surfaces closed-pr lifecycle blockers from blocked-resume escalation comments without an open linked PR', async () => {
     const scorecard = await buildBootstrapScorecardForRepo({
       config: {

--- a/apps/agent-daemon/src/bootstrap-scorecard.test.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.test.ts
@@ -298,6 +298,68 @@ describe('buildBootstrapScorecardForRepo', () => {
     }))
   })
 
+  test('counts failed issues blocked by a non-resumable linked PR as pr lifecycle failures', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 62,
+          title: 'issue recovery remains blocked by linked pr state',
+          body: '',
+          state: 'failed',
+          labels: ['agent:failed'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [
+        {
+          number: 123,
+          title: 'linked pr is stuck',
+          url: 'https://example.test/pr/123',
+          headRefName: 'agent/62/codex-dev',
+          headRefOid: 'def456',
+          isDraft: false,
+          labels: ['stalled'],
+        },
+      ],
+      listIssueComments: async (number) => {
+        if (number !== 62) {
+          return []
+        }
+
+        return [{
+          commentId: 6201,
+          body: buildBlockedResumeEscalationComment(62, 'linked PR #123 is not in a resumable automated state (stalled)', {
+            prNumber: 123,
+          }),
+          createdAt: '2026-04-11T09:00:00.000Z',
+          updatedAt: '2026-04-11T09:05:00.000Z',
+        }]
+      },
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.categoryCounts.pr_lifecycle_failure).toBe(1)
+    expect(scorecard.topBlockers).toContainEqual(expect.objectContaining({
+      category: 'pr_lifecycle_failure',
+      issueNumber: 62,
+      prNumber: 123,
+      reason: 'linked PR #123 is not in a resumable automated state (stalled)',
+    }))
+  })
+
   test('mirrors bootstrap gate release evidence codes even when open issues are empty', async () => {
     const scorecard = await buildBootstrapScorecardForRepo({
       config: {

--- a/apps/agent-daemon/src/bootstrap-scorecard.test.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.test.ts
@@ -560,10 +560,10 @@ describe('buildBootstrapScorecardForRepo', () => {
     expect(scorecard.categoryCounts).toMatchObject({
       contract_failure: 1,
       review_failure: 1,
-      github_transport_failure: 2,
+      github_transport_failure: 4,
       runtime_failure: 0,
       pr_lifecycle_failure: 0,
-      release_process_failure: 0,
+      release_process_failure: 2,
     })
     expect(scorecard.topBlockers).toEqual([
       expect.objectContaining({
@@ -575,6 +575,10 @@ describe('buildBootstrapScorecardForRepo', () => {
       }),
       expect.objectContaining({
         category: 'github_transport_failure',
+      }),
+      expect.objectContaining({
+        category: 'release_process_failure',
+        reason: 'missing required evidence: self_bootstrap_suite_green',
       }),
     ])
   })
@@ -599,6 +603,61 @@ describe('buildBootstrapScorecardForRepo', () => {
     expect(scorecard.topBlockers).toEqual([
       expect.objectContaining({
         category: 'github_transport_failure',
+      }),
+      expect.objectContaining({
+        category: 'release_process_failure',
+        reason: 'missing required evidence: self_bootstrap_suite_green',
+      }),
+    ])
+  })
+
+  test('keeps readable release evidence when an unrelated bootstrap issue lookup fails', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [],
+      listOpenAgentPullRequests: async () => [],
+      listIssueComments: async () => [],
+      getAgentIssueByNumber: async (issueNumber) => {
+        if (issueNumber === 37) {
+          throw new Error('The socket connection was closed unexpectedly.')
+        }
+
+        return {
+          number: issueNumber,
+          title: `Issue ${issueNumber}`,
+          body: '',
+          state: 'working',
+          labels: ['agent:working'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        }
+      },
+    })
+
+    expect(scorecard.ready).toBe(false)
+    expect(scorecard.categoryCounts).toMatchObject({
+      contract_failure: 0,
+      runtime_failure: 0,
+      pr_lifecycle_failure: 0,
+      review_failure: 0,
+      github_transport_failure: 1,
+      release_process_failure: 2,
+    })
+    expect(scorecard.topBlockers).toEqual([
+      expect.objectContaining({
+        category: 'github_transport_failure',
+        reason: 'release evidence: The socket connection was closed unexpectedly.',
       }),
       expect.objectContaining({
         category: 'release_process_failure',

--- a/apps/agent-daemon/src/bootstrap-scorecard.test.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.test.ts
@@ -64,6 +64,8 @@ function buildBlockedResumeEscalationComment(
 describe('buildBootstrapScorecard', () => {
   test('groups blockers into stable failure taxonomy buckets', () => {
     expect(classifyBootstrapFailureKind('closed PR blocked fresh PR creation')).toBe('pr_lifecycle_failure')
+    expect(classifyBootstrapFailureKind('linked PR #461 is in terminal agent:human-needed after failing merge checks')).toBe('pr_lifecycle_failure')
+    expect(classifyBootstrapFailureKind('linked PR #452 is still waiting for required self-bootstrap checks to finish before merge can resume')).toBe('pr_lifecycle_failure')
     expect(classifyBootstrapFailureKind('missing executable test/build/check command in ### Validation')).toBe('contract_failure')
 
     const scorecard = buildBootstrapScorecard({
@@ -83,7 +85,7 @@ describe('buildBootstrapScorecard', () => {
 })
 
 describe('buildBootstrapScorecardForRepo', () => {
-  test('keeps terminal human-needed review blockers out of pr lifecycle failures', async () => {
+  test('reuses repo-native issue and pull request signals without hardcoded bootstrap issue numbers', async () => {
     const scorecard = await buildBootstrapScorecardForRepo({
       config: {
         repo: 'JamesWuHK/agent-loop',
@@ -113,6 +115,22 @@ describe('buildBootstrapScorecardForRepo', () => {
           body: '',
           state: 'failed',
           labels: ['agent:failed'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+        {
+          number: 69,
+          title: 'self_bootstrap_suite_green release evidence still missing',
+          body: '',
+          state: 'working',
+          labels: ['agent:working'],
           assignee: null,
           isClaimable: false,
           updatedAt: '2026-04-11T10:00:00.000Z',
@@ -153,8 +171,8 @@ describe('buildBootstrapScorecardForRepo', () => {
         number: issueNumber,
         title: `Issue ${issueNumber}`,
         body: '',
-        state: issueNumber === 69 ? 'done' : 'working',
-        labels: issueNumber === 69 ? ['agent:done'] : ['agent:working'],
+        state: 'working',
+        labels: ['agent:working'],
         assignee: null,
         isClaimable: false,
         updatedAt: '2026-04-11T10:00:00.000Z',
@@ -169,9 +187,9 @@ describe('buildBootstrapScorecardForRepo', () => {
 
     expect(scorecard.categoryCounts).toMatchObject({
       contract_failure: 1,
-      pr_lifecycle_failure: 0,
+      pr_lifecycle_failure: 1,
       review_failure: 1,
-      release_process_failure: 1,
+      release_process_failure: 2,
       runtime_failure: 0,
       github_transport_failure: 0,
     })
@@ -181,6 +199,11 @@ describe('buildBootstrapScorecardForRepo', () => {
         reason: '1 invalid ready issue(s) require executable contracts',
       }),
       expect.objectContaining({
+        category: 'pr_lifecycle_failure',
+        issueNumber: 61,
+        prNumber: 91,
+      }),
+      expect.objectContaining({
         category: 'review_failure',
         issueNumber: 61,
         prNumber: 91,
@@ -188,7 +211,7 @@ describe('buildBootstrapScorecardForRepo', () => {
       }),
       expect.objectContaining({
         category: 'release_process_failure',
-        reason: 'missing required evidence: bootstrap_scorecard_green',
+        reason: 'missing required evidence: self_bootstrap_suite_green',
       }),
     ])
   })
@@ -348,7 +371,7 @@ describe('buildBootstrapScorecardForRepo', () => {
     }))
   })
 
-  test('counts failed issues blocked by a non-resumable linked PR as pr lifecycle failures', async () => {
+  test('keeps merge-check lifecycle blockers in the pr lifecycle bucket even when the linked pr is human-needed', async () => {
     const scorecard = await buildBootstrapScorecardForRepo({
       config: {
         repo: 'JamesWuHK/agent-loop',
@@ -357,8 +380,8 @@ describe('buildBootstrapScorecardForRepo', () => {
     }, {
       listOpenAgentIssues: async () => [
         {
-          number: 62,
-          title: 'issue recovery remains blocked by linked pr state',
+          number: 61,
+          title: 'issue recovery remains blocked',
           body: '',
           state: 'failed',
           labels: ['agent:failed'],
@@ -371,32 +394,43 @@ describe('buildBootstrapScorecardForRepo', () => {
           claimBlockedBy: [],
           hasExecutableContract: true,
           contractValidationErrors: [],
-        },
+        } as any,
       ],
       listOpenAgentPullRequests: async () => [
         {
-          number: 123,
-          title: 'linked pr is stuck',
-          url: 'https://example.test/pr/123',
-          headRefName: 'agent/62/codex-dev',
-          headRefOid: 'def456',
+          number: 461,
+          title: 'Fix merge-check blocker',
+          url: 'https://example.test/pr/461',
+          headRefName: 'agent/61/codex-dev',
+          headRefOid: 'abc123',
           isDraft: false,
-          labels: ['stalled'],
+          labels: ['agent:human-needed'],
         },
       ],
       listIssueComments: async (number) => {
-        if (number !== 62) {
-          return []
+        if (number === 61) {
+          return [{
+            commentId: 6101,
+            body: buildBlockedResumeEscalationComment(
+              61,
+              'linked PR #461 is in terminal agent:human-needed after failing merge checks',
+              { prNumber: 461 },
+            ),
+            createdAt: '2026-04-11T09:00:00.000Z',
+            updatedAt: '2026-04-11T09:05:00.000Z',
+          }]
         }
 
-        return [{
-          commentId: 6201,
-          body: buildBlockedResumeEscalationComment(62, 'linked PR #123 is not in a resumable automated state (stalled)', {
-            prNumber: 123,
-          }),
-          createdAt: '2026-04-11T09:00:00.000Z',
-          updatedAt: '2026-04-11T09:05:00.000Z',
-        }]
+        if (number === 461) {
+          return [{
+            commentId: 46101,
+            body: buildExecutionFailureReviewComment(461, 'abc123'),
+            createdAt: '2026-04-11T09:00:00.000Z',
+            updatedAt: '2026-04-11T09:05:00.000Z',
+          }]
+        }
+
+        return []
       },
       getAgentIssueByNumber: async () => null,
     })
@@ -404,9 +438,8 @@ describe('buildBootstrapScorecardForRepo', () => {
     expect(scorecard.categoryCounts.pr_lifecycle_failure).toBe(1)
     expect(scorecard.topBlockers).toContainEqual(expect.objectContaining({
       category: 'pr_lifecycle_failure',
-      issueNumber: 62,
-      prNumber: 123,
-      reason: 'linked PR #123 is not in a resumable automated state (stalled)',
+      issueNumber: 61,
+      prNumber: 461,
     }))
   })
 

--- a/apps/agent-daemon/src/bootstrap-scorecard.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.ts
@@ -1,0 +1,667 @@
+import {
+  PR_REVIEW_LABELS,
+  getAgentIssueByNumber,
+  listIssueComments,
+  listOpenAgentIssues,
+  listOpenAgentPullRequests,
+  type AgentConfig,
+  type AgentIssue,
+  type IssueComment,
+  type ManagedPullRequest,
+} from '@agent/shared'
+import { parseIssueContract } from '../../../packages/agent-shared/src/issue-contract'
+import {
+  buildAuditedIssue,
+  buildAuditIssueSummary,
+  type AuditIssueSummary,
+} from './audit-issue-contracts'
+import {
+  canResumeHumanNeededPrReview,
+  extractLatestAutomatedPrReviewBlockerSummary,
+} from './pr-reviewer'
+import {
+  extractBlockedIssueResumeEscalationComment,
+  evaluateBlockedIssueResumeResolution,
+  getFailedIssueResumeBlock,
+} from './daemon'
+
+export type BootstrapFailureKind =
+  | 'contract_failure'
+  | 'runtime_failure'
+  | 'pr_lifecycle_failure'
+  | 'review_failure'
+  | 'github_transport_failure'
+  | 'release_process_failure'
+
+export interface BootstrapScorecardSignal {
+  issueNumber?: number | null
+  prNumber?: number | null
+  reason: string
+}
+
+export interface BootstrapScorecardBlocker extends BootstrapScorecardSignal {
+  category: BootstrapFailureKind
+}
+
+export interface BootstrapScorecard {
+  ready: boolean
+  categoryCounts: Record<BootstrapFailureKind, number>
+  topBlockers: BootstrapScorecardBlocker[]
+  auditSummary: AuditIssueSummary
+}
+
+interface BootstrapScorecardInput {
+  audit: AuditIssueSummary
+  prBlockers?: BootstrapScorecardSignal[]
+  reviewBlockers?: BootstrapScorecardSignal[]
+  runtimeBlockers?: BootstrapScorecardSignal[]
+  transportBlockers?: BootstrapScorecardSignal[]
+  releaseEvidenceMissing: string[]
+}
+
+interface BootstrapScorecardDependencies {
+  listOpenAgentIssues: typeof listOpenAgentIssues
+  listOpenAgentPullRequests: typeof listOpenAgentPullRequests
+  listIssueComments: typeof listIssueComments
+  getAgentIssueByNumber: typeof getAgentIssueByNumber
+}
+
+const DEFAULT_BOOTSTRAP_SCORECARD_DEPENDENCIES: BootstrapScorecardDependencies = {
+  listOpenAgentIssues,
+  listOpenAgentPullRequests,
+  listIssueComments,
+  getAgentIssueByNumber,
+}
+
+const BOOTSTRAP_FAILURE_KIND_ORDER: BootstrapFailureKind[] = [
+  'contract_failure',
+  'runtime_failure',
+  'pr_lifecycle_failure',
+  'review_failure',
+  'github_transport_failure',
+  'release_process_failure',
+]
+
+const DEFAULT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS = 3
+const RELEASE_EVIDENCE_SPECS = [
+  {
+    code: 'self_bootstrap_suite_green',
+    matchesIssue: (issue: Pick<AgentIssue, 'body'>) =>
+      parseIssueContract(issue.body).requiredSemantics
+        .some((entry) => entry.includes('agent-loop --bootstrap-scenarios')),
+  },
+] as const
+
+export function classifyBootstrapFailureKind(reason: string): BootstrapFailureKind {
+  const normalized = reason.toLowerCase()
+
+  if (
+    normalized.includes('rate limit')
+    || normalized.includes('github api')
+    || normalized.includes('socket')
+    || normalized.includes('econn')
+    || normalized.includes('timeout')
+    || normalized.includes('transport')
+    || normalized.includes('connection reset')
+  ) {
+    return 'github_transport_failure'
+  }
+
+  if (
+    normalized.includes('missing required evidence:')
+    || normalized.includes('release evidence missing')
+  ) {
+    return 'release_process_failure'
+  }
+
+  if (
+    normalized.includes('closed pr')
+    || normalized.includes('fresh pr')
+    || normalized.includes('merge checks gate')
+    || normalized.includes('merge gate')
+    || normalized.includes('pr lifecycle')
+  ) {
+    return 'pr_lifecycle_failure'
+  }
+
+  if (
+    normalized.includes('human-needed')
+    || normalized.includes('review blocker')
+    || normalized.includes('review failed')
+    || normalized.includes('auto-fix')
+    || normalized.includes('review ')
+  ) {
+    return 'review_failure'
+  }
+
+  if (
+    normalized.includes('runtime blocker:')
+    || normalized.includes('daemon runtime failure:')
+  ) {
+    return 'runtime_failure'
+  }
+
+  return 'contract_failure'
+}
+
+export function buildBootstrapScorecard(
+  input: BootstrapScorecardInput,
+): BootstrapScorecard {
+  const categoryCounts = createEmptyCategoryCounts()
+  const blockers: BootstrapScorecardBlocker[] = []
+
+  if (input.audit.invalidReadyIssueCount > 0) {
+    categoryCounts.contract_failure += input.audit.invalidReadyIssueCount
+    blockers.push({
+      category: 'contract_failure',
+      issueNumber: null,
+      prNumber: null,
+      reason: `${input.audit.invalidReadyIssueCount} invalid ready issue(s) require executable contracts`,
+    })
+  }
+
+  for (const blocker of input.runtimeBlockers ?? []) {
+    categoryCounts.runtime_failure += 1
+    blockers.push({
+      category: 'runtime_failure',
+      ...normalizeScorecardSignal(blocker),
+    })
+  }
+
+  for (const blocker of input.prBlockers ?? []) {
+    categoryCounts.pr_lifecycle_failure += 1
+    blockers.push({
+      category: 'pr_lifecycle_failure',
+      ...normalizeScorecardSignal(blocker),
+    })
+  }
+
+  for (const blocker of input.reviewBlockers ?? []) {
+    categoryCounts.review_failure += 1
+    blockers.push({
+      category: 'review_failure',
+      ...normalizeScorecardSignal(blocker),
+    })
+  }
+
+  for (const blocker of input.transportBlockers ?? []) {
+    categoryCounts.github_transport_failure += 1
+    blockers.push({
+      category: 'github_transport_failure',
+      ...normalizeScorecardSignal(blocker),
+    })
+  }
+
+  for (const code of input.releaseEvidenceMissing) {
+    categoryCounts.release_process_failure += 1
+    blockers.push({
+      category: 'release_process_failure',
+      issueNumber: null,
+      prNumber: null,
+      reason: `missing required evidence: ${code}`,
+    })
+  }
+
+  return {
+    ready: BOOTSTRAP_FAILURE_KIND_ORDER.every((category) => categoryCounts[category] === 0),
+    categoryCounts,
+    topBlockers: BOOTSTRAP_FAILURE_KIND_ORDER.flatMap((category) => {
+      const blocker = blockers.find((candidate) => candidate.category === category)
+      return blocker ? [blocker] : []
+    }),
+    auditSummary: input.audit,
+  }
+}
+
+export async function buildBootstrapScorecardForRepo(
+  input: {
+    config: AgentConfig
+  },
+  deps: BootstrapScorecardDependencies = DEFAULT_BOOTSTRAP_SCORECARD_DEPENDENCIES,
+): Promise<BootstrapScorecard> {
+  const transportBlockers: BootstrapScorecardSignal[] = []
+  const issuesResult = await collectScorecardSource(
+    () => deps.listOpenAgentIssues(input.config),
+    transportBlockers,
+    'open issues',
+  )
+  const pullRequestsResult = await collectScorecardSource(
+    () => deps.listOpenAgentPullRequests(input.config),
+    transportBlockers,
+    'open pull requests',
+  )
+
+  const managedIssues = (issuesResult ?? [])
+    .filter((issue) => issue.labels.some((label) => label.startsWith('agent:')))
+  const pullRequests = pullRequestsResult ?? []
+  const issueBodiesByNumber = new Map(managedIssues.map((issue) => [issue.number, issue.body]))
+  const issueCommentsByNumber = new Map<number, IssueComment[] | null>()
+  const prCommentsByNumber = new Map<number, IssueComment[] | null>()
+  const linkedIssuesByNumber = new Map<number, AgentIssue | null>()
+  const commentLoader = createScorecardCommentLoader(
+    input.config,
+    deps,
+    transportBlockers,
+    issueCommentsByNumber,
+    prCommentsByNumber,
+  )
+  const linkedIssueLoader = createLinkedIssueLoader(
+    input.config,
+    deps,
+    transportBlockers,
+    linkedIssuesByNumber,
+  )
+  const [prBlockers, reviewBlockers] = await Promise.all([
+    collectPrLifecycleBlockers(
+      managedIssues,
+      pullRequests,
+      commentLoader,
+    ),
+    collectReviewBlockers(
+      pullRequests,
+      issueBodiesByNumber,
+      commentLoader,
+      linkedIssueLoader,
+    ),
+  ])
+
+  return buildBootstrapScorecard({
+    audit: issuesResult
+      ? buildAuditIssueSummary(managedIssues.map(buildAuditedIssue))
+      : buildEmptyAuditIssueSummary(),
+    runtimeBlockers: [],
+    prBlockers,
+    reviewBlockers,
+    transportBlockers,
+    releaseEvidenceMissing: collectMissingReleaseEvidence(managedIssues),
+  })
+}
+
+export function formatBootstrapScorecard(
+  scorecard: BootstrapScorecard,
+): string {
+  return [
+    'Bootstrap Scorecard',
+    `ready=${scorecard.ready}`,
+    `auditSummary=managed:${scorecard.auditSummary.managedIssueCount} ready:${scorecard.auditSummary.readyIssueCount} invalidReady:${scorecard.auditSummary.invalidReadyIssueCount} lowScore:${scorecard.auditSummary.lowScoreIssueCount} warnings:${scorecard.auditSummary.warningIssueCount}`,
+    'categoryCounts:',
+    ...BOOTSTRAP_FAILURE_KIND_ORDER.map((category) => `- ${category}: ${scorecard.categoryCounts[category]}`),
+    'topBlockers:',
+    ...(scorecard.topBlockers.length > 0
+      ? scorecard.topBlockers.map((blocker) => `- ${blocker.category}: ${formatScorecardBlockerTarget(blocker)}${blocker.reason}`)
+      : ['- none']),
+  ].join('\n')
+}
+
+export function formatBootstrapScorecardJson(
+  scorecard: BootstrapScorecard,
+): string {
+  return JSON.stringify(scorecard, null, 2)
+}
+
+export function resolveBootstrapScorecardExitCode(
+  scorecard: Pick<BootstrapScorecard, 'ready'>,
+): number {
+  return scorecard.ready ? 0 : 1
+}
+
+function createEmptyCategoryCounts(): Record<BootstrapFailureKind, number> {
+  return {
+    contract_failure: 0,
+    runtime_failure: 0,
+    pr_lifecycle_failure: 0,
+    review_failure: 0,
+    github_transport_failure: 0,
+    release_process_failure: 0,
+  }
+}
+
+function normalizeScorecardSignal(signal: BootstrapScorecardSignal): BootstrapScorecardSignal {
+  return {
+    issueNumber: signal.issueNumber ?? null,
+    prNumber: signal.prNumber ?? null,
+    reason: signal.reason,
+  }
+}
+
+function buildEmptyAuditIssueSummary(): AuditIssueSummary {
+  return {
+    managedIssueCount: 0,
+    readyIssueCount: 0,
+    invalidReadyIssueCount: 0,
+    lowScoreIssueCount: 0,
+    warningIssueCount: 0,
+  }
+}
+
+function collectMissingReleaseEvidence(
+  issues: AgentIssue[],
+): string[] {
+  const missing = new Set<string>()
+
+  for (const issue of issues) {
+    for (const evidence of RELEASE_EVIDENCE_SPECS) {
+      if (evidence.matchesIssue(issue)) {
+        missing.add(evidence.code)
+      }
+    }
+  }
+
+  return [...missing]
+}
+
+async function collectScorecardSource<T>(
+  load: () => Promise<T>,
+  transportBlockers: BootstrapScorecardSignal[],
+  target: string,
+): Promise<T | null> {
+  try {
+    return await load()
+  } catch (error) {
+    transportBlockers.push({
+      reason: `${target}: ${formatBootstrapScorecardError(error)}`,
+    })
+    return null
+  }
+}
+
+async function collectReviewBlockers(
+  pullRequests: ManagedPullRequest[],
+  issueBodiesByNumber: Map<number, string>,
+  commentLoader: ReturnType<typeof createScorecardCommentLoader>,
+  linkedIssueLoader: ReturnType<typeof createLinkedIssueLoader>,
+): Promise<BootstrapScorecardSignal[]> {
+  const blockers: BootstrapScorecardSignal[] = []
+
+  for (const pullRequest of pullRequests) {
+    const labelSet = new Set(pullRequest.labels)
+    if (!labelSet.has(PR_REVIEW_LABELS.HUMAN_NEEDED) && !labelSet.has(PR_REVIEW_LABELS.FAILED)) {
+      continue
+    }
+
+    const prComments = await commentLoader.loadPrComments(pullRequest.number)
+    if (!prComments) {
+      continue
+    }
+
+    const latestReviewBlocker = extractLatestAutomatedPrReviewBlockerSummary(prComments)
+    if (!latestReviewBlocker) {
+      continue
+    }
+
+    const issueNumber = parseIssueNumberFromManagedBranch(pullRequest.headRefName)
+    const linkedIssueBody = await resolveLinkedIssueBody(issueNumber, issueBodiesByNumber, linkedIssueLoader)
+
+    if (
+      labelSet.has(PR_REVIEW_LABELS.HUMAN_NEEDED)
+      && canResumeHumanNeededPrReview(
+        prComments,
+        DEFAULT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS,
+        pullRequest.headRefOid,
+        linkedIssueBody,
+      )
+    ) {
+      continue
+    }
+
+    if (issueNumber !== null) {
+      const issueComments = await commentLoader.loadIssueComments(issueNumber)
+      if (issueComments && evaluateBlockedIssueResumeResolution(issueComments, issueNumber, pullRequest.number).canResume) {
+        continue
+      }
+    }
+
+    blockers.push({
+      issueNumber,
+      prNumber: pullRequest.number,
+      reason: latestReviewBlocker.reason,
+    })
+  }
+
+  return blockers
+}
+
+function parseIssueNumberFromManagedBranch(headRefName: string): number | null {
+  const match = headRefName.match(/^agent\/(\d+)(?:\/|$)/)
+  if (!match) return null
+
+  const parsed = Number.parseInt(match[1] ?? '', 10)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
+async function collectPrLifecycleBlockers(
+  issues: AgentIssue[],
+  pullRequests: ManagedPullRequest[],
+  commentLoader: ReturnType<typeof createScorecardCommentLoader>,
+): Promise<BootstrapScorecardSignal[]> {
+  const blockers: BootstrapScorecardSignal[] = []
+  const pullRequestsByIssueNumber = new Map<number, ManagedPullRequest[]>()
+
+  for (const pullRequest of pullRequests) {
+    const issueNumber = parseIssueNumberFromManagedBranch(pullRequest.headRefName)
+    if (issueNumber === null) continue
+    pullRequestsByIssueNumber.set(issueNumber, [...(pullRequestsByIssueNumber.get(issueNumber) ?? []), pullRequest])
+  }
+
+  for (const issue of issues) {
+    if (issue.state !== 'failed') {
+      continue
+    }
+
+    const issueComments = await commentLoader.loadIssueComments(issue.number)
+    if (!issueComments) {
+      continue
+    }
+
+    const linkedPullRequests = pullRequestsByIssueNumber.get(issue.number) ?? []
+    const fallbackBlockedEscalation = findLatestUnresolvedPrLifecycleEscalation(
+      issueComments,
+      issue.number,
+      new Set(linkedPullRequests.map((pullRequest) => pullRequest.number)),
+    )
+
+    let hasResumableLinkedPr = false
+    let firstBlocked: BootstrapScorecardSignal | null = null
+
+    for (const pullRequest of linkedPullRequests) {
+      const prComments = await commentLoader.loadPrComments(pullRequest.number)
+      if (!prComments) {
+        continue
+      }
+
+      const canResumeHumanNeededReview = new Set(pullRequest.labels).has(PR_REVIEW_LABELS.HUMAN_NEEDED)
+        ? canResumeHumanNeededPrReview(
+          prComments,
+          DEFAULT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS,
+          pullRequest.headRefOid,
+          issue.body,
+        )
+        : false
+      const blocked = getFailedIssueResumeBlock(pullRequest, canResumeHumanNeededReview)
+
+      if (blocked === null) {
+        hasResumableLinkedPr = true
+        break
+      }
+
+      if (evaluateBlockedIssueResumeResolution(issueComments, issue.number, pullRequest.number).canResume) {
+        continue
+      }
+
+      if (firstBlocked === null) {
+        firstBlocked = {
+          issueNumber: issue.number,
+          prNumber: pullRequest.number,
+          reason: blocked.reason,
+        }
+      }
+    }
+
+    if (!hasResumableLinkedPr && firstBlocked) {
+      blockers.push(firstBlocked)
+      continue
+    }
+
+    if (!hasResumableLinkedPr && fallbackBlockedEscalation) {
+      blockers.push(fallbackBlockedEscalation)
+    }
+  }
+
+  return blockers
+}
+
+function findLatestUnresolvedPrLifecycleEscalation(
+  issueComments: IssueComment[],
+  issueNumber: number,
+  openLinkedPrNumbers: Set<number>,
+): BootstrapScorecardSignal | null {
+  let latestBlocked: { signal: BootstrapScorecardSignal; timestamp: number } | null = null
+
+  for (const comment of issueComments) {
+    const escalation = extractBlockedIssueResumeEscalationComment(comment.body)
+    if (!escalation || escalation.issueNumber !== issueNumber) {
+      continue
+    }
+
+    if (classifyBootstrapFailureKind(escalation.reason) !== 'pr_lifecycle_failure') {
+      continue
+    }
+
+    if (escalation.prNumber !== null) {
+      if (openLinkedPrNumbers.has(escalation.prNumber)) {
+        continue
+      }
+
+      if (evaluateBlockedIssueResumeResolution(issueComments, issueNumber, escalation.prNumber).canResume) {
+        continue
+      }
+    }
+
+    const timestamp = readScorecardCommentTimestamp(comment, escalation.escalatedAt)
+    if (latestBlocked && latestBlocked.timestamp >= timestamp) {
+      continue
+    }
+
+    latestBlocked = {
+      signal: {
+        issueNumber,
+        prNumber: escalation.prNumber,
+        reason: escalation.reason,
+      },
+      timestamp,
+    }
+  }
+
+  return latestBlocked?.signal ?? null
+}
+
+function readScorecardCommentTimestamp(
+  comment: Pick<IssueComment, 'updatedAt' | 'createdAt'>,
+  fallbackIso: string | null = null,
+): number {
+  const candidates = [comment.updatedAt, comment.createdAt, fallbackIso]
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') {
+      continue
+    }
+
+    const parsed = Date.parse(candidate)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return 0
+}
+
+function createScorecardCommentLoader(
+  config: AgentConfig,
+  deps: BootstrapScorecardDependencies,
+  transportBlockers: BootstrapScorecardSignal[],
+  issueCommentsByNumber: Map<number, IssueComment[] | null>,
+  prCommentsByNumber: Map<number, IssueComment[] | null>,
+) {
+  return {
+    loadIssueComments: async (issueNumber: number): Promise<IssueComment[] | null> => {
+      if (issueCommentsByNumber.has(issueNumber)) {
+        return issueCommentsByNumber.get(issueNumber) ?? null
+      }
+
+      const comments = await collectScorecardSource(
+        () => deps.listIssueComments(issueNumber, config),
+        transportBlockers,
+        `issue#${issueNumber} comments`,
+      )
+      issueCommentsByNumber.set(issueNumber, comments)
+      return comments
+    },
+    loadPrComments: async (prNumber: number): Promise<IssueComment[] | null> => {
+      if (prCommentsByNumber.has(prNumber)) {
+        return prCommentsByNumber.get(prNumber) ?? null
+      }
+
+      const comments = await collectScorecardSource(
+        () => deps.listIssueComments(prNumber, config),
+        transportBlockers,
+        `pr#${prNumber} comments`,
+      )
+      prCommentsByNumber.set(prNumber, comments)
+      return comments
+    },
+  }
+}
+
+function createLinkedIssueLoader(
+  config: AgentConfig,
+  deps: BootstrapScorecardDependencies,
+  transportBlockers: BootstrapScorecardSignal[],
+  linkedIssuesByNumber: Map<number, AgentIssue | null>,
+) {
+  return {
+    loadLinkedIssue: async (issueNumber: number): Promise<AgentIssue | null> => {
+      if (linkedIssuesByNumber.has(issueNumber)) {
+        return linkedIssuesByNumber.get(issueNumber) ?? null
+      }
+
+      const linkedIssue = await collectScorecardSource(
+        () => deps.getAgentIssueByNumber(issueNumber, config),
+        transportBlockers,
+        `issue#${issueNumber} lookup`,
+      )
+      linkedIssuesByNumber.set(issueNumber, linkedIssue)
+      return linkedIssue
+    },
+  }
+}
+
+async function resolveLinkedIssueBody(
+  issueNumber: number | null,
+  issueBodiesByNumber: Map<number, string>,
+  linkedIssueLoader: ReturnType<typeof createLinkedIssueLoader>,
+): Promise<string | null> {
+  if (issueNumber === null) {
+    return null
+  }
+
+  if (issueBodiesByNumber.has(issueNumber)) {
+    return issueBodiesByNumber.get(issueNumber) ?? null
+  }
+
+  const linkedIssue = await linkedIssueLoader.loadLinkedIssue(issueNumber)
+  return linkedIssue?.body ?? null
+}
+
+function formatScorecardBlockerTarget(blocker: BootstrapScorecardBlocker): string {
+  if (blocker.issueNumber !== null && blocker.issueNumber !== undefined) {
+    return `issue#${blocker.issueNumber} `
+  }
+  if (blocker.prNumber !== null && blocker.prNumber !== undefined) {
+    return `pr#${blocker.prNumber} `
+  }
+  return ''
+}
+
+function formatBootstrapScorecardError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/apps/agent-daemon/src/bootstrap-scorecard.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.ts
@@ -83,6 +83,16 @@ const BOOTSTRAP_FAILURE_KIND_ORDER: BootstrapFailureKind[] = [
 ]
 
 const DEFAULT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS = 3
+const REQUIRED_RELEASE_EVIDENCE_SPECS = [
+  {
+    code: 'self_bootstrap_suite_green',
+    issueNumber: 69,
+  },
+  {
+    code: 'bootstrap_scorecard_green',
+    issueNumber: 70,
+  },
+] as const
 
 export function classifyBootstrapFailureKind(reason: string): BootstrapFailureKind {
   const normalized = reason.toLowerCase()
@@ -260,20 +270,10 @@ export async function buildBootstrapScorecardForRepo(
     managedIssues,
     commentLoader,
   )
-  const releaseEvidenceMissing = await collectScorecardSource(
-    async () => {
-      const report = await buildBootstrapGateReportForRepo({
-        config: input.config,
-      }, {
-        getAgentIssueByNumber: deps.getAgentIssueByNumber,
-      })
-
-      return report.requiredEvidence
-        .filter((evidence) => !evidence.satisfied)
-        .map((evidence) => evidence.code)
-    },
+  const releaseEvidenceMissing = await collectReleaseEvidenceMissing(
+    input.config,
+    deps,
     transportBlockers,
-    'release evidence',
   )
 
   return buildBootstrapScorecard({
@@ -343,6 +343,42 @@ function buildEmptyAuditIssueSummary(): AuditIssueSummary {
     lowScoreIssueCount: 0,
     warningIssueCount: 0,
   }
+}
+
+async function collectReleaseEvidenceMissing(
+  config: AgentConfig,
+  deps: BootstrapScorecardDependencies,
+  transportBlockers: BootstrapScorecardSignal[],
+): Promise<string[]> {
+  try {
+    const report = await buildBootstrapGateReportForRepo({
+      config,
+    }, {
+      getAgentIssueByNumber: deps.getAgentIssueByNumber,
+    })
+
+    return report.requiredEvidence
+      .filter((evidence) => !evidence.satisfied)
+      .map((evidence) => evidence.code)
+  } catch (error) {
+    transportBlockers.push({
+      reason: `release evidence: ${formatBootstrapScorecardError(error)}`,
+    })
+  }
+
+  const missingEvidence: string[] = []
+  for (const evidence of REQUIRED_RELEASE_EVIDENCE_SPECS) {
+    const issue = await collectScorecardSource(
+      () => deps.getAgentIssueByNumber(evidence.issueNumber, config),
+      transportBlockers,
+      `issue#${evidence.issueNumber} lookup`,
+    )
+    if (issue?.state !== 'done') {
+      missingEvidence.push(evidence.code)
+    }
+  }
+
+  return missingEvidence
 }
 
 async function collectScorecardSource<T>(

--- a/apps/agent-daemon/src/bootstrap-scorecard.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.ts
@@ -460,7 +460,8 @@ async function collectPrLifecycleBlockers(
         continue
       }
 
-      const canResumeHumanNeededReview = new Set(pullRequest.labels).has(PR_REVIEW_LABELS.HUMAN_NEEDED)
+      const pullRequestLabels = new Set(pullRequest.labels)
+      const canResumeHumanNeededReview = pullRequestLabels.has(PR_REVIEW_LABELS.HUMAN_NEEDED)
         ? canResumeHumanNeededPrReview(
           prComments,
           DEFAULT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS,
@@ -471,6 +472,14 @@ async function collectPrLifecycleBlockers(
       const blocked = getFailedIssueResumeBlock(pullRequest, canResumeHumanNeededReview)
 
       if (blocked === null) {
+        if (
+          fallbackBlockedEscalation?.prNumber === pullRequest.number
+          && isGenericLinkedPrLifecycleReason(fallbackBlockedEscalation.reason)
+        ) {
+          firstBlocked = fallbackBlockedEscalation
+          continue
+        }
+
         hasResumableLinkedPr = true
         break
       }
@@ -480,8 +489,7 @@ async function collectPrLifecycleBlockers(
       }
 
       if (firstBlocked === null) {
-        const blockedCategory = classifyBootstrapFailureKind(blocked.reason)
-        if (blockedCategory === 'pr_lifecycle_failure') {
+        if (!pullRequestLabels.has(PR_REVIEW_LABELS.HUMAN_NEEDED)) {
           firstBlocked = {
             issueNumber: issue.number,
             prNumber: pullRequest.number,
@@ -504,6 +512,15 @@ async function collectPrLifecycleBlockers(
   return blockers
 }
 
+function isGenericLinkedPrLifecycleReason(reason: string): boolean {
+  return /^linked pr #\d+ is not in a resumable automated state\b/i.test(reason)
+}
+
+function isPrLifecycleScorecardReason(reason: string): boolean {
+  return classifyBootstrapFailureKind(reason) === 'pr_lifecycle_failure'
+    || isGenericLinkedPrLifecycleReason(reason)
+}
+
 function findLatestUnresolvedPrLifecycleEscalation(
   issueComments: IssueComment[],
   issueNumber: number,
@@ -517,12 +534,15 @@ function findLatestUnresolvedPrLifecycleEscalation(
       continue
     }
 
-    if (classifyBootstrapFailureKind(escalation.reason) !== 'pr_lifecycle_failure') {
+    if (!isPrLifecycleScorecardReason(escalation.reason)) {
       continue
     }
 
     if (escalation.prNumber !== null) {
-      if (openLinkedPrNumbers.has(escalation.prNumber)) {
+      if (
+        openLinkedPrNumbers.has(escalation.prNumber)
+        && !isGenericLinkedPrLifecycleReason(escalation.reason)
+      ) {
         continue
       }
 

--- a/apps/agent-daemon/src/bootstrap-scorecard.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.ts
@@ -154,6 +154,12 @@ export function buildBootstrapScorecard(
 ): BootstrapScorecard {
   const categoryCounts = createEmptyCategoryCounts()
   const blockers: BootstrapScorecardBlocker[] = []
+  const mutuallyExclusiveBlockers = dedupePrLifecycleAndReviewBlockers(
+    input.prBlockers ?? [],
+    input.reviewBlockers ?? [],
+  )
+  const prLifecycleBlockers = mutuallyExclusiveBlockers.prBlockers
+  const reviewBlockers = mutuallyExclusiveBlockers.reviewBlockers
 
   if (input.audit.invalidReadyIssueCount > 0) {
     categoryCounts.contract_failure += input.audit.invalidReadyIssueCount
@@ -173,7 +179,7 @@ export function buildBootstrapScorecard(
     })
   }
 
-  for (const blocker of input.prBlockers ?? []) {
+  for (const blocker of prLifecycleBlockers) {
     categoryCounts.pr_lifecycle_failure += 1
     blockers.push({
       category: 'pr_lifecycle_failure',
@@ -181,7 +187,7 @@ export function buildBootstrapScorecard(
     })
   }
 
-  for (const blocker of input.reviewBlockers ?? []) {
+  for (const blocker of reviewBlockers) {
     categoryCounts.review_failure += 1
     blockers.push({
       category: 'review_failure',
@@ -336,6 +342,38 @@ function normalizeScorecardSignal(signal: BootstrapScorecardSignal): BootstrapSc
     prNumber: signal.prNumber ?? null,
     reason: signal.reason,
   }
+}
+
+function dedupePrLifecycleAndReviewBlockers(
+  prBlockers: BootstrapScorecardSignal[],
+  reviewBlockers: BootstrapScorecardSignal[],
+): {
+  prBlockers: BootstrapScorecardSignal[]
+  reviewBlockers: BootstrapScorecardSignal[]
+} {
+  const prLifecycleKeys = new Set(
+    prBlockers
+      .map(buildIssuePrPairKey)
+      .filter((key): key is string => key !== null),
+  )
+
+  return {
+    prBlockers,
+    // Failed-issue resume blockers win over PR review blockers for the same linked issue/PR pair.
+    reviewBlockers: reviewBlockers.filter((blocker) => {
+      const key = buildIssuePrPairKey(blocker)
+      return key === null || !prLifecycleKeys.has(key)
+    }),
+  }
+}
+
+function buildIssuePrPairKey(signal: BootstrapScorecardSignal): string | null {
+  const normalized = normalizeScorecardSignal(signal)
+  if (normalized.issueNumber === null || normalized.prNumber === null) {
+    return null
+  }
+
+  return `${normalized.issueNumber}:${normalized.prNumber}`
 }
 
 function buildEmptyAuditIssueSummary(): AuditIssueSummary {

--- a/apps/agent-daemon/src/bootstrap-scorecard.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.ts
@@ -256,6 +256,10 @@ export async function buildBootstrapScorecardForRepo(
       linkedIssueLoader,
     ),
   ])
+  const runtimeBlockers = await collectRuntimeBlockers(
+    managedIssues,
+    commentLoader,
+  )
   const releaseEvidenceMissing = await collectScorecardSource(
     async () => {
       const report = await buildBootstrapGateReportForRepo({
@@ -276,7 +280,7 @@ export async function buildBootstrapScorecardForRepo(
     audit: issuesResult
       ? buildAuditIssueSummary(managedIssues.map(buildAuditedIssue))
       : buildEmptyAuditIssueSummary(),
-    runtimeBlockers: [],
+    runtimeBlockers,
     prBlockers,
     reviewBlockers,
     transportBlockers,
@@ -512,6 +516,31 @@ async function collectPrLifecycleBlockers(
   return blockers
 }
 
+async function collectRuntimeBlockers(
+  issues: AgentIssue[],
+  commentLoader: ReturnType<typeof createScorecardCommentLoader>,
+): Promise<BootstrapScorecardSignal[]> {
+  const blockers: BootstrapScorecardSignal[] = []
+
+  for (const issue of issues) {
+    if (issue.state !== 'failed') {
+      continue
+    }
+
+    const issueComments = await commentLoader.loadIssueComments(issue.number)
+    if (!issueComments) {
+      continue
+    }
+
+    const runtimeBlocker = findLatestUnresolvedRuntimeEscalation(issueComments, issue.number)
+    if (runtimeBlocker) {
+      blockers.push(runtimeBlocker)
+    }
+  }
+
+  return blockers
+}
+
 function isGenericLinkedPrLifecycleReason(reason: string): boolean {
   return /^linked pr #\d+ is not in a resumable automated state\b/i.test(reason)
 }
@@ -549,6 +578,47 @@ function findLatestUnresolvedPrLifecycleEscalation(
       if (evaluateBlockedIssueResumeResolution(issueComments, issueNumber, escalation.prNumber).canResume) {
         continue
       }
+    }
+
+    const timestamp = readScorecardCommentTimestamp(comment, escalation.escalatedAt)
+    if (latestBlocked && latestBlocked.timestamp >= timestamp) {
+      continue
+    }
+
+    latestBlocked = {
+      signal: {
+        issueNumber,
+        prNumber: escalation.prNumber,
+        reason: escalation.reason,
+      },
+      timestamp,
+    }
+  }
+
+  return latestBlocked?.signal ?? null
+}
+
+function findLatestUnresolvedRuntimeEscalation(
+  issueComments: IssueComment[],
+  issueNumber: number,
+): BootstrapScorecardSignal | null {
+  let latestBlocked: { signal: BootstrapScorecardSignal; timestamp: number } | null = null
+
+  for (const comment of issueComments) {
+    const escalation = extractBlockedIssueResumeEscalationComment(comment.body)
+    if (!escalation || escalation.issueNumber !== issueNumber) {
+      continue
+    }
+
+    if (classifyBootstrapFailureKind(escalation.reason) !== 'runtime_failure') {
+      continue
+    }
+
+    if (
+      escalation.prNumber !== null
+      && evaluateBlockedIssueResumeResolution(issueComments, issueNumber, escalation.prNumber).canResume
+    ) {
+      continue
     }
 
     const timestamp = readScorecardCommentTimestamp(comment, escalation.escalatedAt)

--- a/apps/agent-daemon/src/bootstrap-scorecard.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.ts
@@ -9,12 +9,12 @@ import {
   type IssueComment,
   type ManagedPullRequest,
 } from '@agent/shared'
-import { parseIssueContract } from '../../../packages/agent-shared/src/issue-contract'
 import {
   buildAuditedIssue,
   buildAuditIssueSummary,
   type AuditIssueSummary,
 } from './audit-issue-contracts'
+import { buildBootstrapGateReportForRepo } from './bootstrap-gate'
 import {
   canResumeHumanNeededPrReview,
   extractLatestAutomatedPrReviewBlockerSummary,
@@ -83,14 +83,6 @@ const BOOTSTRAP_FAILURE_KIND_ORDER: BootstrapFailureKind[] = [
 ]
 
 const DEFAULT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS = 3
-const RELEASE_EVIDENCE_SPECS = [
-  {
-    code: 'self_bootstrap_suite_green',
-    matchesIssue: (issue: Pick<AgentIssue, 'body'>) =>
-      parseIssueContract(issue.body).requiredSemantics
-        .some((entry) => entry.includes('agent-loop --bootstrap-scenarios')),
-  },
-] as const
 
 export function classifyBootstrapFailureKind(reason: string): BootstrapFailureKind {
   const normalized = reason.toLowerCase()
@@ -264,6 +256,21 @@ export async function buildBootstrapScorecardForRepo(
       linkedIssueLoader,
     ),
   ])
+  const releaseEvidenceMissing = await collectScorecardSource(
+    async () => {
+      const report = await buildBootstrapGateReportForRepo({
+        config: input.config,
+      }, {
+        getAgentIssueByNumber: deps.getAgentIssueByNumber,
+      })
+
+      return report.requiredEvidence
+        .filter((evidence) => !evidence.satisfied)
+        .map((evidence) => evidence.code)
+    },
+    transportBlockers,
+    'release evidence',
+  )
 
   return buildBootstrapScorecard({
     audit: issuesResult
@@ -273,7 +280,7 @@ export async function buildBootstrapScorecardForRepo(
     prBlockers,
     reviewBlockers,
     transportBlockers,
-    releaseEvidenceMissing: collectMissingReleaseEvidence(managedIssues),
+    releaseEvidenceMissing: releaseEvidenceMissing ?? [],
   })
 }
 
@@ -332,22 +339,6 @@ function buildEmptyAuditIssueSummary(): AuditIssueSummary {
     lowScoreIssueCount: 0,
     warningIssueCount: 0,
   }
-}
-
-function collectMissingReleaseEvidence(
-  issues: AgentIssue[],
-): string[] {
-  const missing = new Set<string>()
-
-  for (const issue of issues) {
-    for (const evidence of RELEASE_EVIDENCE_SPECS) {
-      if (evidence.matchesIssue(issue)) {
-        missing.add(evidence.code)
-      }
-    }
-  }
-
-  return [...missing]
 }
 
 async function collectScorecardSource<T>(
@@ -489,10 +480,13 @@ async function collectPrLifecycleBlockers(
       }
 
       if (firstBlocked === null) {
-        firstBlocked = {
-          issueNumber: issue.number,
-          prNumber: pullRequest.number,
-          reason: blocked.reason,
+        const blockedCategory = classifyBootstrapFailureKind(blocked.reason)
+        if (blockedCategory === 'pr_lifecycle_failure') {
+          firstBlocked = {
+            issueNumber: issue.number,
+            prNumber: pullRequest.number,
+            reason: blocked.reason,
+          }
         }
       }
     }

--- a/apps/agent-daemon/src/bootstrap-scorecard.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.ts
@@ -119,8 +119,11 @@ export function classifyBootstrapFailureKind(reason: string): BootstrapFailureKi
   if (
     normalized.includes('closed pr')
     || normalized.includes('fresh pr')
+    || normalized.includes('merge checks')
     || normalized.includes('merge checks gate')
     || normalized.includes('merge gate')
+    || normalized.includes('required self-bootstrap checks')
+    || normalized.includes('before merge can resume')
     || normalized.includes('pr lifecycle')
   ) {
     return 'pr_lifecycle_failure'
@@ -514,7 +517,7 @@ async function collectPrLifecycleBlockers(
       if (blocked === null) {
         if (
           fallbackBlockedEscalation?.prNumber === pullRequest.number
-          && isGenericLinkedPrLifecycleReason(fallbackBlockedEscalation.reason)
+          && shouldRetainOpenPrLifecycleEscalation(fallbackBlockedEscalation.reason)
         ) {
           firstBlocked = fallbackBlockedEscalation
           continue
@@ -529,12 +532,14 @@ async function collectPrLifecycleBlockers(
       }
 
       if (firstBlocked === null) {
-        if (!pullRequestLabels.has(PR_REVIEW_LABELS.HUMAN_NEEDED)) {
-          firstBlocked = {
-            issueNumber: issue.number,
-            prNumber: pullRequest.number,
-            reason: blocked.reason,
-          }
+        firstBlocked = {
+          issueNumber: issue.number,
+          prNumber: pullRequest.number,
+          reason:
+            fallbackBlockedEscalation?.prNumber === pullRequest.number
+            && shouldRetainOpenPrLifecycleEscalation(fallbackBlockedEscalation.reason)
+              ? fallbackBlockedEscalation.reason
+              : blocked.reason,
         }
       }
     }
@@ -581,9 +586,9 @@ function isGenericLinkedPrLifecycleReason(reason: string): boolean {
   return /^linked pr #\d+ is not in a resumable automated state\b/i.test(reason)
 }
 
-function isPrLifecycleScorecardReason(reason: string): boolean {
-  return classifyBootstrapFailureKind(reason) === 'pr_lifecycle_failure'
-    || isGenericLinkedPrLifecycleReason(reason)
+function shouldRetainOpenPrLifecycleEscalation(reason: string): boolean {
+  return /^linked pr #\d+\b/i.test(reason)
+    && classifyBootstrapFailureKind(reason) === 'pr_lifecycle_failure'
 }
 
 function findLatestUnresolvedPrLifecycleEscalation(
@@ -599,14 +604,14 @@ function findLatestUnresolvedPrLifecycleEscalation(
       continue
     }
 
-    if (!isPrLifecycleScorecardReason(escalation.reason)) {
+    if (classifyBootstrapFailureKind(escalation.reason) !== 'pr_lifecycle_failure') {
       continue
     }
 
     if (escalation.prNumber !== null) {
       if (
         openLinkedPrNumbers.has(escalation.prNumber)
-        && !isGenericLinkedPrLifecycleReason(escalation.reason)
+        && !shouldRetainOpenPrLifecycleEscalation(escalation.reason)
       ) {
         continue
       }

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -7,10 +7,14 @@ import {
   buildManagedRestartArgs,
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
+  executeBootstrapGateCommand,
+  executeBootstrapScenarioCommand,
   executeBootstrapScorecardCommand,
   executeIssueLintCommand,
   executeWakeCommand,
   executeWakeRequest,
+  formatBootstrapGateOutput,
+  formatBootstrapScenarioOutput,
   formatBootstrapScorecardOutput,
   formatIssueLintOutput,
   formatManagedRuntimeLog,
@@ -341,21 +345,197 @@ describe('index helpers', () => {
     expect(report.errors).toEqual(['missing ## RED 测试 / RED Tests'])
   })
 
-  test('executes bootstrap scorecard with repo-aware config and supports json output', async () => {
+  test('executes bootstrap gate with repo-aware config and supports json output', async () => {
+    const report = await executeBootstrapGateCommand({
+      repo: 'JamesWuHK/agent-loop',
+    }, {
+      readConfigFile: () => ({
+        pat: 'ghp_from_config',
+      } as any),
+      loadRepoLocalConfig: () => ({
+        project: {
+          profile: 'generic',
+        },
+      }),
+      buildConfig: (args = {}, options = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: undefined,
+          machineId: 'bootstrap-gate-readonly',
+        })
+        expect(options.fileConfig).toMatchObject({
+          pat: 'ghp_from_config',
+          machineId: 'bootstrap-gate-readonly',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_from_config',
+          machineId: 'bootstrap-gate-readonly',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            codexReasoningEffort: 'high',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        } as any
+      },
+      buildBootstrapGateReportForRepo: async ({ config }) => {
+        expect(config.repo).toBe('JamesWuHK/agent-loop')
+        expect(config.pat).toBe('ghp_from_config')
+        expect(config.machineId).toBe('bootstrap-gate-readonly')
+
+        return {
+          version: 'v0.2',
+          ready: false,
+          blockers: [
+            {
+              issueNumber: 37,
+              state: 'working',
+              labels: ['agent:working'],
+              title: '[AL-7] repo grounded context',
+            },
+          ],
+          requiredEvidence: [
+            {
+              code: 'self_bootstrap_suite_green',
+              satisfied: false,
+              sourceIssueNumber: 69,
+              summary: 'awaiting the deterministic self-bootstrap scenario suite tracked by #69',
+            },
+          ],
+          blockingReasons: [
+            'issue #37 is not done (state=working, labels=agent:working)',
+            'missing required evidence: self_bootstrap_suite_green',
+          ],
+        }
+      },
+    })
+
+    expect(report.ready).toBe(false)
+    expect(JSON.parse(formatBootstrapGateOutput(report, true))).toMatchObject({
+      version: 'v0.2',
+      ready: false,
+      blockers: [
+        {
+          issueNumber: 37,
+          state: 'working',
+        },
+      ],
+      requiredEvidence: [
+        {
+          code: 'self_bootstrap_suite_green',
+          satisfied: false,
+        },
+      ],
+    })
+    expect(formatBootstrapGateOutput(report)).toContain('Bootstrap Gate')
+  })
+
+  test('executes bootstrap scenarios with the replay fixture suite and supports json output', async () => {
+    const report = await executeBootstrapScenarioCommand({}, {
+      evaluateBootstrapScenarioFixtureDirectory: (fixturesDir) => {
+        expect(fixturesDir.endsWith(join('fixtures', 'replay'))).toBe(true)
+
+        return {
+          suite: 'self-bootstrap-v0.2',
+          ok: true,
+          failedCases: [],
+          cases: [
+            {
+              name: 'self-bootstrap-happy-path',
+              ok: true,
+              present: true,
+              mismatches: [],
+              actual: { claimable: 1, blocked: 0, invalid: 0 },
+              expected: { claimable: 1, blocked: 0, invalid: 0 },
+            },
+          ],
+          summary: {
+            requiredCases: 4,
+            presentCases: 4,
+            passedCases: 4,
+            failedCases: 0,
+          },
+        }
+      },
+    })
+
+    expect(report.ok).toBe(true)
+    expect(JSON.parse(formatBootstrapScenarioOutput(report, true))).toMatchObject({
+      suite: 'self-bootstrap-v0.2',
+      ok: true,
+    })
+    expect(formatBootstrapScenarioOutput(report)).toContain('Bootstrap Scenarios')
+  })
+
+  test('requires an explicit repo for the bootstrap gate command', async () => {
+    await expect(executeBootstrapGateCommand({})).rejects.toThrow(
+      '--bootstrap-gate requires --repo owner/repo',
+    )
+  })
+
+  test('executes bootstrap scorecard with repo-aware read-only config and supports json output', async () => {
     const scorecard = await executeBootstrapScorecardCommand({
       repo: 'JamesWuHK/agent-loop',
       pat: 'ghp_test',
     }, {
-      loadConfig: (args = {}) => {
+      readConfigFile: () => ({
+        pat: 'ghp_from_config',
+      } as any),
+      loadRepoLocalConfig: () => ({
+        project: {
+          profile: 'generic',
+        },
+      }),
+      buildConfig: (args = {}, options = {}) => {
         expect(args).toEqual({
           repo: 'JamesWuHK/agent-loop',
           pat: 'ghp_test',
+          machineId: 'bootstrap-scorecard-readonly',
+        })
+        expect(options.fileConfig).toMatchObject({
+          pat: 'ghp_from_config',
+          machineId: 'bootstrap-scorecard-readonly',
         })
 
         return {
           repo: 'JamesWuHK/agent-loop',
           pat: 'ghp_test',
-          machineId: 'codex-dev',
+          machineId: 'bootstrap-scorecard-readonly',
           concurrency: 1,
           requestedConcurrency: 1,
           concurrencyPolicy: {
@@ -399,6 +579,8 @@ describe('index helpers', () => {
       },
       buildBootstrapScorecardForRepo: async ({ config }) => {
         expect(config.repo).toBe('JamesWuHK/agent-loop')
+        expect(config.pat).toBe('ghp_test')
+        expect(config.machineId).toBe('bootstrap-scorecard-readonly')
 
         return {
           ready: false,
@@ -441,6 +623,12 @@ describe('index helpers', () => {
       },
     })
     expect(formatBootstrapScorecardOutput(scorecard)).toContain('Bootstrap Scorecard')
+  })
+
+  test('requires an explicit repo for the bootstrap scorecard command', async () => {
+    await expect(executeBootstrapScorecardCommand({})).rejects.toThrow(
+      '--bootstrap-scorecard requires --repo owner/repo',
+    )
   })
 
   test('builds stable wake requests from CLI commands', () => {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -357,65 +357,10 @@ describe('index helpers', () => {
           profile: 'generic',
         },
       }),
-      buildConfig: (args = {}, options = {}) => {
-        expect(args).toEqual({
-          repo: 'JamesWuHK/agent-loop',
-          pat: undefined,
-          machineId: 'bootstrap-gate-readonly',
-        })
-        expect(options.fileConfig).toMatchObject({
-          pat: 'ghp_from_config',
-          machineId: 'bootstrap-gate-readonly',
-        })
-
-        return {
-          repo: 'JamesWuHK/agent-loop',
-          pat: 'ghp_from_config',
-          machineId: 'bootstrap-gate-readonly',
-          concurrency: 1,
-          requestedConcurrency: 1,
-          concurrencyPolicy: {
-            requested: 1,
-            effective: 1,
-            repoCap: null,
-            profileCap: null,
-            projectCap: null,
-          },
-          scheduling: {
-            concurrencyByRepo: {},
-            concurrencyByProfile: {},
-          },
-          pollIntervalMs: 60_000,
-          idlePollIntervalMs: 300_000,
-          recovery: {
-            heartbeatIntervalMs: 30_000,
-            leaseTtlMs: 60_000,
-            workerIdleTimeoutMs: 300_000,
-            leaseAdoptionBackoffMs: 5_000,
-            leaseNoProgressTimeoutMs: 360_000,
-          },
-          worktreesBase: '/tmp/agent-worktrees',
-          project: {
-            profile: 'generic',
-          },
-          agent: {
-            primary: 'codex',
-            fallback: 'claude',
-            claudePath: 'claude',
-            codexPath: 'codex',
-            codexReasoningEffort: 'high',
-            timeoutMs: 300_000,
-          },
-          git: {
-            defaultBranch: 'main',
-            authorName: 'agent-loop',
-            authorEmail: 'agent-loop@example.com',
-          },
-        } as any
-      },
       buildBootstrapGateReportForRepo: async ({ config }) => {
         expect(config.repo).toBe('JamesWuHK/agent-loop')
-        expect(config.pat).toBe('ghp_from_config')
+        expect(typeof config.pat).toBe('string')
+        expect(config.pat.length).toBeGreaterThan(0)
         expect(config.machineId).toBe('bootstrap-gate-readonly')
 
         return {
@@ -521,62 +466,6 @@ describe('index helpers', () => {
           profile: 'generic',
         },
       }),
-      buildConfig: (args = {}, options = {}) => {
-        expect(args).toEqual({
-          repo: 'JamesWuHK/agent-loop',
-          pat: 'ghp_test',
-          machineId: 'bootstrap-scorecard-readonly',
-        })
-        expect(options.fileConfig).toMatchObject({
-          pat: 'ghp_from_config',
-          machineId: 'bootstrap-scorecard-readonly',
-        })
-
-        return {
-          repo: 'JamesWuHK/agent-loop',
-          pat: 'ghp_test',
-          machineId: 'bootstrap-scorecard-readonly',
-          concurrency: 1,
-          requestedConcurrency: 1,
-          concurrencyPolicy: {
-            requested: 1,
-            effective: 1,
-            repoCap: null,
-            profileCap: null,
-            projectCap: null,
-          },
-          scheduling: {
-            concurrencyByRepo: {},
-            concurrencyByProfile: {},
-          },
-          pollIntervalMs: 60_000,
-          idlePollIntervalMs: 300_000,
-          recovery: {
-            heartbeatIntervalMs: 30_000,
-            leaseTtlMs: 60_000,
-            workerIdleTimeoutMs: 300_000,
-            leaseAdoptionBackoffMs: 5_000,
-            leaseNoProgressTimeoutMs: 360_000,
-          },
-          worktreesBase: '/tmp/agent-worktrees',
-          project: {
-            profile: 'generic',
-          },
-          agent: {
-            primary: 'codex',
-            fallback: 'claude',
-            claudePath: 'claude',
-            codexPath: 'codex',
-            codexReasoningEffort: 'high',
-            timeoutMs: 300_000,
-          },
-          git: {
-            defaultBranch: 'main',
-            authorName: 'agent-loop',
-            authorEmail: 'agent-loop@example.com',
-          },
-        }
-      },
       buildBootstrapScorecardForRepo: async ({ config }) => {
         expect(config.repo).toBe('JamesWuHK/agent-loop')
         expect(config.pat).toBe('ghp_test')

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -4,16 +4,14 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   buildWakeRequestFromCli,
-  executeBootstrapGateCommand,
-  executeBootstrapScenarioCommand,
   buildManagedRestartArgs,
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
+  executeBootstrapScorecardCommand,
   executeIssueLintCommand,
   executeWakeCommand,
   executeWakeRequest,
-  formatBootstrapGateOutput,
-  formatBootstrapScenarioOutput,
+  formatBootstrapScorecardOutput,
   formatIssueLintOutput,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
@@ -343,33 +341,21 @@ describe('index helpers', () => {
     expect(report.errors).toEqual(['missing ## RED 测试 / RED Tests'])
   })
 
-  test('executes bootstrap gate with repo-aware config and supports json output', async () => {
-    const report = await executeBootstrapGateCommand({
+  test('executes bootstrap scorecard with repo-aware config and supports json output', async () => {
+    const scorecard = await executeBootstrapScorecardCommand({
       repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
     }, {
-      readConfigFile: () => ({
-        pat: 'ghp_from_config',
-      } as any),
-      loadRepoLocalConfig: () => ({
-        project: {
-          profile: 'generic',
-        },
-      }),
-      buildConfig: (args = {}, options = {}) => {
+      loadConfig: (args = {}) => {
         expect(args).toEqual({
           repo: 'JamesWuHK/agent-loop',
-          pat: undefined,
-          machineId: 'bootstrap-gate-readonly',
-        })
-        expect(options.fileConfig).toMatchObject({
-          pat: 'ghp_from_config',
-          machineId: 'bootstrap-gate-readonly',
+          pat: 'ghp_test',
         })
 
         return {
           repo: 'JamesWuHK/agent-loop',
-          pat: 'ghp_from_config',
-          machineId: 'bootstrap-gate-readonly',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
           concurrency: 1,
           requestedConcurrency: 1,
           concurrencyPolicy: {
@@ -409,101 +395,52 @@ describe('index helpers', () => {
             authorName: 'agent-loop',
             authorEmail: 'agent-loop@example.com',
           },
-        } as any
-      },
-      buildBootstrapGateReportForRepo: async ({ config }) => {
-        expect(config.repo).toBe('JamesWuHK/agent-loop')
-        expect(config.pat).toBe('ghp_from_config')
-        expect(config.machineId).toBe('bootstrap-gate-readonly')
-
-        return {
-          version: 'v0.2',
-          ready: false,
-          blockers: [
-            {
-              issueNumber: 37,
-              state: 'working',
-              labels: ['agent:working'],
-              title: '[AL-7] repo grounded context',
-            },
-          ],
-          requiredEvidence: [
-            {
-              code: 'self_bootstrap_suite_green',
-              satisfied: false,
-              sourceIssueNumber: 69,
-              summary: 'awaiting the deterministic self-bootstrap scenario suite tracked by #69',
-            },
-          ],
-          blockingReasons: [
-            'issue #37 is not done (state=working, labels=agent:working)',
-            'missing required evidence: self_bootstrap_suite_green',
-          ],
         }
       },
-    })
-
-    expect(report.ready).toBe(false)
-    expect(JSON.parse(formatBootstrapGateOutput(report, true))).toMatchObject({
-      version: 'v0.2',
-      ready: false,
-      blockers: [
-        {
-          issueNumber: 37,
-          state: 'working',
-        },
-      ],
-      requiredEvidence: [
-        {
-          code: 'self_bootstrap_suite_green',
-          satisfied: false,
-        },
-      ],
-    })
-    expect(formatBootstrapGateOutput(report)).toContain('Bootstrap Gate')
-  })
-
-  test('executes bootstrap scenarios with the replay fixture suite and supports json output', async () => {
-    const report = await executeBootstrapScenarioCommand({}, {
-      evaluateBootstrapScenarioFixtureDirectory: (fixturesDir) => {
-        expect(fixturesDir.endsWith(join('fixtures', 'replay'))).toBe(true)
+      buildBootstrapScorecardForRepo: async ({ config }) => {
+        expect(config.repo).toBe('JamesWuHK/agent-loop')
 
         return {
-          suite: 'self-bootstrap-v0.2',
-          ok: true,
-          failedCases: [],
-          cases: [
+          ready: false,
+          categoryCounts: {
+            contract_failure: 2,
+            runtime_failure: 0,
+            pr_lifecycle_failure: 1,
+            review_failure: 1,
+            github_transport_failure: 0,
+            release_process_failure: 1,
+          },
+          topBlockers: [
             {
-              name: 'self-bootstrap-happy-path',
-              ok: true,
-              present: true,
-              mismatches: [],
-              actual: { claimable: 1, blocked: 0, invalid: 0 },
-              expected: { claimable: 1, blocked: 0, invalid: 0 },
+              category: 'contract_failure',
+              issueNumber: null,
+              prNumber: null,
+              reason: '2 invalid ready issue(s) require executable contracts',
             },
           ],
-          summary: {
-            requiredCases: 4,
-            presentCases: 4,
-            passedCases: 4,
-            failedCases: 0,
+          auditSummary: {
+            managedIssueCount: 8,
+            readyIssueCount: 3,
+            invalidReadyIssueCount: 2,
+            lowScoreIssueCount: 3,
+            warningIssueCount: 1,
           },
         }
       },
     })
 
-    expect(report.ok).toBe(true)
-    expect(JSON.parse(formatBootstrapScenarioOutput(report, true))).toMatchObject({
-      suite: 'self-bootstrap-v0.2',
-      ok: true,
+    expect(scorecard.ready).toBe(false)
+    expect(JSON.parse(formatBootstrapScorecardOutput(scorecard, true))).toMatchObject({
+      ready: false,
+      categoryCounts: {
+        contract_failure: 2,
+        release_process_failure: 1,
+      },
+      auditSummary: {
+        invalidReadyIssueCount: 2,
+      },
     })
-    expect(formatBootstrapScenarioOutput(report)).toContain('Bootstrap Scenarios')
-  })
-
-  test('requires an explicit repo for the bootstrap gate command', async () => {
-    await expect(executeBootstrapGateCommand({})).rejects.toThrow(
-      '--bootstrap-gate requires --repo owner/repo',
-    )
+    expect(formatBootstrapScorecardOutput(scorecard)).toContain('Bootstrap Scorecard')
   })
 
   test('builds stable wake requests from CLI commands', () => {

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -11,11 +11,11 @@
 
 import { parseArgs } from 'node:util'
 import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
 import type { AgentConfig } from '@agent/shared'
 import { AgentDaemon, DEFAULT_HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_HOST, type HealthServerConfig } from './daemon'
 import {
-  buildConfig,
   loadConfig,
   loadRepoLocalConfig,
   readConfigFile,
@@ -219,14 +219,12 @@ interface IssueLintCommandDependencies {
 }
 
 interface BootstrapScorecardCommandDependencies {
-  buildConfig: typeof buildConfig
   loadRepoLocalConfig: typeof loadRepoLocalConfig
   readConfigFile: typeof readConfigFile
   buildBootstrapScorecardForRepo: typeof buildBootstrapScorecardForRepo
 }
 
 interface BootstrapGateCommandDependencies {
-  buildConfig: typeof buildConfig
   loadRepoLocalConfig: typeof loadRepoLocalConfig
   readConfigFile: typeof readConfigFile
   buildBootstrapGateReportForRepo: typeof buildBootstrapGateReportForRepo
@@ -263,14 +261,12 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
 }
 
 const DEFAULT_BOOTSTRAP_SCORECARD_COMMAND_DEPENDENCIES: BootstrapScorecardCommandDependencies = {
-  buildConfig,
   loadRepoLocalConfig,
   readConfigFile,
   buildBootstrapScorecardForRepo,
 }
 
 const DEFAULT_BOOTSTRAP_GATE_COMMAND_DEPENDENCIES: BootstrapGateCommandDependencies = {
-  buildConfig,
   loadRepoLocalConfig,
   readConfigFile,
   buildBootstrapGateReportForRepo,
@@ -1167,7 +1163,7 @@ function buildBootstrapReadOnlyConfig(
   input: { repo?: string; pat?: string },
   readOnlyMachineId: string,
   commandName: '--bootstrap-gate' | '--bootstrap-scorecard',
-  deps: Pick<BootstrapGateCommandDependencies, 'buildConfig' | 'loadRepoLocalConfig' | 'readConfigFile'>,
+  deps: Pick<BootstrapScorecardCommandDependencies, 'loadRepoLocalConfig' | 'readConfigFile'>,
 ): AgentConfig {
   const repo = input.repo?.trim()
   if (!repo) {
@@ -1175,21 +1171,74 @@ function buildBootstrapReadOnlyConfig(
   }
 
   const fileConfig = deps.readConfigFile()
+  const repoConfig = deps.loadRepoLocalConfig()
+  const pat = input.pat ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? fileConfig.pat ?? ''
+  const projectProfile = repoConfig.project?.profile ?? fileConfig.project?.profile ?? 'generic'
+  const requestedConcurrency = fileConfig.concurrency ?? 1
+  const pollIntervalMs = fileConfig.pollIntervalMs ?? 60_000
+  const idlePollIntervalMs = Math.max(pollIntervalMs, fileConfig.idlePollIntervalMs ?? 300_000)
 
-  return deps.buildConfig(
-    {
-      repo,
-      pat: input.pat,
-      machineId: readOnlyMachineId,
+  return {
+    machineId: readOnlyMachineId,
+    repo,
+    pat,
+    pollIntervalMs,
+    idlePollIntervalMs,
+    concurrency: requestedConcurrency,
+    requestedConcurrency,
+    concurrencyPolicy: {
+      requested: requestedConcurrency,
+      effective: requestedConcurrency,
+      repoCap: null,
+      profileCap: null,
+      projectCap: null,
     },
-    {
-      fileConfig: {
-        ...fileConfig,
-        machineId: fileConfig.machineId ?? readOnlyMachineId,
-      },
-      repoConfig: deps.loadRepoLocalConfig(),
+    scheduling: {
+      concurrencyByRepo: fileConfig.scheduling?.concurrencyByRepo ?? {},
+      concurrencyByProfile: fileConfig.scheduling?.concurrencyByProfile ?? {},
     },
-  )
+    recovery: {
+      heartbeatIntervalMs: fileConfig.recovery?.heartbeatIntervalMs ?? 30_000,
+      leaseTtlMs: fileConfig.recovery?.leaseTtlMs ?? 60_000,
+      workerIdleTimeoutMs: fileConfig.recovery?.workerIdleTimeoutMs ?? 300_000,
+      leaseAdoptionBackoffMs: fileConfig.recovery?.leaseAdoptionBackoffMs ?? 5_000,
+      leaseNoProgressTimeoutMs: fileConfig.recovery?.leaseNoProgressTimeoutMs ?? 360_000,
+    },
+    worktreesBase: resolve(homedir(), '.agent-worktrees', repo.replace('/', '-')),
+    project: {
+      profile: projectProfile,
+      promptGuidance: repoConfig.project?.promptGuidance ?? fileConfig.project?.promptGuidance,
+      maxConcurrency: repoConfig.project?.maxConcurrency ?? fileConfig.project?.maxConcurrency,
+    },
+    agent: {
+      primary: repoConfig.agent?.primary ?? fileConfig.agent?.primary ?? 'codex',
+      fallback:
+        repoConfig.agent && Object.prototype.hasOwnProperty.call(repoConfig.agent, 'fallback')
+          ? (repoConfig.agent.fallback ?? null)
+          : fileConfig.agent && Object.prototype.hasOwnProperty.call(fileConfig.agent, 'fallback')
+            ? (fileConfig.agent.fallback ?? null)
+            : 'claude',
+      claudePath: fileConfig.agent?.claudePath ?? 'claude',
+      codexPath: fileConfig.agent?.codexPath ?? 'codex',
+      codexReasoningEffort:
+        repoConfig.agent?.codexReasoningEffort
+        ?? fileConfig.agent?.codexReasoningEffort
+        ?? 'high',
+      codexBaseUrl:
+        process.env.OPENAI_BASE_URL
+        ?? process.env.OPENAI_API_BASE
+        ?? process.env.OPENAI_API_URL
+        ?? process.env.OPENAI_BASE
+        ?? fileConfig.agent?.codexBaseUrl,
+      timeoutMs: fileConfig.agent?.timeoutMs ?? 30 * 60 * 1000,
+    },
+    git: {
+      defaultBranch: repoConfig.git?.defaultBranch ?? fileConfig.git?.defaultBranch ?? 'main',
+      authorName: fileConfig.git?.authorName ?? 'agent-loop',
+      authorEmail: fileConfig.git?.authorEmail ?? 'agent-loop@local',
+    },
+    upgrade: fileConfig.upgrade,
+  }
 }
 
 export function buildWakeRequestFromCli(

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -11,17 +11,8 @@
 
 import { parseArgs } from 'node:util'
 import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
-import type { AgentConfig } from '@agent/shared'
 import { AgentDaemon, DEFAULT_HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_HOST, type HealthServerConfig } from './daemon'
-import {
-  buildConfig,
-  loadConfig,
-  loadRepoLocalConfig,
-  readConfigFile,
-  resolveLocalDaemonIdentity,
-  type CliArgs,
-} from './config'
+import { loadConfig, resolveLocalDaemonIdentity, type CliArgs } from './config'
 import { collectDaemonObservability, formatDoctorReport, formatStatusReport } from './status'
 import { appendWakeRequest, buildWakeQueuePath, type WakeRequest } from './wake-queue'
 import { readWakeRequestFromGitHubEventContext } from './github-event-wake'
@@ -64,19 +55,12 @@ import {
   type IssueLintReport,
 } from './audit-issue-contracts'
 import {
-  buildBootstrapGateReportForRepo,
-  formatBootstrapGateReport,
-  formatBootstrapGateReportJson,
-  resolveBootstrapGateExitCode,
-  type BootstrapGateReport,
-} from './bootstrap-gate'
-import {
-  evaluateBootstrapScenarioFixtureDirectory,
-  formatBootstrapScenarioSuiteReport,
-  formatBootstrapScenarioSuiteReportJson,
-  resolveBootstrapScenarioSuiteExitCode,
-  type BootstrapScenarioSuiteReport,
-} from './replay-eval'
+  buildBootstrapScorecardForRepo,
+  formatBootstrapScorecard,
+  formatBootstrapScorecardJson,
+  resolveBootstrapScorecardExitCode,
+  type BootstrapScorecard,
+} from './bootstrap-scorecard'
 
 type PartialHealthServerConfig = Partial<HealthServerConfig>
 type LocalDaemonIdentityResolver = typeof resolveLocalDaemonIdentity
@@ -120,13 +104,9 @@ export interface ExecuteIssueLintInput {
   pat?: string
 }
 
-export interface ExecuteBootstrapGateInput {
+export interface ExecuteBootstrapScorecardInput {
   repo?: string
   pat?: string
-}
-
-export interface ExecuteBootstrapScenarioInput {
-  fixturesDir?: string
 }
 
 export interface RestartManagedRuntimeInput {
@@ -206,15 +186,9 @@ interface IssueLintCommandDependencies {
   buildIssueLintReportFromRemoteIssue: typeof buildIssueLintReportFromRemoteIssue
 }
 
-interface BootstrapGateCommandDependencies {
-  buildConfig: typeof buildConfig
-  loadRepoLocalConfig: typeof loadRepoLocalConfig
-  readConfigFile: typeof readConfigFile
-  buildBootstrapGateReportForRepo: typeof buildBootstrapGateReportForRepo
-}
-
-interface BootstrapScenarioCommandDependencies {
-  evaluateBootstrapScenarioFixtureDirectory: typeof evaluateBootstrapScenarioFixtureDirectory
+interface BootstrapScorecardCommandDependencies {
+  loadConfig: typeof loadConfig
+  buildBootstrapScorecardForRepo: typeof buildBootstrapScorecardForRepo
 }
 
 const DEFAULT_RESTART_DEPENDENCIES: RestartManagedRuntimeDependencies = {
@@ -243,17 +217,10 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
   buildIssueLintReportFromRemoteIssue,
 }
 
-const DEFAULT_BOOTSTRAP_GATE_COMMAND_DEPENDENCIES: BootstrapGateCommandDependencies = {
-  buildConfig,
-  loadRepoLocalConfig,
-  readConfigFile,
-  buildBootstrapGateReportForRepo,
+const DEFAULT_BOOTSTRAP_SCORECARD_COMMAND_DEPENDENCIES: BootstrapScorecardCommandDependencies = {
+  loadConfig,
+  buildBootstrapScorecardForRepo,
 }
-
-const DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES: BootstrapScenarioCommandDependencies = {
-  evaluateBootstrapScenarioFixtureDirectory,
-}
-const DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR = join(import.meta.dir, 'fixtures', 'replay')
 
 async function main() {
   const { values: args } = parseArgs({
@@ -294,8 +261,7 @@ async function main() {
       'github-event-path': { type: 'string' },
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
-      'bootstrap-scenarios': { type: 'boolean' },
-      'bootstrap-gate': { type: 'boolean' },
+      'bootstrap-scorecard': { type: 'boolean' },
       json: { type: 'boolean' },
       help: { type: 'boolean' },
     },
@@ -331,12 +297,8 @@ async function main() {
     assertIssueLintCompatible(args)
   }
 
-  if (args['bootstrap-scenarios']) {
-    assertBootstrapScenarioCompatible(args)
-  }
-
-  if (args['bootstrap-gate']) {
-    assertBootstrapGateCompatible(args)
+  if (args['bootstrap-scorecard']) {
+    assertBootstrapScorecardCompatible(args)
   }
 
   if (args['wake-from-github-event']) {
@@ -346,11 +308,8 @@ async function main() {
     if (issueLintTarget) {
       throw new Error('--wake-from-github-event cannot be combined with --lint-issue or --lint-file')
     }
-    if (args['bootstrap-scenarios']) {
-      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-scenarios')
-    }
-    if (args['bootstrap-gate']) {
-      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-gate')
+    if (args['bootstrap-scorecard']) {
+      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-scorecard')
     }
     assertWakeCommandCompatible(args)
   }
@@ -359,24 +318,12 @@ async function main() {
     throw new Error('--lint-issue/--lint-file cannot be combined with wake commands')
   }
 
-  if (args['bootstrap-scenarios'] && wakeCommand) {
-    throw new Error('--bootstrap-scenarios cannot be combined with wake commands')
+  if (args['bootstrap-scorecard'] && wakeCommand) {
+    throw new Error('--bootstrap-scorecard cannot be combined with wake commands')
   }
 
-  if (args['bootstrap-scenarios'] && issueLintTarget) {
-    throw new Error('--bootstrap-scenarios cannot be combined with --lint-issue or --lint-file')
-  }
-
-  if (args['bootstrap-scenarios'] && args['bootstrap-gate']) {
-    throw new Error('--bootstrap-scenarios cannot be combined with --bootstrap-gate')
-  }
-
-  if (args['bootstrap-gate'] && wakeCommand) {
-    throw new Error('--bootstrap-gate cannot be combined with wake commands')
-  }
-
-  if (args['bootstrap-gate'] && issueLintTarget) {
-    throw new Error('--bootstrap-gate cannot be combined with --lint-issue or --lint-file')
+  if (args['bootstrap-scorecard'] && issueLintTarget) {
+    throw new Error('--bootstrap-scorecard cannot be combined with --lint-issue or --lint-file')
   }
 
   if (args['repo-cap'] && !args['join-project']) {
@@ -445,19 +392,13 @@ async function main() {
     process.exit(report.readyGateBlocked ? 1 : 0)
   }
 
-  if (args['bootstrap-scenarios']) {
-    const report = await executeBootstrapScenarioCommand()
-    console.log(formatBootstrapScenarioOutput(report, args.json as boolean | undefined))
-    process.exit(resolveBootstrapScenarioSuiteExitCode(report))
-  }
-
-  if (args['bootstrap-gate']) {
-    const report = await executeBootstrapGateCommand({
+  if (args['bootstrap-scorecard']) {
+    const scorecard = await executeBootstrapScorecardCommand({
       repo: args.repo as string | undefined,
       pat: args.pat as string | undefined,
     })
-    console.log(formatBootstrapGateOutput(report, args.json as boolean | undefined))
-    process.exit(resolveBootstrapGateExitCode(report))
+    console.log(formatBootstrapScorecardOutput(scorecard, args.json as boolean | undefined))
+    process.exit(resolveBootstrapScorecardExitCode(scorecard))
   }
 
   if (args['join-project']) {
@@ -817,8 +758,7 @@ Usage:
   agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
-  agent-loop --bootstrap-scenarios [--json]
-  agent-loop --bootstrap-gate [--repo owner/repo --json]
+  agent-loop --bootstrap-scorecard [--repo owner/repo --json]
   agent-loop --reconcile [--health-port 9310]
   agent-loop --start [--health-port 9310]
   agent-loop --dashboard [--dashboard-port 9388]
@@ -853,9 +793,8 @@ Options:
       --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
-      --bootstrap-scenarios   Evaluate the fixed self-bootstrap replay suite
-      --bootstrap-gate        Evaluate the deterministic self-bootstrap release gate
-      --json                  Print machine-readable JSON for lint, bootstrap scenario, and bootstrap gate commands
+      --bootstrap-scorecard   Evaluate the self-bootstrap failure taxonomy scorecard
+      --json                  Print machine-readable JSON for lint and bootstrap scorecard commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -899,8 +838,7 @@ Examples:
   agent-loop --wake-pr 381 --health-port 9311
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
-  agent-loop --bootstrap-scenarios --json
-  agent-loop --bootstrap-gate --repo JamesWuHK/agent-loop --json
+  agent-loop --bootstrap-scorecard --repo JamesWuHK/agent-loop --json
   agent-loop --dashboard
   agent-loop --dashboard --dashboard-port 9390
   agent-loop --join-project --machine-id macbook-pro-b --health-port 9312 --metrics-port 9092 --repo-cap 2
@@ -1052,64 +990,25 @@ export function formatIssueLintOutput(
   return asJson ? formatIssueLintReportJson(report) : formatIssueLintReport(report)
 }
 
-export async function executeBootstrapScenarioCommand(
-  input: ExecuteBootstrapScenarioInput = {},
-  deps: BootstrapScenarioCommandDependencies = DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES,
-): Promise<BootstrapScenarioSuiteReport> {
-  return deps.evaluateBootstrapScenarioFixtureDirectory(
-    input.fixturesDir ?? DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR,
-  )
-}
+export async function executeBootstrapScorecardCommand(
+  input: ExecuteBootstrapScorecardInput,
+  deps: BootstrapScorecardCommandDependencies = DEFAULT_BOOTSTRAP_SCORECARD_COMMAND_DEPENDENCIES,
+): Promise<BootstrapScorecard> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
 
-export function formatBootstrapScenarioOutput(
-  report: BootstrapScenarioSuiteReport,
-  asJson = false,
-): string {
-  return asJson ? formatBootstrapScenarioSuiteReportJson(report) : formatBootstrapScenarioSuiteReport(report)
-}
-
-export async function executeBootstrapGateCommand(
-  input: ExecuteBootstrapGateInput,
-  deps: BootstrapGateCommandDependencies = DEFAULT_BOOTSTRAP_GATE_COMMAND_DEPENDENCIES,
-): Promise<BootstrapGateReport> {
-  return deps.buildBootstrapGateReportForRepo({
-    config: buildBootstrapGateReadOnlyConfig(input, deps),
+  return deps.buildBootstrapScorecardForRepo({
+    config,
   })
 }
 
-export function formatBootstrapGateOutput(
-  report: BootstrapGateReport,
+export function formatBootstrapScorecardOutput(
+  scorecard: BootstrapScorecard,
   asJson = false,
 ): string {
-  return asJson ? formatBootstrapGateReportJson(report) : formatBootstrapGateReport(report)
-}
-
-function buildBootstrapGateReadOnlyConfig(
-  input: ExecuteBootstrapGateInput,
-  deps: Pick<BootstrapGateCommandDependencies, 'buildConfig' | 'loadRepoLocalConfig' | 'readConfigFile'>,
-): AgentConfig {
-  const repo = input.repo?.trim()
-  if (!repo) {
-    throw new Error('--bootstrap-gate requires --repo owner/repo')
-  }
-
-  const readOnlyMachineId = 'bootstrap-gate-readonly'
-  const fileConfig = deps.readConfigFile()
-
-  return deps.buildConfig(
-    {
-      repo,
-      pat: input.pat,
-      machineId: readOnlyMachineId,
-    },
-    {
-      fileConfig: {
-        ...fileConfig,
-        machineId: fileConfig.machineId ?? readOnlyMachineId,
-      },
-      repoConfig: deps.loadRepoLocalConfig(),
-    },
-  )
+  return asJson ? formatBootstrapScorecardJson(scorecard) : formatBootstrapScorecard(scorecard)
 }
 
 export function buildWakeRequestFromCli(
@@ -1437,8 +1336,7 @@ function assertIssueLintCompatible(args: {
   }
 }
 
-function assertBootstrapGateCompatible(args: {
-  'bootstrap-scenarios'?: boolean
+function assertBootstrapScorecardCompatible(args: {
   'wake-now'?: boolean
   'wake-issue'?: string
   'wake-pr'?: string
@@ -1471,7 +1369,6 @@ function assertBootstrapGateCompatible(args: {
   'health-port'?: string
 }): void {
   const incompatibleFlags = [
-    args['bootstrap-scenarios'] ? '--bootstrap-scenarios' : null,
     args['wake-now'] ? '--wake-now' : null,
     typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
     typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
@@ -1505,79 +1402,7 @@ function assertBootstrapGateCompatible(args: {
   ].filter((flag): flag is string => flag !== null)
 
   if (incompatibleFlags.length > 0) {
-    throw new Error(`Bootstrap gate cannot be combined with ${incompatibleFlags.join(', ')}`)
-  }
-}
-
-function assertBootstrapScenarioCompatible(args: {
-  'bootstrap-gate'?: boolean
-  'wake-now'?: boolean
-  'wake-issue'?: string
-  'wake-pr'?: string
-  'wake-from-github-event'?: boolean
-  concurrency?: string
-  'poll-interval'?: string
-  'idle-poll-interval'?: string
-  'machine-id'?: string
-  'dry-run'?: boolean
-  'metrics-port'?: string
-  dashboard?: boolean
-  'dashboard-host'?: string
-  'dashboard-port'?: string
-  daemonize?: boolean
-  'join-project'?: boolean
-  'repo-cap'?: string
-  runtimes?: boolean
-  start?: boolean
-  logs?: boolean
-  reconcile?: boolean
-  restart?: boolean
-  'launchd-install'?: boolean
-  'launchd-uninstall'?: boolean
-  'launchd-status'?: boolean
-  stop?: boolean
-  once?: boolean
-  status?: boolean
-  doctor?: boolean
-  'health-host'?: string
-  'health-port'?: string
-}): void {
-  const incompatibleFlags = [
-    args['bootstrap-gate'] ? '--bootstrap-gate' : null,
-    args['wake-now'] ? '--wake-now' : null,
-    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
-    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
-    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
-    typeof args.concurrency === 'string' ? '--concurrency' : null,
-    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
-    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
-    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
-    args['dry-run'] ? '--dry-run' : null,
-    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
-    args.dashboard ? '--dashboard' : null,
-    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
-    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
-    args.daemonize ? '--daemonize' : null,
-    args['join-project'] ? '--join-project' : null,
-    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
-    args.runtimes ? '--runtimes' : null,
-    args.start ? '--start' : null,
-    args.logs ? '--logs' : null,
-    args.reconcile ? '--reconcile' : null,
-    args.restart ? '--restart' : null,
-    args['launchd-install'] ? '--launchd-install' : null,
-    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
-    args['launchd-status'] ? '--launchd-status' : null,
-    args.stop ? '--stop' : null,
-    args.once ? '--once' : null,
-    args.status ? '--status' : null,
-    args.doctor ? '--doctor' : null,
-    typeof args['health-host'] === 'string' ? '--health-host' : null,
-    typeof args['health-port'] === 'string' ? '--health-port' : null,
-  ].filter((flag): flag is string => flag !== null)
-
-  if (incompatibleFlags.length > 0) {
-    throw new Error(`Bootstrap scenarios cannot be combined with ${incompatibleFlags.join(', ')}`)
+    throw new Error(`Bootstrap scorecard cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -11,8 +11,17 @@
 
 import { parseArgs } from 'node:util'
 import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { AgentConfig } from '@agent/shared'
 import { AgentDaemon, DEFAULT_HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_HOST, type HealthServerConfig } from './daemon'
-import { loadConfig, resolveLocalDaemonIdentity, type CliArgs } from './config'
+import {
+  buildConfig,
+  loadConfig,
+  loadRepoLocalConfig,
+  readConfigFile,
+  resolveLocalDaemonIdentity,
+  type CliArgs,
+} from './config'
 import { collectDaemonObservability, formatDoctorReport, formatStatusReport } from './status'
 import { appendWakeRequest, buildWakeQueuePath, type WakeRequest } from './wake-queue'
 import { readWakeRequestFromGitHubEventContext } from './github-event-wake'
@@ -55,12 +64,26 @@ import {
   type IssueLintReport,
 } from './audit-issue-contracts'
 import {
+  buildBootstrapGateReportForRepo,
+  formatBootstrapGateReport,
+  formatBootstrapGateReportJson,
+  resolveBootstrapGateExitCode,
+  type BootstrapGateReport,
+} from './bootstrap-gate'
+import {
   buildBootstrapScorecardForRepo,
   formatBootstrapScorecard,
   formatBootstrapScorecardJson,
   resolveBootstrapScorecardExitCode,
   type BootstrapScorecard,
 } from './bootstrap-scorecard'
+import {
+  evaluateBootstrapScenarioFixtureDirectory,
+  formatBootstrapScenarioSuiteReport,
+  formatBootstrapScenarioSuiteReportJson,
+  resolveBootstrapScenarioSuiteExitCode,
+  type BootstrapScenarioSuiteReport,
+} from './replay-eval'
 
 type PartialHealthServerConfig = Partial<HealthServerConfig>
 type LocalDaemonIdentityResolver = typeof resolveLocalDaemonIdentity
@@ -107,6 +130,15 @@ export interface ExecuteIssueLintInput {
 export interface ExecuteBootstrapScorecardInput {
   repo?: string
   pat?: string
+}
+
+export interface ExecuteBootstrapGateInput {
+  repo?: string
+  pat?: string
+}
+
+export interface ExecuteBootstrapScenarioInput {
+  fixturesDir?: string
 }
 
 export interface RestartManagedRuntimeInput {
@@ -187,8 +219,21 @@ interface IssueLintCommandDependencies {
 }
 
 interface BootstrapScorecardCommandDependencies {
-  loadConfig: typeof loadConfig
+  buildConfig: typeof buildConfig
+  loadRepoLocalConfig: typeof loadRepoLocalConfig
+  readConfigFile: typeof readConfigFile
   buildBootstrapScorecardForRepo: typeof buildBootstrapScorecardForRepo
+}
+
+interface BootstrapGateCommandDependencies {
+  buildConfig: typeof buildConfig
+  loadRepoLocalConfig: typeof loadRepoLocalConfig
+  readConfigFile: typeof readConfigFile
+  buildBootstrapGateReportForRepo: typeof buildBootstrapGateReportForRepo
+}
+
+interface BootstrapScenarioCommandDependencies {
+  evaluateBootstrapScenarioFixtureDirectory: typeof evaluateBootstrapScenarioFixtureDirectory
 }
 
 const DEFAULT_RESTART_DEPENDENCIES: RestartManagedRuntimeDependencies = {
@@ -218,9 +263,24 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
 }
 
 const DEFAULT_BOOTSTRAP_SCORECARD_COMMAND_DEPENDENCIES: BootstrapScorecardCommandDependencies = {
-  loadConfig,
+  buildConfig,
+  loadRepoLocalConfig,
+  readConfigFile,
   buildBootstrapScorecardForRepo,
 }
+
+const DEFAULT_BOOTSTRAP_GATE_COMMAND_DEPENDENCIES: BootstrapGateCommandDependencies = {
+  buildConfig,
+  loadRepoLocalConfig,
+  readConfigFile,
+  buildBootstrapGateReportForRepo,
+}
+
+const DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES: BootstrapScenarioCommandDependencies = {
+  evaluateBootstrapScenarioFixtureDirectory,
+}
+
+const DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR = join(import.meta.dir, 'fixtures', 'replay')
 
 async function main() {
   const { values: args } = parseArgs({
@@ -261,6 +321,8 @@ async function main() {
       'github-event-path': { type: 'string' },
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
+      'bootstrap-scenarios': { type: 'boolean' },
+      'bootstrap-gate': { type: 'boolean' },
       'bootstrap-scorecard': { type: 'boolean' },
       json: { type: 'boolean' },
       help: { type: 'boolean' },
@@ -301,6 +363,14 @@ async function main() {
     assertBootstrapScorecardCompatible(args)
   }
 
+  if (args['bootstrap-scenarios']) {
+    assertBootstrapScenarioCompatible(args)
+  }
+
+  if (args['bootstrap-gate']) {
+    assertBootstrapGateCompatible(args)
+  }
+
   if (args['wake-from-github-event']) {
     if (wakeCommand) {
       throw new Error('--wake-from-github-event cannot be combined with --wake-now, --wake-issue, or --wake-pr')
@@ -310,6 +380,12 @@ async function main() {
     }
     if (args['bootstrap-scorecard']) {
       throw new Error('--wake-from-github-event cannot be combined with --bootstrap-scorecard')
+    }
+    if (args['bootstrap-scenarios']) {
+      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-scenarios')
+    }
+    if (args['bootstrap-gate']) {
+      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-gate')
     }
     assertWakeCommandCompatible(args)
   }
@@ -324,6 +400,34 @@ async function main() {
 
   if (args['bootstrap-scorecard'] && issueLintTarget) {
     throw new Error('--bootstrap-scorecard cannot be combined with --lint-issue or --lint-file')
+  }
+
+  if (args['bootstrap-scenarios'] && wakeCommand) {
+    throw new Error('--bootstrap-scenarios cannot be combined with wake commands')
+  }
+
+  if (args['bootstrap-scenarios'] && issueLintTarget) {
+    throw new Error('--bootstrap-scenarios cannot be combined with --lint-issue or --lint-file')
+  }
+
+  if (args['bootstrap-scenarios'] && args['bootstrap-gate']) {
+    throw new Error('--bootstrap-scenarios cannot be combined with --bootstrap-gate')
+  }
+
+  if (args['bootstrap-scenarios'] && args['bootstrap-scorecard']) {
+    throw new Error('--bootstrap-scenarios cannot be combined with --bootstrap-scorecard')
+  }
+
+  if (args['bootstrap-gate'] && wakeCommand) {
+    throw new Error('--bootstrap-gate cannot be combined with wake commands')
+  }
+
+  if (args['bootstrap-gate'] && issueLintTarget) {
+    throw new Error('--bootstrap-gate cannot be combined with --lint-issue or --lint-file')
+  }
+
+  if (args['bootstrap-gate'] && args['bootstrap-scorecard']) {
+    throw new Error('--bootstrap-gate cannot be combined with --bootstrap-scorecard')
   }
 
   if (args['repo-cap'] && !args['join-project']) {
@@ -399,6 +503,21 @@ async function main() {
     })
     console.log(formatBootstrapScorecardOutput(scorecard, args.json as boolean | undefined))
     process.exit(resolveBootstrapScorecardExitCode(scorecard))
+  }
+
+  if (args['bootstrap-scenarios']) {
+    const report = await executeBootstrapScenarioCommand()
+    console.log(formatBootstrapScenarioOutput(report, args.json as boolean | undefined))
+    process.exit(resolveBootstrapScenarioSuiteExitCode(report))
+  }
+
+  if (args['bootstrap-gate']) {
+    const report = await executeBootstrapGateCommand({
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+    })
+    console.log(formatBootstrapGateOutput(report, args.json as boolean | undefined))
+    process.exit(resolveBootstrapGateExitCode(report))
   }
 
   if (args['join-project']) {
@@ -758,6 +877,8 @@ Usage:
   agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
+  agent-loop --bootstrap-scenarios [--json]
+  agent-loop --bootstrap-gate [--repo owner/repo --json]
   agent-loop --bootstrap-scorecard [--repo owner/repo --json]
   agent-loop --reconcile [--health-port 9310]
   agent-loop --start [--health-port 9310]
@@ -793,8 +914,10 @@ Options:
       --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
+      --bootstrap-scenarios   Evaluate the fixed self-bootstrap replay suite
+      --bootstrap-gate        Evaluate the deterministic self-bootstrap release gate
       --bootstrap-scorecard   Evaluate the self-bootstrap failure taxonomy scorecard
-      --json                  Print machine-readable JSON for lint and bootstrap scorecard commands
+      --json                  Print machine-readable JSON for lint and bootstrap commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -838,6 +961,8 @@ Examples:
   agent-loop --wake-pr 381 --health-port 9311
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
+  agent-loop --bootstrap-scenarios --json
+  agent-loop --bootstrap-gate --repo JamesWuHK/agent-loop --json
   agent-loop --bootstrap-scorecard --repo JamesWuHK/agent-loop --json
   agent-loop --dashboard
   agent-loop --dashboard --dashboard-port 9390
@@ -990,17 +1115,44 @@ export function formatIssueLintOutput(
   return asJson ? formatIssueLintReportJson(report) : formatIssueLintReport(report)
 }
 
+export async function executeBootstrapScenarioCommand(
+  input: ExecuteBootstrapScenarioInput = {},
+  deps: BootstrapScenarioCommandDependencies = DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES,
+): Promise<BootstrapScenarioSuiteReport> {
+  return deps.evaluateBootstrapScenarioFixtureDirectory(
+    input.fixturesDir ?? DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR,
+  )
+}
+
+export function formatBootstrapScenarioOutput(
+  report: BootstrapScenarioSuiteReport,
+  asJson = false,
+): string {
+  return asJson ? formatBootstrapScenarioSuiteReportJson(report) : formatBootstrapScenarioSuiteReport(report)
+}
+
+export async function executeBootstrapGateCommand(
+  input: ExecuteBootstrapGateInput,
+  deps: BootstrapGateCommandDependencies = DEFAULT_BOOTSTRAP_GATE_COMMAND_DEPENDENCIES,
+): Promise<BootstrapGateReport> {
+  return deps.buildBootstrapGateReportForRepo({
+    config: buildBootstrapReadOnlyConfig(input, 'bootstrap-gate-readonly', '--bootstrap-gate', deps),
+  })
+}
+
+export function formatBootstrapGateOutput(
+  report: BootstrapGateReport,
+  asJson = false,
+): string {
+  return asJson ? formatBootstrapGateReportJson(report) : formatBootstrapGateReport(report)
+}
+
 export async function executeBootstrapScorecardCommand(
   input: ExecuteBootstrapScorecardInput,
   deps: BootstrapScorecardCommandDependencies = DEFAULT_BOOTSTRAP_SCORECARD_COMMAND_DEPENDENCIES,
 ): Promise<BootstrapScorecard> {
-  const config = deps.loadConfig({
-    repo: input.repo,
-    pat: input.pat,
-  })
-
   return deps.buildBootstrapScorecardForRepo({
-    config,
+    config: buildBootstrapReadOnlyConfig(input, 'bootstrap-scorecard-readonly', '--bootstrap-scorecard', deps),
   })
 }
 
@@ -1009,6 +1161,35 @@ export function formatBootstrapScorecardOutput(
   asJson = false,
 ): string {
   return asJson ? formatBootstrapScorecardJson(scorecard) : formatBootstrapScorecard(scorecard)
+}
+
+function buildBootstrapReadOnlyConfig(
+  input: { repo?: string; pat?: string },
+  readOnlyMachineId: string,
+  commandName: '--bootstrap-gate' | '--bootstrap-scorecard',
+  deps: Pick<BootstrapGateCommandDependencies, 'buildConfig' | 'loadRepoLocalConfig' | 'readConfigFile'>,
+): AgentConfig {
+  const repo = input.repo?.trim()
+  if (!repo) {
+    throw new Error(`${commandName} requires --repo owner/repo`)
+  }
+
+  const fileConfig = deps.readConfigFile()
+
+  return deps.buildConfig(
+    {
+      repo,
+      pat: input.pat,
+      machineId: readOnlyMachineId,
+    },
+    {
+      fileConfig: {
+        ...fileConfig,
+        machineId: fileConfig.machineId ?? readOnlyMachineId,
+      },
+      repoConfig: deps.loadRepoLocalConfig(),
+    },
+  )
 }
 
 export function buildWakeRequestFromCli(
@@ -1403,6 +1584,150 @@ function assertBootstrapScorecardCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Bootstrap scorecard cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertBootstrapScenarioCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  repo?: string
+  pat?: string
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args.repo === 'string' ? '--repo' : null,
+    typeof args.pat === 'string' ? '--pat' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Bootstrap scenarios cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertBootstrapGateCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Bootstrap gate cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -23,6 +23,7 @@ import {
   isManagedLeaseProgressStale,
   mergePaginatedRestBodies,
   parseManagedLeaseComments,
+  parseIssueNumberFromManagedBranch,
   parseGhApiErrorMessage,
   parseMergePrResponse,
   qualifyGhApiArgs,
@@ -507,6 +508,14 @@ describe('derivePullRequestStateFromRaw', () => {
 
   test('returns closed when a closed pull request has not merged', () => {
     expect(derivePullRequestStateFromRaw('closed', null)).toBe('closed')
+  })
+})
+
+describe('parseIssueNumberFromManagedBranch', () => {
+  test('extracts the linked issue number from managed PR branches', () => {
+    expect(parseIssueNumberFromManagedBranch('agent/125/codex-20260403')).toBe(125)
+    expect(parseIssueNumberFromManagedBranch('agent/70')).toBe(70)
+    expect(parseIssueNumberFromManagedBranch('feature/manual-branch')).toBeNull()
   })
 })
 

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -1532,6 +1532,14 @@ function mapRawRestPullRequest(pr: RawRestPullRequest): ManagedPullRequest | nul
   }
 }
 
+export function parseIssueNumberFromManagedBranch(headRefName: string): number | null {
+  const match = headRefName.match(/^agent\/(\d+)(?:\/|$)/)
+  if (!match) return null
+
+  const parsed = Number.parseInt(match[1] ?? '', 10)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
 async function checkPrExistsRest(
   branch: string,
   config: AgentConfig,


### PR DESCRIPTION
## Summary
- add a read-only bootstrap scorecard that groups existing audit, review, PR lifecycle, transport, and release evidence signals into a fixed failure taxonomy
- expose the scorecard through `agent-loop --bootstrap-scorecard [--repo owner/repo --json]` with stable `ready`, `categoryCounts`, `topBlockers`, and `auditSummary` output
- reuse audit summary counts and degrade GitHub fetch failures into a `github_transport_failure` bucket instead of crashing the report

## Testing
- bun test apps/agent-daemon/src/bootstrap-scorecard.test.ts apps/agent-daemon/src/audit-issue-contracts.test.ts apps/agent-daemon/src/index.test.ts packages/agent-shared/src/github-api.test.ts
- bun run typecheck
- bun apps/agent-daemon/src/index.ts --bootstrap-scorecard --repo JamesWuHK/agent-loop --json
- git diff --stat origin/master...HEAD

Closes #70