### PR TITLE
Fix #37: [AL-7] 生成 repo-grounded issue authoring context

### DIFF
--- a/apps/agent-daemon/src/issue-authoring-context.test.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.test.ts
@@ -134,6 +134,63 @@ describe('buildRepoAuthoringContext', () => {
     expect(context.candidateAllowedFiles.some((value) => value.startsWith('/'))).toBe(false)
   })
 
+  test('ignores injected manifest paths that resolve outside the repo root', async () => {
+    const sandboxRoot = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-manifests-'))
+    const root = join(sandboxRoot, 'repo')
+    const outsideRoot = join(sandboxRoot, 'outside')
+
+    mkdirSync(join(root, 'apps/web/src/pages'), { recursive: true })
+    mkdirSync(outsideRoot, { recursive: true })
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+      },
+    }))
+    writeFileSync(join(root, 'apps/web/package.json'), JSON.stringify({
+      name: 'web',
+      scripts: {
+        verify: 'bun test src/pages/LoginPage.test.tsx',
+      },
+    }))
+    writeFileSync(join(outsideRoot, 'package.json'), JSON.stringify({
+      name: 'outside',
+      scripts: {
+        lint: 'bun run lint ../secrets.ts',
+      },
+    }))
+
+    const context = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '更新 LoginPage 交互并补测试',
+      repoRelativeFilePaths: [
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/pages/LoginPage.test.tsx',
+        'apps/web/src/App.tsx',
+      ],
+      rootPackageJsonPath: 'package.json',
+      workspacePackageJsonPaths: [
+        'apps/web/package.json',
+        '../outside/package.json',
+      ],
+    })
+
+    expect(context).toEqual({
+      candidateValidationCommands: [
+        'bun test',
+        'bun test apps/web/src/pages/LoginPage.test.tsx',
+      ],
+      candidateAllowedFiles: [
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/pages/LoginPage.test.tsx',
+      ],
+      candidateForbiddenFiles: [
+        'apps/web/src/App.tsx',
+      ],
+    })
+  })
+
   test('keeps allowed and forbidden file ordering stable for unsorted repo-relative inputs', async () => {
     const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-stable-files-'))
     mkdirSync(join(root, 'apps/web'), { recursive: true })

--- a/apps/agent-daemon/src/issue-authoring-context.test.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildRepoAuthoringContext } from './issue-authoring-context'
+
+describe('buildRepoAuthoringContext', () => {
+  test('collects workspace validation commands and repo-relative file candidates from repo scan', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-'))
+    mkdirSync(join(root, 'apps/example/src/pages'), { recursive: true })
+    mkdirSync(join(root, '.agent-loop/drafts'), { recursive: true })
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+        typecheck: 'bun run typecheck',
+      },
+      workspaces: ['apps/*'],
+    }))
+    writeFileSync(join(root, 'apps/example/package.json'), JSON.stringify({
+      name: 'example',
+      scripts: {
+        test: 'bun run --bun test src/pages/LoginPage.test.tsx',
+      },
+    }))
+    writeFileSync(join(root, 'apps/example/src/App.tsx'), 'export function App() { return null }\n')
+    writeFileSync(join(root, 'apps/example/src/main.tsx'), 'export const main = true\n')
+    writeFileSync(join(root, 'apps/example/src/pages/LoginPage.tsx'), 'export function LoginPage() { return null }\n')
+    writeFileSync(join(root, 'apps/example/src/pages/LoginPage.test.tsx'), 'export {}\n')
+    writeFileSync(join(root, '.agent-loop/drafts/LoginPage.tsx'), 'export const ignored = true\n')
+
+    const context = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '修复 LoginPage 的登录重定向，并补上对应测试',
+    })
+
+    expect(context.candidateValidationCommands).toEqual([
+      'bun run --bun test apps/example/src/pages/LoginPage.test.tsx',
+      'bun run typecheck',
+      'bun test',
+    ])
+    expect(context.candidateAllowedFiles).toEqual([
+      'apps/example/src/pages/LoginPage.tsx',
+      'apps/example/src/pages/LoginPage.test.tsx',
+    ])
+    expect(context.candidateForbiddenFiles).toEqual([
+      'apps/example/src/App.tsx',
+      'apps/example/src/main.tsx',
+    ])
+    expect(context.candidateAllowedFiles.some((value) => value.startsWith(root))).toBe(false)
+    expect(context.candidateAllowedFiles.some((value) => value.includes('.agent-loop'))).toBe(false)
+    expect(context.candidateValidationCommands.some((value) => value.startsWith(root))).toBe(false)
+  })
+
+  test('keeps validation command ordering stable across root and injected workspace manifests', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-order-'))
+    mkdirSync(join(root, 'apps/web'), { recursive: true })
+    mkdirSync(join(root, 'packages/shared'), { recursive: true })
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        lint: 'bun run lint',
+        test: 'bun test',
+        typecheck: 'bun run typecheck',
+      },
+    }))
+    writeFileSync(join(root, 'apps/web/package.json'), JSON.stringify({
+      name: 'web',
+      scripts: {
+        test: 'bun run --cwd src/pages test LoginPage.test.tsx',
+      },
+    }))
+    writeFileSync(join(root, 'packages/shared/package.json'), JSON.stringify({
+      name: 'shared',
+      scripts: {
+        verify: 'bun test src/index.test.ts',
+      },
+    }))
+
+    const context = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueTitle: '调整 LoginPage 文案并确认测试',
+      issueBody: '需要补齐登录页回归。',
+      issueText: '',
+      repoRelativeFilePaths: [
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/pages/LoginPage.test.tsx',
+        'packages/shared/src/index.test.ts',
+      ],
+      rootPackageJsonPath: 'package.json',
+      workspacePackageJsonPaths: [
+        'packages/shared/package.json',
+        'apps/web/package.json',
+      ],
+    })
+
+    expect(context.candidateValidationCommands).toEqual([
+      'bun run --cwd apps/web/src/pages test apps/web/src/pages/LoginPage.test.tsx',
+      'bun run lint',
+      'bun run typecheck',
+      'bun test',
+      'bun test packages/shared/src/index.test.ts',
+    ])
+  })
+
+  test('ignores absolute and parent-relative file inputs when ranking candidates', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-paths-'))
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+      },
+    }))
+
+    const context = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '修复 packages/agent-shared/src/project-profile.ts 的提示文案',
+      repoRelativeFilePaths: [
+        '/tmp/escape.ts',
+        '../outside.ts',
+        'packages/agent-shared/src/project-profile.test.ts',
+        'packages/agent-shared/src/project-profile.ts',
+      ],
+      rootPackageJsonPath: 'package.json',
+      workspacePackageJsonPaths: [],
+    })
+
+    expect(context.candidateAllowedFiles).toEqual([
+      'packages/agent-shared/src/project-profile.ts',
+      'packages/agent-shared/src/project-profile.test.ts',
+    ])
+    expect(context.candidateAllowedFiles.some((value) => value.startsWith('/'))).toBe(false)
+  })
+
+  test('keeps allowed and forbidden file ordering stable for unsorted repo-relative inputs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-stable-files-'))
+    mkdirSync(join(root, 'apps/web'), { recursive: true })
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+      },
+    }))
+    writeFileSync(join(root, 'apps/web/package.json'), JSON.stringify({
+      name: 'web',
+      scripts: {
+        verify: 'bun test src/pages/LoginPage.test.tsx',
+      },
+    }))
+
+    const firstContext = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '更新 LoginPage 交互并补测试',
+      repoRelativeFilePaths: [
+        'apps/web/src/pages/LoginPage.test.tsx',
+        'apps/web/src/router.tsx',
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/main.tsx',
+        'apps/web/src/App.tsx',
+      ],
+      rootPackageJsonPath: 'package.json',
+      workspacePackageJsonPaths: ['apps/web/package.json'],
+    })
+
+    const secondContext = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '更新 LoginPage 交互并补测试',
+      repoRelativeFilePaths: [
+        'apps/web/src/main.tsx',
+        'apps/web/src/App.tsx',
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/router.tsx',
+        'apps/web/src/pages/LoginPage.test.tsx',
+      ],
+      rootPackageJsonPath: 'package.json',
+      workspacePackageJsonPaths: ['apps/web/package.json'],
+    })
+
+    expect(firstContext).toEqual(secondContext)
+    expect(firstContext).toEqual({
+      candidateValidationCommands: [
+        'bun test',
+        'bun test apps/web/src/pages/LoginPage.test.tsx',
+      ],
+      candidateAllowedFiles: [
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/pages/LoginPage.test.tsx',
+      ],
+      candidateForbiddenFiles: [
+        'apps/web/src/App.tsx',
+        'apps/web/src/main.tsx',
+        'apps/web/src/router.tsx',
+      ],
+    })
+    expect(firstContext.candidateForbiddenFiles.some((value) => value.startsWith('/'))).toBe(false)
+  })
+})

--- a/apps/agent-daemon/src/issue-authoring-context.test.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.test.ts
@@ -191,6 +191,66 @@ describe('buildRepoAuthoringContext', () => {
     })
   })
 
+  test('ignores root workspace entries that resolve outside the repo root', async () => {
+    const sandboxRoot = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-root-workspaces-'))
+    const root = join(sandboxRoot, 'repo')
+    const outsideRoot = join(sandboxRoot, 'outside')
+
+    mkdirSync(join(root, 'apps/web/src/pages'), { recursive: true })
+    mkdirSync(join(outsideRoot, 'pkg'), { recursive: true })
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+      },
+      workspaces: ['apps/*', '../outside', '../outside/*'],
+    }))
+    writeFileSync(join(root, 'apps/web/package.json'), JSON.stringify({
+      name: 'web',
+      scripts: {
+        verify: 'bun test src/pages/LoginPage.test.tsx',
+      },
+    }))
+    writeFileSync(join(outsideRoot, 'package.json'), JSON.stringify({
+      name: 'outside-root',
+      scripts: {
+        lint: 'bun run lint ../secrets.ts',
+      },
+    }))
+    writeFileSync(join(outsideRoot, 'pkg/package.json'), JSON.stringify({
+      name: 'outside-pkg',
+      scripts: {
+        check: 'bun test ../escape.test.ts',
+      },
+    }))
+
+    const context = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '更新 LoginPage 交互并补测试',
+      repoRelativeFilePaths: [
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/pages/LoginPage.test.tsx',
+        'apps/web/src/App.tsx',
+      ],
+      rootPackageJsonPath: 'package.json',
+    })
+
+    expect(context).toEqual({
+      candidateValidationCommands: [
+        'bun test',
+        'bun test apps/web/src/pages/LoginPage.test.tsx',
+      ],
+      candidateAllowedFiles: [
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/pages/LoginPage.test.tsx',
+      ],
+      candidateForbiddenFiles: [
+        'apps/web/src/App.tsx',
+      ],
+    })
+  })
+
   test('keeps allowed and forbidden file ordering stable for unsorted repo-relative inputs', async () => {
     const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-stable-files-'))
     mkdirSync(join(root, 'apps/web'), { recursive: true })

--- a/apps/agent-daemon/src/issue-authoring-context.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.ts
@@ -1,0 +1,659 @@
+import { existsSync, readdirSync, readFileSync, type Dirent } from 'node:fs'
+import { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
+import type { BuildRepoAuthoringContextInput, RepoAuthoringContext } from '@agent/shared'
+
+interface PackageManifestRecord {
+  scripts?: Record<string, unknown>
+  workspaces?: string[] | { packages?: string[] }
+}
+
+interface PackageManifest {
+  dir: string
+  scripts: Record<string, string>
+}
+
+interface ScoredFileCandidate {
+  path: string
+  score: number
+}
+
+const IGNORED_DIRECTORY_NAMES = new Set([
+  '.agent-loop',
+  '.cache',
+  '.git',
+  '.next',
+  '.runtime',
+  '.turbo',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+])
+
+const VALIDATION_SCRIPT_PATTERN = /\b(test|tests|check|lint|typecheck|build|verify|coverage)\b/i
+const TEST_INTENT_PATTERN = /\b(test|tests|spec|specs|coverage|verify|validation)\b|测试|用例|验证|回归/i
+const SOURCE_FILE_PATTERN = /\.(ts|tsx|js|jsx|mjs|cjs|json|md|py|go|rs|java|kt|swift|rb|php|cs|sh|yaml|yml)$/i
+const BROAD_SCOPE_FILE_PATTERNS = [
+  /(?:^|\/)App\.[^/]+$/i,
+  /(?:^|\/)main\.[^/]+$/i,
+  /(?:^|\/)index\.[^/]+$/i,
+  /(?:^|\/)router\.[^/]+$/i,
+  /(?:^|\/)layout\.[^/]+$/i,
+  /(?:^|\/)api\.[^/]+$/i,
+  /(?:^|\/)daemon\.[^/]+$/i,
+] as const
+
+const MAX_ALLOWED_FILE_CANDIDATES = 8
+const MAX_FORBIDDEN_FILE_CANDIDATES = 8
+
+export async function buildRepoAuthoringContext(
+  input: BuildRepoAuthoringContextInput,
+): Promise<RepoAuthoringContext> {
+  const repoRoot = resolve(input.repoRoot)
+  const packageManifests = collectPackageManifests(
+    repoRoot,
+    input.rootPackageJsonPath,
+    input.workspacePackageJsonPaths,
+  )
+  const repoFiles = input.repoRelativeFilePaths
+    ? sanitizeRepoRelativeFilePaths(repoRoot, input.repoRelativeFilePaths)
+    : collectRepoFiles(repoRoot)
+  const candidateAllowedFiles = collectCandidateAllowedFiles(resolveIssueText(input), repoFiles)
+
+  return {
+    candidateValidationCommands: collectCandidateValidationCommands(repoRoot, packageManifests),
+    candidateAllowedFiles,
+    candidateForbiddenFiles: collectCandidateForbiddenFiles(
+      repoFiles,
+      candidateAllowedFiles,
+      packageManifests.map((manifest) => manifest.dir),
+    ),
+  }
+}
+
+function collectCandidateValidationCommands(
+  repoRoot: string,
+  manifests: PackageManifest[],
+): string[] {
+  const commands = new Set<string>()
+
+  for (const manifest of manifests) {
+    for (const [scriptName, scriptCommand] of Object.entries(manifest.scripts).sort(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      if (!looksLikeValidationScript(scriptName, scriptCommand)) {
+        continue
+      }
+
+      const normalized = normalizeValidationCommand(repoRoot, manifest.dir, scriptCommand)
+      if (normalized) {
+        commands.add(normalized)
+      }
+    }
+  }
+
+  return [...commands].sort((left, right) => left.localeCompare(right))
+}
+
+function looksLikeValidationScript(name: string, command: string): boolean {
+  return VALIDATION_SCRIPT_PATTERN.test(name) || VALIDATION_SCRIPT_PATTERN.test(command)
+}
+
+function normalizeValidationCommand(
+  repoRoot: string,
+  packageDir: string,
+  command: string,
+): string | null {
+  const tokens = tokenizeCommand(command)
+  if (tokens.length === 0) {
+    return null
+  }
+
+  let commandCwd = resolve(repoRoot, packageDir)
+  const normalizedTokens: string[] = []
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = stripWrappingQuotes(tokens[index] ?? '')
+    if (!token) {
+      continue
+    }
+
+    if ((token === '--cwd' || token === '-C' || token === 'cd') && tokens[index + 1]) {
+      const cwdToken = stripWrappingQuotes(tokens[index + 1] ?? '')
+      const resolvedCwd = resolveCommandPath(repoRoot, commandCwd, cwdToken)
+      if (!resolvedCwd) {
+        return null
+      }
+
+      commandCwd = resolvedCwd
+      normalizedTokens.push(token)
+      normalizedTokens.push(toRepoRelativePath(repoRoot, resolvedCwd) || '.')
+      index += 1
+      continue
+    }
+
+    if (looksLikePathToken(token)) {
+      const resolvedPath = resolveCommandPath(repoRoot, commandCwd, token)
+      if (!resolvedPath) {
+        return null
+      }
+
+      normalizedTokens.push(toRepoRelativePath(repoRoot, resolvedPath) || '.')
+      continue
+    }
+
+    normalizedTokens.push(token)
+  }
+
+  return normalizedTokens.join(' ')
+}
+
+function tokenizeCommand(command: string): string[] {
+  return command.match(/"[^"]*"|'[^']*'|\S+/g) ?? []
+}
+
+function stripWrappingQuotes(token: string): string {
+  return token.replace(/^['"]|['"]$/g, '')
+}
+
+function looksLikePathToken(token: string): boolean {
+  if (!token || token.startsWith('-')) {
+    return false
+  }
+
+  if (token.includes('...')) {
+    return false
+  }
+
+  if (token === '.' || token === '..') {
+    return true
+  }
+
+  if (/^[A-Z_][A-Z0-9_]*=/.test(token)) {
+    return false
+  }
+
+  if (/^[A-Za-z0-9_.-]+$/.test(token) && !token.includes('.') && !token.includes('/')) {
+    return false
+  }
+
+  return token.includes('/') || token.includes('\\') || /\.[A-Za-z0-9]+$/.test(token)
+}
+
+function resolveCommandPath(
+  repoRoot: string,
+  commandCwd: string,
+  token: string,
+): string | null {
+  const absolutePath = token.startsWith('/')
+    ? resolve(token)
+    : resolve(commandCwd, token.replace(/\\/g, '/'))
+
+  if (!isPathInsideRepo(repoRoot, absolutePath)) {
+    return null
+  }
+
+  return absolutePath
+}
+
+function collectCandidateAllowedFiles(
+  issueText: string,
+  repoFiles: string[],
+): string[] {
+  const keywords = extractIssueKeywords(issueText)
+  if (keywords.length === 0) {
+    return []
+  }
+
+  const wantsTests = TEST_INTENT_PATTERN.test(issueText)
+  const rankedFiles = repoFiles
+    .map((path) => ({
+      path,
+      score: scoreRepoFile(path, keywords, wantsTests),
+    }))
+    .filter((candidate) => candidate.score > 0)
+    .sort(compareScoredCandidates)
+
+  const orderedCandidates: string[] = []
+  const seen = new Set<string>()
+
+  for (const candidate of rankedFiles) {
+    pushUniquePath(orderedCandidates, seen, candidate.path)
+    for (const related of collectRelatedAllowedFiles(candidate.path, repoFiles, wantsTests)) {
+      pushUniquePath(orderedCandidates, seen, related)
+    }
+
+    if (orderedCandidates.length >= MAX_ALLOWED_FILE_CANDIDATES) {
+      break
+    }
+  }
+
+  return orderedCandidates.slice(0, MAX_ALLOWED_FILE_CANDIDATES)
+}
+
+function compareScoredCandidates(left: ScoredFileCandidate, right: ScoredFileCandidate): number {
+  if (right.score !== left.score) {
+    return right.score - left.score
+  }
+
+  if (isTestFile(left.path) !== isTestFile(right.path)) {
+    return isTestFile(left.path) ? 1 : -1
+  }
+
+  return left.path.localeCompare(right.path)
+}
+
+function scoreRepoFile(
+  path: string,
+  keywords: string[],
+  wantsTests: boolean,
+): number {
+  const normalizedPath = path.toLowerCase()
+  const fileName = basename(normalizedPath)
+  const fileStem = normalizeFileStem(normalizedPath)
+  let score = 0
+
+  for (const keyword of keywords) {
+    if (fileStem === keyword) {
+      score += 24
+      continue
+    }
+
+    if (fileName.startsWith(`${keyword}.`) || fileName.includes(`${keyword}.`)) {
+      score += 18
+      continue
+    }
+
+    if (keyword.length >= 5 && fileName.includes(keyword)) {
+      score += 12
+    } else if (normalizedPath.includes(`/${keyword}/`)) {
+      score += 8
+    } else if (keyword.length >= 5 && normalizedPath.includes(keyword)) {
+      score += 6
+    }
+  }
+
+  if (score > 0 && SOURCE_FILE_PATTERN.test(path)) {
+    score += 1
+  }
+
+  if (isTestFile(path)) {
+    score -= 1
+    if (wantsTests) {
+      score += 1
+    }
+  }
+
+  return score
+}
+
+function collectRelatedAllowedFiles(
+  path: string,
+  repoFiles: string[],
+  wantsTests: boolean,
+): string[] {
+  const targetDirectory = dirname(path)
+  const targetStem = normalizeFileStem(path)
+
+  return repoFiles
+    .filter((candidate) => candidate !== path)
+    .filter((candidate) => dirname(candidate) === targetDirectory)
+    .filter((candidate) => normalizeFileStem(candidate) === targetStem)
+    .filter((candidate) => wantsTests || !isTestFile(candidate))
+    .sort((left, right) => {
+      if (isTestFile(left) !== isTestFile(right)) {
+        return isTestFile(left) ? 1 : -1
+      }
+
+      return left.localeCompare(right)
+    })
+}
+
+function normalizeFileStem(path: string): string {
+  return basename(path, extname(path)).replace(/\.(test|spec)$/i, '')
+}
+
+function isTestFile(path: string): boolean {
+  return /\.(test|spec)\.[^.]+$/i.test(path)
+}
+
+function extractIssueKeywords(issueText: string): string[] {
+  const keywords = new Set<string>()
+
+  for (const match of issueText.matchAll(/[A-Za-z][A-Za-z0-9._-]{1,}/g)) {
+    addKeywordTerms(keywords, match[0])
+  }
+
+  for (const match of issueText.matchAll(/[A-Za-z0-9_.-]+\.[A-Za-z0-9]+/g)) {
+    addKeywordTerms(keywords, match[0])
+  }
+
+  return [...keywords]
+    .filter((value) => value.length >= 2)
+    .sort((left, right) => right.length - left.length || left.localeCompare(right))
+}
+
+function addKeywordTerms(keywords: Set<string>, rawValue: string): void {
+  const normalized = rawValue.trim().replace(/^['"`]+|['"`]+$/g, '')
+  if (!normalized) {
+    return
+  }
+
+  const lowered = normalized.toLowerCase()
+  keywords.add(lowered)
+
+  const withoutExtension = lowered.replace(/\.[a-z0-9]+$/i, '')
+  if (withoutExtension !== lowered) {
+    keywords.add(withoutExtension)
+  }
+
+  const identifierParts = normalized
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[^A-Za-z0-9]+/)
+    .map((part) => part.toLowerCase())
+    .filter((part) => part.length >= 2)
+
+  for (const part of identifierParts) {
+    keywords.add(part)
+  }
+}
+
+function collectCandidateForbiddenFiles(
+  repoFiles: string[],
+  allowedFiles: string[],
+  packageDirs: string[],
+): string[] {
+  if (allowedFiles.length === 0) {
+    return []
+  }
+
+  const relevantPackageDirs = resolveRelevantPackageDirs(allowedFiles, packageDirs)
+  const allowedSet = new Set(allowedFiles)
+
+  return repoFiles
+    .filter((path) => !allowedSet.has(path))
+    .filter((path) => relevantPackageDirs.some((packageDir) =>
+      packageDir === '.' || path.startsWith(`${packageDir}/`),
+    ))
+    .filter((path) => BROAD_SCOPE_FILE_PATTERNS.some((pattern) => pattern.test(path)))
+    .sort((left, right) => left.localeCompare(right))
+    .slice(0, MAX_FORBIDDEN_FILE_CANDIDATES)
+}
+
+function resolveRelevantPackageDirs(
+  allowedFiles: string[],
+  packageDirs: string[],
+): string[] {
+  const sortedPackageDirs = [...packageDirs].sort((left, right) => right.length - left.length)
+  const relevant = new Set<string>()
+
+  for (const allowedFile of allowedFiles) {
+    const matchedPackage = sortedPackageDirs.find((packageDir) =>
+      packageDir === '.' || allowedFile.startsWith(`${packageDir}/`),
+    )
+
+    if (matchedPackage) {
+      relevant.add(matchedPackage)
+    }
+  }
+
+  return [...relevant].sort((left, right) => left.localeCompare(right))
+}
+
+function pushUniquePath(target: string[], seen: Set<string>, path: string): void {
+  if (seen.has(path)) {
+    return
+  }
+
+  seen.add(path)
+  target.push(path)
+}
+
+function resolveIssueText(input: BuildRepoAuthoringContextInput): string {
+  const explicitIssueText = input.issueText.trim()
+  if (explicitIssueText) {
+    return explicitIssueText
+  }
+
+  return [input.issueTitle, input.issueBody]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join('\n')
+}
+
+function sanitizeRepoRelativeFilePaths(
+  repoRoot: string,
+  repoRelativeFilePaths: string[],
+): string[] {
+  const seen = new Set<string>()
+  const sanitized: string[] = []
+
+  for (const value of repoRelativeFilePaths) {
+    const normalized = value.trim().replace(/\\/g, '/').replace(/^\.\/?/, '')
+    if (!normalized || normalized.startsWith('/')) {
+      continue
+    }
+
+    const absolutePath = resolve(repoRoot, normalized)
+    if (!isPathInsideRepo(repoRoot, absolutePath)) {
+      continue
+    }
+
+    const repoRelativePath = toRepoRelativePath(repoRoot, absolutePath)
+    if (seen.has(repoRelativePath)) {
+      continue
+    }
+
+    seen.add(repoRelativePath)
+    sanitized.push(repoRelativePath)
+  }
+
+  return sanitized.sort((left, right) => left.localeCompare(right))
+}
+
+function collectPackageManifests(
+  repoRoot: string,
+  rootPackageJsonPath?: string,
+  workspacePackageJsonPaths?: string[],
+): PackageManifest[] {
+  const explicitRootPackageJsonPath = rootPackageJsonPath?.trim() || 'package.json'
+  const rootPackage = readPackageManifest(join(repoRoot, explicitRootPackageJsonPath))
+  const manifests: PackageManifest[] = []
+  const packageJsonPaths = new Set<string>([explicitRootPackageJsonPath])
+
+  for (const workspacePackageJsonPath of workspacePackageJsonPaths ?? []) {
+    const normalized = workspacePackageJsonPath.trim()
+    if (normalized) {
+      packageJsonPaths.add(normalized)
+    }
+  }
+
+  if (rootPackage) {
+    manifests.push({
+      dir: '.',
+      scripts: rootPackage.scripts,
+    })
+
+    for (const workspaceDir of expandWorkspacePatterns(repoRoot, extractWorkspacePatterns(rootPackage.raw))) {
+      packageJsonPaths.add(join(workspaceDir, 'package.json').replace(/\\/g, '/'))
+    }
+  }
+
+  for (const packageJsonPath of [...packageJsonPaths].sort((left, right) => left.localeCompare(right))) {
+    if (packageJsonPath === explicitRootPackageJsonPath) {
+      continue
+    }
+
+    const manifest = readPackageManifest(join(repoRoot, packageJsonPath))
+    if (!manifest) {
+      continue
+    }
+
+    const packageDir = dirname(packageJsonPath).replace(/\\/g, '/')
+    manifests.push({
+      dir: packageDir === '.' ? '.' : packageDir,
+      scripts: manifest.scripts,
+    })
+  }
+
+  return manifests
+    .filter((manifest, index, allManifests) =>
+      allManifests.findIndex((candidate) => candidate.dir === manifest.dir) === index,
+    )
+    .sort((left, right) => left.dir.localeCompare(right.dir))
+}
+
+function readPackageManifest(path: string): { raw: PackageManifestRecord; scripts: Record<string, string> } | null {
+  const parsed = readJsonFile<PackageManifestRecord>(path)
+  if (!parsed) {
+    return null
+  }
+
+  return {
+    raw: parsed,
+    scripts: toStringRecord(parsed.scripts),
+  }
+}
+
+function readJsonFile<T>(path: string): T | null {
+  if (!existsSync(path)) {
+    return null
+  }
+
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T
+  } catch {
+    return null
+  }
+}
+
+function toStringRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object') {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  )
+}
+
+function extractWorkspacePatterns(manifest: PackageManifestRecord): string[] {
+  if (Array.isArray(manifest.workspaces)) {
+    return manifest.workspaces.filter((value): value is string => typeof value === 'string')
+  }
+
+  const packages = manifest.workspaces?.packages
+  if (!Array.isArray(packages)) {
+    return []
+  }
+
+  return packages.filter((value): value is string => typeof value === 'string')
+}
+
+function expandWorkspacePatterns(repoRoot: string, patterns: string[]): string[] {
+  const matches = new Set<string>()
+
+  for (const pattern of patterns) {
+    const normalizedPattern = pattern.trim().replace(/\\/g, '/').replace(/^\.\/?/, '').replace(/\/$/, '')
+    if (!normalizedPattern) {
+      continue
+    }
+
+    if (!normalizedPattern.includes('*')) {
+      const literalPath = join(repoRoot, normalizedPattern)
+      if (existsSync(join(literalPath, 'package.json'))) {
+        matches.add(normalizedPattern)
+      }
+      continue
+    }
+
+    const segments = normalizedPattern.split('/').filter(Boolean)
+    visitWorkspacePattern(repoRoot, repoRoot, segments, 0, matches)
+  }
+
+  return [...matches].sort((left, right) => left.localeCompare(right))
+}
+
+function visitWorkspacePattern(
+  repoRoot: string,
+  currentPath: string,
+  segments: string[],
+  index: number,
+  matches: Set<string>,
+): void {
+  if (index >= segments.length) {
+    if (existsSync(join(currentPath, 'package.json'))) {
+      matches.add(toRepoRelativePath(repoRoot, currentPath))
+    }
+    return
+  }
+
+  const segment = segments[index]
+  if (!segment) {
+    return
+  }
+
+  if (segment === '**') {
+    visitWorkspacePattern(repoRoot, currentPath, segments, index + 1, matches)
+    for (const child of listChildDirectories(currentPath)) {
+      visitWorkspacePattern(repoRoot, child, segments, index, matches)
+    }
+    return
+  }
+
+  if (segment === '*') {
+    for (const child of listChildDirectories(currentPath)) {
+      visitWorkspacePattern(repoRoot, child, segments, index + 1, matches)
+    }
+    return
+  }
+
+  const nextPath = join(currentPath, segment)
+  if (existsSync(nextPath)) {
+    visitWorkspacePattern(repoRoot, nextPath, segments, index + 1, matches)
+  }
+}
+
+function listChildDirectories(path: string): string[] {
+  return readdirSync(path, { withFileTypes: true })
+    .filter((entry: Dirent) => entry.isDirectory())
+    .filter((entry: Dirent) => !IGNORED_DIRECTORY_NAMES.has(entry.name))
+    .map((entry: Dirent) => join(path, entry.name))
+    .sort((left, right) => left.localeCompare(right))
+}
+
+function collectRepoFiles(repoRoot: string): string[] {
+  const files: string[] = []
+
+  const visit = (currentPath: string): void => {
+    for (const entry of readdirSync(currentPath, { withFileTypes: true })
+      .sort((left: Dirent, right: Dirent) => left.name.localeCompare(right.name))) {
+      const entryPath = join(currentPath, entry.name)
+
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRECTORY_NAMES.has(entry.name)) {
+          continue
+        }
+
+        visit(entryPath)
+        continue
+      }
+
+      if (entry.isFile()) {
+        files.push(toRepoRelativePath(repoRoot, entryPath))
+      }
+    }
+  }
+
+  visit(repoRoot)
+  return files.sort((left, right) => left.localeCompare(right))
+}
+
+function toRepoRelativePath(repoRoot: string, absolutePath: string): string {
+  return relative(repoRoot, absolutePath).split(sep).join('/')
+}
+
+function isPathInsideRepo(repoRoot: string, absolutePath: string): boolean {
+  const normalizedRoot = resolve(repoRoot)
+  const normalizedPath = resolve(absolutePath)
+  return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}${sep}`)
+}

--- a/apps/agent-daemon/src/issue-authoring-context.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync, type Dirent } from 'node:fs'
 import { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
-import type { BuildRepoAuthoringContextInput, RepoAuthoringContext } from '@agent/shared'
+import type { RepoAuthoringContext } from '@agent/shared'
 
 interface PackageManifestRecord {
   scripts?: Record<string, unknown>
@@ -15,6 +15,16 @@ interface PackageManifest {
 interface ScoredFileCandidate {
   path: string
   score: number
+}
+
+interface RepoAuthoringContextInput {
+  repoRoot: string
+  issueText: string
+  issueTitle?: string
+  issueBody?: string
+  repoRelativeFilePaths?: string[]
+  rootPackageJsonPath?: string
+  workspacePackageJsonPaths?: string[]
 }
 
 const IGNORED_DIRECTORY_NAMES = new Set([
@@ -47,7 +57,7 @@ const MAX_ALLOWED_FILE_CANDIDATES = 8
 const MAX_FORBIDDEN_FILE_CANDIDATES = 8
 
 export async function buildRepoAuthoringContext(
-  input: BuildRepoAuthoringContextInput,
+  input: RepoAuthoringContextInput,
 ): Promise<RepoAuthoringContext> {
   const repoRoot = resolve(input.repoRoot)
   const packageManifests = collectPackageManifests(
@@ -409,7 +419,7 @@ function pushUniquePath(target: string[], seen: Set<string>, path: string): void
   target.push(path)
 }
 
-function resolveIssueText(input: BuildRepoAuthoringContextInput): string {
+function resolveIssueText(input: RepoAuthoringContextInput): string {
   const explicitIssueText = input.issueText.trim()
   if (explicitIssueText) {
     return explicitIssueText
@@ -579,9 +589,13 @@ function expandWorkspacePatterns(repoRoot: string, patterns: string[]): string[]
     }
 
     if (!normalizedPattern.includes('*')) {
-      const literalPath = join(repoRoot, normalizedPattern)
+      const literalPath = resolve(repoRoot, normalizedPattern)
+      if (!isPathInsideRepo(repoRoot, literalPath)) {
+        continue
+      }
+
       if (existsSync(join(literalPath, 'package.json'))) {
-        matches.add(normalizedPattern)
+        matches.add(toRepoRelativePath(repoRoot, literalPath))
       }
       continue
     }
@@ -600,6 +614,10 @@ function visitWorkspacePattern(
   index: number,
   matches: Set<string>,
 ): void {
+  if (!isPathInsideRepo(repoRoot, currentPath)) {
+    return
+  }
+
   if (index >= segments.length) {
     if (existsSync(join(currentPath, 'package.json'))) {
       matches.add(toRepoRelativePath(repoRoot, currentPath))
@@ -628,7 +646,7 @@ function visitWorkspacePattern(
   }
 
   const nextPath = join(currentPath, segment)
-  if (existsSync(nextPath)) {
+  if (isPathInsideRepo(repoRoot, nextPath) && existsSync(nextPath)) {
     visitWorkspacePattern(repoRoot, nextPath, segments, index + 1, matches)
   }
 }

--- a/apps/agent-daemon/src/issue-authoring-context.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.ts
@@ -455,13 +455,19 @@ function collectPackageManifests(
   rootPackageJsonPath?: string,
   workspacePackageJsonPaths?: string[],
 ): PackageManifest[] {
-  const explicitRootPackageJsonPath = rootPackageJsonPath?.trim() || 'package.json'
-  const rootPackage = readPackageManifest(join(repoRoot, explicitRootPackageJsonPath))
+  const sanitizedRootPackageJsonPath = sanitizeManifestPath(repoRoot, rootPackageJsonPath?.trim() || 'package.json')
+  const rootPackage = sanitizedRootPackageJsonPath
+    ? readPackageManifest(join(repoRoot, sanitizedRootPackageJsonPath))
+    : null
   const manifests: PackageManifest[] = []
-  const packageJsonPaths = new Set<string>([explicitRootPackageJsonPath])
+  const packageJsonPaths = new Set<string>()
+
+  if (sanitizedRootPackageJsonPath) {
+    packageJsonPaths.add(sanitizedRootPackageJsonPath)
+  }
 
   for (const workspacePackageJsonPath of workspacePackageJsonPaths ?? []) {
-    const normalized = workspacePackageJsonPath.trim()
+    const normalized = sanitizeManifestPath(repoRoot, workspacePackageJsonPath)
     if (normalized) {
       packageJsonPaths.add(normalized)
     }
@@ -479,7 +485,7 @@ function collectPackageManifests(
   }
 
   for (const packageJsonPath of [...packageJsonPaths].sort((left, right) => left.localeCompare(right))) {
-    if (packageJsonPath === explicitRootPackageJsonPath) {
+    if (packageJsonPath === sanitizedRootPackageJsonPath) {
       continue
     }
 
@@ -500,6 +506,20 @@ function collectPackageManifests(
       allManifests.findIndex((candidate) => candidate.dir === manifest.dir) === index,
     )
     .sort((left, right) => left.dir.localeCompare(right.dir))
+}
+
+function sanitizeManifestPath(repoRoot: string, manifestPath: string): string | null {
+  const normalized = manifestPath.trim().replace(/\\/g, '/').replace(/^\.\/?/, '')
+  if (!normalized || normalized.startsWith('/')) {
+    return null
+  }
+
+  const absolutePath = resolve(repoRoot, normalized)
+  if (!isPathInsideRepo(repoRoot, absolutePath)) {
+    return null
+  }
+
+  return toRepoRelativePath(repoRoot, absolutePath)
 }
 
 function readPackageManifest(path: string): { raw: PackageManifestRecord; scripts: Record<string, string> } | null {

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -116,6 +116,22 @@ export interface ProjectProfileConfig {
   maxConcurrency?: number
 }
 
+export interface BuildRepoAuthoringContextInput {
+  repoRoot: string
+  issueText: string
+  issueTitle?: string
+  issueBody?: string
+  repoRelativeFilePaths?: string[]
+  rootPackageJsonPath?: string
+  workspacePackageJsonPaths?: string[]
+}
+
+export interface RepoAuthoringContext {
+  candidateValidationCommands: string[]
+  candidateAllowedFiles: string[]
+  candidateForbiddenFiles: string[]
+}
+
 export interface AgentSchedulingConfig {
   concurrencyByRepo: Record<string, number>
   concurrencyByProfile: Partial<Record<ProjectProfileName, number>>


### PR DESCRIPTION
## Summary
- add a repo-grounded authoring context builder that scans package manifests and repo files in read-only mode
- normalize candidate validation commands and candidate allowed/forbidden files into stable repo-relative output
- cover repo scan, injected manifest/file inputs, and stable ordering with focused tests

## Validation
- bun test apps/agent-daemon/src/issue-authoring-context.test.ts packages/agent-shared/src/project-profile.test.ts
- bun run typecheck

## Notes
- this PR replaces the polluted stacked implementation in #45 with a clean branch based on `master`