### PR TITLE
Fix #39: [AL-9] 增加 parent -> child split CLI 并产出 dependsOn 图

### DIFF
--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -4,20 +4,20 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   buildWakeRequestFromCli,
-  executeBootstrapGateCommand,
-  executeBootstrapScenarioCommand,
   buildManagedRestartArgs,
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
   executeIssueLintCommand,
+  executeIssueRewriteCommand,
+  executeIssueSplitCommand,
   executeWakeCommand,
   executeWakeRequest,
-  formatBootstrapGateOutput,
-  formatBootstrapScenarioOutput,
   formatIssueLintOutput,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
   resolveIssueLintTarget,
+  resolveIssueRewriteTarget,
+  resolveIssueSplitTarget,
   resolveWakeCommand,
   startManagedRuntime,
   reconcileManagedRuntime,
@@ -66,6 +66,43 @@ describe('index helpers', () => {
     })).toThrow('Only one of --lint-issue or --lint-file can be used at a time')
   })
 
+  test('resolves rewrite targets and rejects empty rewrite paths', () => {
+    expect(resolveIssueRewriteTarget({
+      'rewrite-file': 'docs/issues/ready-draft.md',
+    })).toEqual({
+      path: 'docs/issues/ready-draft.md',
+    })
+
+    expect(() => resolveIssueRewriteTarget({
+      'rewrite-file': '   ',
+    })).toThrow('--rewrite-file must be a non-empty path')
+  })
+
+  test('resolves split targets, start numbers, and rejects detached split numbering', () => {
+    expect(resolveIssueSplitTarget({
+      'split-file': 'docs/issues/quality-parent.md',
+      'split-start-number': '41',
+    })).toEqual({
+      path: 'docs/issues/quality-parent.md',
+      startNumber: 41,
+    })
+
+    expect(resolveIssueSplitTarget({
+      'split-file': 'docs/issues/quality-parent.md',
+    })).toEqual({
+      path: 'docs/issues/quality-parent.md',
+      startNumber: 1,
+    })
+
+    expect(() => resolveIssueSplitTarget({
+      'split-file': '   ',
+    })).toThrow('--split-file must be a non-empty path')
+
+    expect(() => resolveIssueSplitTarget({
+      'split-start-number': '41',
+    })).toThrow('--split-start-number can only be used with --split-file')
+  })
+
   test('executes local issue lint without loading remote config', async () => {
     const report = await executeIssueLintCommand({
       target: {
@@ -105,6 +142,183 @@ describe('index helpers', () => {
       valid: true,
       readyGateBlocked: false,
     })
+  })
+
+  test('executes local issue rewrite by reading a draft file and returning markdown only', async () => {
+    const draftDir = mkdtempSync(join(tmpdir(), 'agent-loop-rewrite-test-'))
+    const draftPath = join(draftDir, 'draft.md')
+    writeFileSync(draftPath, '修复 ready gate 对 Validation 缺失路径的提示，并补测试\n')
+
+    const result = await executeIssueRewriteCommand({
+      target: {
+        path: draftPath,
+      },
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/repo',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      readTextFile: (path) => {
+        expect(path).toBe(draftPath)
+        return readFileSync(path, 'utf-8')
+      },
+      rewriteIssueDraft: async ({ issueText, repoRoot, config }) => {
+        expect(issueText).toContain('修复 ready gate')
+        expect(repoRoot).toBe('/tmp/repo')
+        expect(config!.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          markdown: '## 用户故事\n\n作为维护者，我希望 rewrite CLI 输出 canonical contract。',
+          validation: {
+            valid: true,
+            score: 100,
+            errors: [],
+            warnings: [],
+          },
+        }
+      },
+    })
+
+    expect(result.markdown.startsWith('## 用户故事')).toBe(true)
+    expect(result.validation.valid).toBe(true)
+  })
+
+  test('executes local issue split by reading a parent file and returning markdown only', async () => {
+    const draftDir = mkdtempSync(join(tmpdir(), 'agent-loop-split-test-'))
+    const draftPath = join(draftDir, 'parent.md')
+    writeFileSync(draftPath, '# [AL-EPIC] issue authoring pipeline\n\n父 issue 负责串起 lint、rewrite、split 三条子线。\n')
+
+    const result = await executeIssueSplitCommand({
+      target: {
+        path: draftPath,
+        startNumber: 41,
+      },
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/repo',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      readTextFile: (path) => {
+        expect(path).toBe(draftPath)
+        return readFileSync(path, 'utf-8')
+      },
+      splitTrackingIssue: async ({ issueText, title, body, repoRoot, config, issueNumberAllocator }) => {
+        expect(issueText).toContain('父 issue 负责串起')
+        expect(title).toBe('[AL-EPIC] issue authoring pipeline')
+        expect(body).toBe('父 issue 负责串起 lint、rewrite、split 三条子线。')
+        expect(repoRoot).toBe('/tmp/repo')
+        expect(config!.repo).toBe('JamesWuHK/agent-loop')
+        expect(issueNumberAllocator!()).toBe(41)
+
+        return {
+          parentSummary: '按 lint -> rewrite -> split 的顺序推进 child issues。',
+          children: [],
+          markdown: '## Parent Summary\n\nParent issue: [AL-EPIC] issue authoring pipeline\n\n按 lint -> rewrite -> split 的顺序推进 child issues。',
+        }
+      },
+    })
+
+    expect(result.markdown.startsWith('## Parent Summary')).toBe(true)
+    expect(result.markdown).toContain('Parent issue: [AL-EPIC] issue authoring pipeline')
+    expect(result.markdown).not.toContain('(untitled tracking issue)')
   })
 
   test('executes remote issue lint with repo-aware config and supports json output', async () => {
@@ -157,7 +371,6 @@ describe('index helpers', () => {
             fallback: 'claude',
             claudePath: 'claude',
             codexPath: 'codex',
-            codexReasoningEffort: 'high',
             timeoutMs: 300_000,
           },
           git: {
@@ -341,169 +554,6 @@ describe('index helpers', () => {
     })
     expect(report.readyGateBlocked).toBe(true)
     expect(report.errors).toEqual(['missing ## RED 测试 / RED Tests'])
-  })
-
-  test('executes bootstrap gate with repo-aware config and supports json output', async () => {
-    const report = await executeBootstrapGateCommand({
-      repo: 'JamesWuHK/agent-loop',
-    }, {
-      readConfigFile: () => ({
-        pat: 'ghp_from_config',
-      } as any),
-      loadRepoLocalConfig: () => ({
-        project: {
-          profile: 'generic',
-        },
-      }),
-      buildConfig: (args = {}, options = {}) => {
-        expect(args).toEqual({
-          repo: 'JamesWuHK/agent-loop',
-          pat: undefined,
-          machineId: 'bootstrap-gate-readonly',
-        })
-        expect(options.fileConfig).toMatchObject({
-          pat: 'ghp_from_config',
-          machineId: 'bootstrap-gate-readonly',
-        })
-
-        return {
-          repo: 'JamesWuHK/agent-loop',
-          pat: 'ghp_from_config',
-          machineId: 'bootstrap-gate-readonly',
-          concurrency: 1,
-          requestedConcurrency: 1,
-          concurrencyPolicy: {
-            requested: 1,
-            effective: 1,
-            repoCap: null,
-            profileCap: null,
-            projectCap: null,
-          },
-          scheduling: {
-            concurrencyByRepo: {},
-            concurrencyByProfile: {},
-          },
-          pollIntervalMs: 60_000,
-          idlePollIntervalMs: 300_000,
-          recovery: {
-            heartbeatIntervalMs: 30_000,
-            leaseTtlMs: 60_000,
-            workerIdleTimeoutMs: 300_000,
-            leaseAdoptionBackoffMs: 5_000,
-            leaseNoProgressTimeoutMs: 360_000,
-          },
-          worktreesBase: '/tmp/agent-worktrees',
-          project: {
-            profile: 'generic',
-          },
-          agent: {
-            primary: 'codex',
-            fallback: 'claude',
-            claudePath: 'claude',
-            codexPath: 'codex',
-            codexReasoningEffort: 'high',
-            timeoutMs: 300_000,
-          },
-          git: {
-            defaultBranch: 'main',
-            authorName: 'agent-loop',
-            authorEmail: 'agent-loop@example.com',
-          },
-        } as any
-      },
-      buildBootstrapGateReportForRepo: async ({ config }) => {
-        expect(config.repo).toBe('JamesWuHK/agent-loop')
-        expect(config.pat).toBe('ghp_from_config')
-        expect(config.machineId).toBe('bootstrap-gate-readonly')
-
-        return {
-          version: 'v0.2',
-          ready: false,
-          blockers: [
-            {
-              issueNumber: 37,
-              state: 'working',
-              labels: ['agent:working'],
-              title: '[AL-7] repo grounded context',
-            },
-          ],
-          requiredEvidence: [
-            {
-              code: 'self_bootstrap_suite_green',
-              satisfied: false,
-              sourceIssueNumber: 69,
-              summary: 'awaiting the deterministic self-bootstrap scenario suite tracked by #69',
-            },
-          ],
-          blockingReasons: [
-            'issue #37 is not done (state=working, labels=agent:working)',
-            'missing required evidence: self_bootstrap_suite_green',
-          ],
-        }
-      },
-    })
-
-    expect(report.ready).toBe(false)
-    expect(JSON.parse(formatBootstrapGateOutput(report, true))).toMatchObject({
-      version: 'v0.2',
-      ready: false,
-      blockers: [
-        {
-          issueNumber: 37,
-          state: 'working',
-        },
-      ],
-      requiredEvidence: [
-        {
-          code: 'self_bootstrap_suite_green',
-          satisfied: false,
-        },
-      ],
-    })
-    expect(formatBootstrapGateOutput(report)).toContain('Bootstrap Gate')
-  })
-
-  test('executes bootstrap scenarios with the replay fixture suite and supports json output', async () => {
-    const report = await executeBootstrapScenarioCommand({}, {
-      evaluateBootstrapScenarioFixtureDirectory: (fixturesDir) => {
-        expect(fixturesDir.endsWith(join('fixtures', 'replay'))).toBe(true)
-
-        return {
-          suite: 'self-bootstrap-v0.2',
-          ok: true,
-          failedCases: [],
-          cases: [
-            {
-              name: 'self-bootstrap-happy-path',
-              ok: true,
-              present: true,
-              mismatches: [],
-              actual: { claimable: 1, blocked: 0, invalid: 0 },
-              expected: { claimable: 1, blocked: 0, invalid: 0 },
-            },
-          ],
-          summary: {
-            requiredCases: 4,
-            presentCases: 4,
-            passedCases: 4,
-            failedCases: 0,
-          },
-        }
-      },
-    })
-
-    expect(report.ok).toBe(true)
-    expect(JSON.parse(formatBootstrapScenarioOutput(report, true))).toMatchObject({
-      suite: 'self-bootstrap-v0.2',
-      ok: true,
-    })
-    expect(formatBootstrapScenarioOutput(report)).toContain('Bootstrap Scenarios')
-  })
-
-  test('requires an explicit repo for the bootstrap gate command', async () => {
-    await expect(executeBootstrapGateCommand({})).rejects.toThrow(
-      '--bootstrap-gate requires --repo owner/repo',
-    )
   })
 
   test('builds stable wake requests from CLI commands', () => {

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -11,17 +11,8 @@
 
 import { parseArgs } from 'node:util'
 import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
-import type { AgentConfig } from '@agent/shared'
 import { AgentDaemon, DEFAULT_HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_HOST, type HealthServerConfig } from './daemon'
-import {
-  buildConfig,
-  loadConfig,
-  loadRepoLocalConfig,
-  readConfigFile,
-  resolveLocalDaemonIdentity,
-  type CliArgs,
-} from './config'
+import { loadConfig, resolveLocalDaemonIdentity, type CliArgs } from './config'
 import { collectDaemonObservability, formatDoctorReport, formatStatusReport } from './status'
 import { appendWakeRequest, buildWakeQueuePath, type WakeRequest } from './wake-queue'
 import { readWakeRequestFromGitHubEventContext } from './github-event-wake'
@@ -64,19 +55,14 @@ import {
   type IssueLintReport,
 } from './audit-issue-contracts'
 import {
-  buildBootstrapGateReportForRepo,
-  formatBootstrapGateReport,
-  formatBootstrapGateReportJson,
-  resolveBootstrapGateExitCode,
-  type BootstrapGateReport,
-} from './bootstrap-gate'
+  rewriteIssueDraft,
+  type RewriteIssueDraftResult,
+} from './issue-authoring'
 import {
-  evaluateBootstrapScenarioFixtureDirectory,
-  formatBootstrapScenarioSuiteReport,
-  formatBootstrapScenarioSuiteReportJson,
-  resolveBootstrapScenarioSuiteExitCode,
-  type BootstrapScenarioSuiteReport,
-} from './replay-eval'
+  createSequentialIssueNumberAllocator,
+  splitTrackingIssue,
+  type SplitTrackingIssueResult,
+} from './issue-splitter'
 
 type PartialHealthServerConfig = Partial<HealthServerConfig>
 type LocalDaemonIdentityResolver = typeof resolveLocalDaemonIdentity
@@ -92,6 +78,15 @@ export interface IssueLintTarget {
   kind: 'file' | 'issue'
   path?: string
   issueNumber?: number
+}
+
+export interface IssueRewriteTarget {
+  path: string
+}
+
+export interface IssueSplitTarget {
+  path: string
+  startNumber: number
 }
 
 export interface ExecuteWakeCommandInput {
@@ -120,13 +115,18 @@ export interface ExecuteIssueLintInput {
   pat?: string
 }
 
-export interface ExecuteBootstrapGateInput {
+export interface ExecuteIssueRewriteInput {
+  target: IssueRewriteTarget
   repo?: string
   pat?: string
+  repoRoot: string
 }
 
-export interface ExecuteBootstrapScenarioInput {
-  fixturesDir?: string
+export interface ExecuteIssueSplitInput {
+  target: IssueSplitTarget
+  repo?: string
+  pat?: string
+  repoRoot: string
 }
 
 export interface RestartManagedRuntimeInput {
@@ -206,15 +206,16 @@ interface IssueLintCommandDependencies {
   buildIssueLintReportFromRemoteIssue: typeof buildIssueLintReportFromRemoteIssue
 }
 
-interface BootstrapGateCommandDependencies {
-  buildConfig: typeof buildConfig
-  loadRepoLocalConfig: typeof loadRepoLocalConfig
-  readConfigFile: typeof readConfigFile
-  buildBootstrapGateReportForRepo: typeof buildBootstrapGateReportForRepo
+interface IssueRewriteCommandDependencies {
+  loadConfig: typeof loadConfig
+  readTextFile: (path: string) => string
+  rewriteIssueDraft: typeof rewriteIssueDraft
 }
 
-interface BootstrapScenarioCommandDependencies {
-  evaluateBootstrapScenarioFixtureDirectory: typeof evaluateBootstrapScenarioFixtureDirectory
+interface IssueSplitCommandDependencies {
+  loadConfig: typeof loadConfig
+  readTextFile: (path: string) => string
+  splitTrackingIssue: typeof splitTrackingIssue
 }
 
 const DEFAULT_RESTART_DEPENDENCIES: RestartManagedRuntimeDependencies = {
@@ -243,17 +244,17 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
   buildIssueLintReportFromRemoteIssue,
 }
 
-const DEFAULT_BOOTSTRAP_GATE_COMMAND_DEPENDENCIES: BootstrapGateCommandDependencies = {
-  buildConfig,
-  loadRepoLocalConfig,
-  readConfigFile,
-  buildBootstrapGateReportForRepo,
+const DEFAULT_ISSUE_REWRITE_COMMAND_DEPENDENCIES: IssueRewriteCommandDependencies = {
+  loadConfig,
+  readTextFile: (path) => readFileSync(path, 'utf-8'),
+  rewriteIssueDraft,
 }
 
-const DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES: BootstrapScenarioCommandDependencies = {
-  evaluateBootstrapScenarioFixtureDirectory,
+const DEFAULT_ISSUE_SPLIT_COMMAND_DEPENDENCIES: IssueSplitCommandDependencies = {
+  loadConfig,
+  readTextFile: (path) => readFileSync(path, 'utf-8'),
+  splitTrackingIssue,
 }
-const DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR = join(import.meta.dir, 'fixtures', 'replay')
 
 async function main() {
   const { values: args } = parseArgs({
@@ -294,8 +295,9 @@ async function main() {
       'github-event-path': { type: 'string' },
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
-      'bootstrap-scenarios': { type: 'boolean' },
-      'bootstrap-gate': { type: 'boolean' },
+      'rewrite-file': { type: 'string' },
+      'split-file': { type: 'string' },
+      'split-start-number': { type: 'string' },
       json: { type: 'boolean' },
       help: { type: 'boolean' },
     },
@@ -322,6 +324,13 @@ async function main() {
     'lint-issue': args['lint-issue'] as string | undefined,
     'lint-file': args['lint-file'] as string | undefined,
   })
+  const issueRewriteTarget = resolveIssueRewriteTarget({
+    'rewrite-file': args['rewrite-file'] as string | undefined,
+  })
+  const issueSplitTarget = resolveIssueSplitTarget({
+    'split-file': args['split-file'] as string | undefined,
+    'split-start-number': args['split-start-number'] as string | undefined,
+  })
 
   if (wakeCommand) {
     assertWakeCommandCompatible(args)
@@ -331,12 +340,12 @@ async function main() {
     assertIssueLintCompatible(args)
   }
 
-  if (args['bootstrap-scenarios']) {
-    assertBootstrapScenarioCompatible(args)
+  if (issueRewriteTarget) {
+    assertIssueRewriteCompatible(args)
   }
 
-  if (args['bootstrap-gate']) {
-    assertBootstrapGateCompatible(args)
+  if (issueSplitTarget) {
+    assertIssueSplitCompatible(args)
   }
 
   if (args['wake-from-github-event']) {
@@ -346,11 +355,11 @@ async function main() {
     if (issueLintTarget) {
       throw new Error('--wake-from-github-event cannot be combined with --lint-issue or --lint-file')
     }
-    if (args['bootstrap-scenarios']) {
-      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-scenarios')
+    if (issueRewriteTarget) {
+      throw new Error('--wake-from-github-event cannot be combined with --rewrite-file')
     }
-    if (args['bootstrap-gate']) {
-      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-gate')
+    if (issueSplitTarget) {
+      throw new Error('--wake-from-github-event cannot be combined with --split-file')
     }
     assertWakeCommandCompatible(args)
   }
@@ -359,24 +368,24 @@ async function main() {
     throw new Error('--lint-issue/--lint-file cannot be combined with wake commands')
   }
 
-  if (args['bootstrap-scenarios'] && wakeCommand) {
-    throw new Error('--bootstrap-scenarios cannot be combined with wake commands')
+  if (wakeCommand && issueRewriteTarget) {
+    throw new Error('--rewrite-file cannot be combined with wake commands')
   }
 
-  if (args['bootstrap-scenarios'] && issueLintTarget) {
-    throw new Error('--bootstrap-scenarios cannot be combined with --lint-issue or --lint-file')
+  if (issueLintTarget && issueRewriteTarget) {
+    throw new Error('--rewrite-file cannot be combined with --lint-issue or --lint-file')
   }
 
-  if (args['bootstrap-scenarios'] && args['bootstrap-gate']) {
-    throw new Error('--bootstrap-scenarios cannot be combined with --bootstrap-gate')
+  if (wakeCommand && issueSplitTarget) {
+    throw new Error('--split-file cannot be combined with wake commands')
   }
 
-  if (args['bootstrap-gate'] && wakeCommand) {
-    throw new Error('--bootstrap-gate cannot be combined with wake commands')
+  if (issueLintTarget && issueSplitTarget) {
+    throw new Error('--split-file cannot be combined with --lint-issue or --lint-file')
   }
 
-  if (args['bootstrap-gate'] && issueLintTarget) {
-    throw new Error('--bootstrap-gate cannot be combined with --lint-issue or --lint-file')
+  if (issueRewriteTarget && issueSplitTarget) {
+    throw new Error('--split-file cannot be combined with --rewrite-file')
   }
 
   if (args['repo-cap'] && !args['join-project']) {
@@ -445,19 +454,26 @@ async function main() {
     process.exit(report.readyGateBlocked ? 1 : 0)
   }
 
-  if (args['bootstrap-scenarios']) {
-    const report = await executeBootstrapScenarioCommand()
-    console.log(formatBootstrapScenarioOutput(report, args.json as boolean | undefined))
-    process.exit(resolveBootstrapScenarioSuiteExitCode(report))
-  }
-
-  if (args['bootstrap-gate']) {
-    const report = await executeBootstrapGateCommand({
+  if (issueRewriteTarget) {
+    const result = await executeIssueRewriteCommand({
+      target: issueRewriteTarget,
       repo: args.repo as string | undefined,
       pat: args.pat as string | undefined,
+      repoRoot: process.cwd(),
     })
-    console.log(formatBootstrapGateOutput(report, args.json as boolean | undefined))
-    process.exit(resolveBootstrapGateExitCode(report))
+    console.log(result.markdown)
+    process.exit(0)
+  }
+
+  if (issueSplitTarget) {
+    const result = await executeIssueSplitCommand({
+      target: issueSplitTarget,
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+      repoRoot: process.cwd(),
+    })
+    console.log(result.markdown)
+    process.exit(0)
   }
 
   if (args['join-project']) {
@@ -817,8 +833,8 @@ Usage:
   agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
-  agent-loop --bootstrap-scenarios [--json]
-  agent-loop --bootstrap-gate [--repo owner/repo --json]
+  agent-loop --rewrite-file <path> [--repo owner/repo]
+  agent-loop --split-file <path> [--split-start-number <number> --repo owner/repo]
   agent-loop --reconcile [--health-port 9310]
   agent-loop --start [--health-port 9310]
   agent-loop --dashboard [--dashboard-port 9388]
@@ -853,9 +869,10 @@ Options:
       --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
-      --bootstrap-scenarios   Evaluate the fixed self-bootstrap replay suite
-      --bootstrap-gate        Evaluate the deterministic self-bootstrap release gate
-      --json                  Print machine-readable JSON for lint, bootstrap scenario, and bootstrap gate commands
+      --rewrite-file <path>   Rewrite a local issue draft into canonical executable contract markdown
+      --split-file <path>     Split a tracking parent issue into ordered child issue contracts
+      --split-start-number    First child issue number to allocate when building dependsOn arrays (default: 1)
+      --json                  Print machine-readable JSON for lint commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -899,8 +916,8 @@ Examples:
   agent-loop --wake-pr 381 --health-port 9311
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
-  agent-loop --bootstrap-scenarios --json
-  agent-loop --bootstrap-gate --repo JamesWuHK/agent-loop --json
+  agent-loop --rewrite-file docs/issues/ready-gate-draft.md --repo owner/repo
+  agent-loop --split-file docs/issues/quality-parent.md --split-start-number 41 --repo owner/repo
   agent-loop --dashboard
   agent-loop --dashboard --dashboard-port 9390
   agent-loop --join-project --machine-id macbook-pro-b --health-port 9312 --metrics-port 9092 --repo-cap 2
@@ -1026,6 +1043,46 @@ export function resolveIssueLintTarget(args: {
   return targets[0] ?? null
 }
 
+export function resolveIssueRewriteTarget(args: {
+  'rewrite-file'?: string
+}): IssueRewriteTarget | null {
+  if (typeof args['rewrite-file'] !== 'string') {
+    return null
+  }
+
+  const path = args['rewrite-file'].trim()
+  if (!path) {
+    throw new Error('--rewrite-file must be a non-empty path')
+  }
+
+  return { path }
+}
+
+export function resolveIssueSplitTarget(args: {
+  'split-file'?: string
+  'split-start-number'?: string
+}): IssueSplitTarget | null {
+  if (typeof args['split-file'] !== 'string') {
+    if (typeof args['split-start-number'] === 'string') {
+      throw new Error('--split-start-number can only be used with --split-file')
+    }
+
+    return null
+  }
+
+  const path = args['split-file'].trim()
+  if (!path) {
+    throw new Error('--split-file must be a non-empty path')
+  }
+
+  return {
+    path,
+    startNumber: typeof args['split-start-number'] === 'string'
+      ? parseWakeTargetNumber(args['split-start-number'], '--split-start-number')
+      : 1,
+  }
+}
+
 export async function executeIssueLintCommand(
   input: ExecuteIssueLintInput,
   deps: IssueLintCommandDependencies = DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES,
@@ -1045,71 +1102,67 @@ export async function executeIssueLintCommand(
   })
 }
 
+export async function executeIssueRewriteCommand(
+  input: ExecuteIssueRewriteInput,
+  deps: IssueRewriteCommandDependencies = DEFAULT_ISSUE_REWRITE_COMMAND_DEPENDENCIES,
+): Promise<RewriteIssueDraftResult> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+
+  return deps.rewriteIssueDraft({
+    issueText: deps.readTextFile(input.target.path),
+    repoRoot: input.repoRoot,
+    config,
+  })
+}
+
+export async function executeIssueSplitCommand(
+  input: ExecuteIssueSplitInput,
+  deps: IssueSplitCommandDependencies = DEFAULT_ISSUE_SPLIT_COMMAND_DEPENDENCIES,
+): Promise<SplitTrackingIssueResult> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+  const issueText = deps.readTextFile(input.target.path)
+  const issueSource = parseMarkdownIssueSource(issueText)
+
+  return deps.splitTrackingIssue({
+    issueText,
+    title: issueSource.title,
+    body: issueSource.body,
+    repoRoot: input.repoRoot,
+    config,
+    issueNumberAllocator: createSequentialIssueNumberAllocator(input.target.startNumber),
+  })
+}
+
+function parseMarkdownIssueSource(markdown: string): {
+  title?: string
+  body: string
+} {
+  const trimmed = markdown.trim()
+  const headingMatch = trimmed.match(/^#\s+(.+?)\s*(?:\n+|$)([\s\S]*)$/)
+
+  if (!headingMatch) {
+    return {
+      body: trimmed,
+    }
+  }
+
+  return {
+    title: headingMatch[1]?.trim(),
+    body: headingMatch[2]?.trim() || trimmed,
+  }
+}
+
 export function formatIssueLintOutput(
   report: IssueLintReport,
   asJson = false,
 ): string {
   return asJson ? formatIssueLintReportJson(report) : formatIssueLintReport(report)
-}
-
-export async function executeBootstrapScenarioCommand(
-  input: ExecuteBootstrapScenarioInput = {},
-  deps: BootstrapScenarioCommandDependencies = DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES,
-): Promise<BootstrapScenarioSuiteReport> {
-  return deps.evaluateBootstrapScenarioFixtureDirectory(
-    input.fixturesDir ?? DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR,
-  )
-}
-
-export function formatBootstrapScenarioOutput(
-  report: BootstrapScenarioSuiteReport,
-  asJson = false,
-): string {
-  return asJson ? formatBootstrapScenarioSuiteReportJson(report) : formatBootstrapScenarioSuiteReport(report)
-}
-
-export async function executeBootstrapGateCommand(
-  input: ExecuteBootstrapGateInput,
-  deps: BootstrapGateCommandDependencies = DEFAULT_BOOTSTRAP_GATE_COMMAND_DEPENDENCIES,
-): Promise<BootstrapGateReport> {
-  return deps.buildBootstrapGateReportForRepo({
-    config: buildBootstrapGateReadOnlyConfig(input, deps),
-  })
-}
-
-export function formatBootstrapGateOutput(
-  report: BootstrapGateReport,
-  asJson = false,
-): string {
-  return asJson ? formatBootstrapGateReportJson(report) : formatBootstrapGateReport(report)
-}
-
-function buildBootstrapGateReadOnlyConfig(
-  input: ExecuteBootstrapGateInput,
-  deps: Pick<BootstrapGateCommandDependencies, 'buildConfig' | 'loadRepoLocalConfig' | 'readConfigFile'>,
-): AgentConfig {
-  const repo = input.repo?.trim()
-  if (!repo) {
-    throw new Error('--bootstrap-gate requires --repo owner/repo')
-  }
-
-  const readOnlyMachineId = 'bootstrap-gate-readonly'
-  const fileConfig = deps.readConfigFile()
-
-  return deps.buildConfig(
-    {
-      repo,
-      pat: input.pat,
-      machineId: readOnlyMachineId,
-    },
-    {
-      fileConfig: {
-        ...fileConfig,
-        machineId: fileConfig.machineId ?? readOnlyMachineId,
-      },
-      repoConfig: deps.loadRepoLocalConfig(),
-    },
-  )
 }
 
 export function buildWakeRequestFromCli(
@@ -1437,12 +1490,14 @@ function assertIssueLintCompatible(args: {
   }
 }
 
-function assertBootstrapGateCompatible(args: {
-  'bootstrap-scenarios'?: boolean
+function assertIssueRewriteCompatible(args: {
   'wake-now'?: boolean
   'wake-issue'?: string
   'wake-pr'?: string
   'wake-from-github-event'?: boolean
+  'lint-issue'?: string
+  'lint-file'?: string
+  json?: boolean
   concurrency?: string
   'poll-interval'?: string
   'idle-poll-interval'?: string
@@ -1471,11 +1526,13 @@ function assertBootstrapGateCompatible(args: {
   'health-port'?: string
 }): void {
   const incompatibleFlags = [
-    args['bootstrap-scenarios'] ? '--bootstrap-scenarios' : null,
     args['wake-now'] ? '--wake-now' : null,
     typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
     typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
     args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    args.json ? '--json' : null,
     typeof args.concurrency === 'string' ? '--concurrency' : null,
     typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
     typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
@@ -1505,16 +1562,19 @@ function assertBootstrapGateCompatible(args: {
   ].filter((flag): flag is string => flag !== null)
 
   if (incompatibleFlags.length > 0) {
-    throw new Error(`Bootstrap gate cannot be combined with ${incompatibleFlags.join(', ')}`)
+    throw new Error(`Issue rewrite cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 
-function assertBootstrapScenarioCompatible(args: {
-  'bootstrap-gate'?: boolean
+function assertIssueSplitCompatible(args: {
   'wake-now'?: boolean
   'wake-issue'?: string
   'wake-pr'?: string
   'wake-from-github-event'?: boolean
+  'lint-issue'?: string
+  'lint-file'?: string
+  'rewrite-file'?: string
+  json?: boolean
   concurrency?: string
   'poll-interval'?: string
   'idle-poll-interval'?: string
@@ -1543,11 +1603,14 @@ function assertBootstrapScenarioCompatible(args: {
   'health-port'?: string
 }): void {
   const incompatibleFlags = [
-    args['bootstrap-gate'] ? '--bootstrap-gate' : null,
     args['wake-now'] ? '--wake-now' : null,
     typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
     typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
     args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
+    args.json ? '--json' : null,
     typeof args.concurrency === 'string' ? '--concurrency' : null,
     typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
     typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
@@ -1577,7 +1640,7 @@ function assertBootstrapScenarioCompatible(args: {
   ].filter((flag): flag is string => flag !== null)
 
   if (incompatibleFlags.length > 0) {
-    throw new Error(`Bootstrap scenarios cannot be combined with ${incompatibleFlags.join(', ')}`)
+    throw new Error(`Issue split cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/issue-authoring-context.test.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildRepoAuthoringContext } from './issue-authoring-context'
+
+describe('buildRepoAuthoringContext', () => {
+  test('collects workspace validation commands and repo-relative file candidates from repo scan', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-'))
+    mkdirSync(join(root, 'apps/example/src/pages'), { recursive: true })
+    mkdirSync(join(root, '.agent-loop/drafts'), { recursive: true })
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+        typecheck: 'bun run typecheck',
+      },
+      workspaces: ['apps/*'],
+    }))
+    writeFileSync(join(root, 'apps/example/package.json'), JSON.stringify({
+      name: 'example',
+      scripts: {
+        test: 'bun run --bun test src/pages/LoginPage.test.tsx',
+      },
+    }))
+    writeFileSync(join(root, 'apps/example/src/App.tsx'), 'export function App() { return null }\n')
+    writeFileSync(join(root, 'apps/example/src/main.tsx'), 'export const main = true\n')
+    writeFileSync(join(root, 'apps/example/src/pages/LoginPage.tsx'), 'export function LoginPage() { return null }\n')
+    writeFileSync(join(root, 'apps/example/src/pages/LoginPage.test.tsx'), 'export {}\n')
+    writeFileSync(join(root, '.agent-loop/drafts/LoginPage.tsx'), 'export const ignored = true\n')
+
+    const context = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '修复 LoginPage 的登录重定向，并补上对应测试',
+    })
+
+    expect(context.candidateValidationCommands).toEqual([
+      'bun run --bun test apps/example/src/pages/LoginPage.test.tsx',
+      'bun run typecheck',
+      'bun test',
+    ])
+    expect(context.candidateAllowedFiles).toEqual([
+      'apps/example/src/pages/LoginPage.tsx',
+      'apps/example/src/pages/LoginPage.test.tsx',
+    ])
+    expect(context.candidateForbiddenFiles).toEqual([
+      'apps/example/src/App.tsx',
+      'apps/example/src/main.tsx',
+    ])
+    expect(context.candidateAllowedFiles.some((value) => value.startsWith(root))).toBe(false)
+    expect(context.candidateAllowedFiles.some((value) => value.includes('.agent-loop'))).toBe(false)
+    expect(context.candidateValidationCommands.some((value) => value.startsWith(root))).toBe(false)
+  })
+
+  test('keeps validation command ordering stable across root and injected workspace manifests', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-order-'))
+    mkdirSync(join(root, 'apps/web'), { recursive: true })
+    mkdirSync(join(root, 'packages/shared'), { recursive: true })
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        lint: 'bun run lint',
+        test: 'bun test',
+        typecheck: 'bun run typecheck',
+      },
+    }))
+    writeFileSync(join(root, 'apps/web/package.json'), JSON.stringify({
+      name: 'web',
+      scripts: {
+        test: 'bun run --cwd src/pages test LoginPage.test.tsx',
+      },
+    }))
+    writeFileSync(join(root, 'packages/shared/package.json'), JSON.stringify({
+      name: 'shared',
+      scripts: {
+        verify: 'bun test src/index.test.ts',
+      },
+    }))
+
+    const context = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueTitle: '调整 LoginPage 文案并确认测试',
+      issueBody: '需要补齐登录页回归。',
+      issueText: '',
+      repoRelativeFilePaths: [
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/pages/LoginPage.test.tsx',
+        'packages/shared/src/index.test.ts',
+      ],
+      rootPackageJsonPath: 'package.json',
+      workspacePackageJsonPaths: [
+        'packages/shared/package.json',
+        'apps/web/package.json',
+      ],
+    })
+
+    expect(context.candidateValidationCommands).toEqual([
+      'bun run --cwd apps/web/src/pages test apps/web/src/pages/LoginPage.test.tsx',
+      'bun run lint',
+      'bun run typecheck',
+      'bun test',
+      'bun test packages/shared/src/index.test.ts',
+    ])
+  })
+
+  test('ignores absolute and parent-relative file inputs when ranking candidates', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-paths-'))
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+      },
+    }))
+
+    const context = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '修复 packages/agent-shared/src/project-profile.ts 的提示文案',
+      repoRelativeFilePaths: [
+        '/tmp/escape.ts',
+        '../outside.ts',
+        'packages/agent-shared/src/project-profile.test.ts',
+        'packages/agent-shared/src/project-profile.ts',
+      ],
+      rootPackageJsonPath: 'package.json',
+      workspacePackageJsonPaths: [],
+    })
+
+    expect(context.candidateAllowedFiles).toEqual([
+      'packages/agent-shared/src/project-profile.ts',
+      'packages/agent-shared/src/project-profile.test.ts',
+    ])
+    expect(context.candidateAllowedFiles.some((value) => value.startsWith('/'))).toBe(false)
+  })
+
+  test('keeps allowed and forbidden file ordering stable for unsorted repo-relative inputs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-stable-files-'))
+    mkdirSync(join(root, 'apps/web'), { recursive: true })
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+      },
+    }))
+    writeFileSync(join(root, 'apps/web/package.json'), JSON.stringify({
+      name: 'web',
+      scripts: {
+        verify: 'bun test src/pages/LoginPage.test.tsx',
+      },
+    }))
+
+    const firstContext = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '更新 LoginPage 交互并补测试',
+      repoRelativeFilePaths: [
+        'apps/web/src/pages/LoginPage.test.tsx',
+        'apps/web/src/router.tsx',
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/main.tsx',
+        'apps/web/src/App.tsx',
+      ],
+      rootPackageJsonPath: 'package.json',
+      workspacePackageJsonPaths: ['apps/web/package.json'],
+    })
+
+    const secondContext = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '更新 LoginPage 交互并补测试',
+      repoRelativeFilePaths: [
+        'apps/web/src/main.tsx',
+        'apps/web/src/App.tsx',
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/router.tsx',
+        'apps/web/src/pages/LoginPage.test.tsx',
+      ],
+      rootPackageJsonPath: 'package.json',
+      workspacePackageJsonPaths: ['apps/web/package.json'],
+    })
+
+    expect(firstContext).toEqual(secondContext)
+    expect(firstContext).toEqual({
+      candidateValidationCommands: [
+        'bun test',
+        'bun test apps/web/src/pages/LoginPage.test.tsx',
+      ],
+      candidateAllowedFiles: [
+        'apps/web/src/pages/LoginPage.tsx',
+        'apps/web/src/pages/LoginPage.test.tsx',
+      ],
+      candidateForbiddenFiles: [
+        'apps/web/src/App.tsx',
+        'apps/web/src/main.tsx',
+        'apps/web/src/router.tsx',
+      ],
+    })
+    expect(firstContext.candidateForbiddenFiles.some((value) => value.startsWith('/'))).toBe(false)
+  })
+})

--- a/apps/agent-daemon/src/issue-authoring-context.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.ts
@@ -1,0 +1,674 @@
+import { existsSync, readdirSync, readFileSync, type Dirent } from 'node:fs'
+import { basename, dirname, extname, join, relative, resolve, sep } from 'node:path'
+
+export interface BuildRepoAuthoringContextInput {
+  repoRoot: string
+  issueText: string
+  issueTitle?: string
+  issueBody?: string
+  repoRelativeFilePaths?: string[]
+  rootPackageJsonPath?: string
+  workspacePackageJsonPaths?: string[]
+}
+
+export interface RepoAuthoringContext {
+  candidateValidationCommands: string[]
+  candidateAllowedFiles: string[]
+  candidateForbiddenFiles: string[]
+}
+
+interface PackageManifestRecord {
+  scripts?: Record<string, unknown>
+  workspaces?: string[] | { packages?: string[] }
+}
+
+interface PackageManifest {
+  dir: string
+  scripts: Record<string, string>
+}
+
+interface ScoredFileCandidate {
+  path: string
+  score: number
+}
+
+const IGNORED_DIRECTORY_NAMES = new Set([
+  '.agent-loop',
+  '.cache',
+  '.git',
+  '.next',
+  '.runtime',
+  '.turbo',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+])
+
+const VALIDATION_SCRIPT_PATTERN = /\b(test|tests|check|lint|typecheck|build|verify|coverage)\b/i
+const TEST_INTENT_PATTERN = /\b(test|tests|spec|specs|coverage|verify|validation)\b|测试|用例|验证|回归/i
+const SOURCE_FILE_PATTERN = /\.(ts|tsx|js|jsx|mjs|cjs|json|md|py|go|rs|java|kt|swift|rb|php|cs|sh|yaml|yml)$/i
+const BROAD_SCOPE_FILE_PATTERNS = [
+  /(?:^|\/)App\.[^/]+$/i,
+  /(?:^|\/)main\.[^/]+$/i,
+  /(?:^|\/)index\.[^/]+$/i,
+  /(?:^|\/)router\.[^/]+$/i,
+  /(?:^|\/)layout\.[^/]+$/i,
+  /(?:^|\/)api\.[^/]+$/i,
+  /(?:^|\/)daemon\.[^/]+$/i,
+] as const
+
+const MAX_ALLOWED_FILE_CANDIDATES = 8
+const MAX_FORBIDDEN_FILE_CANDIDATES = 8
+
+export async function buildRepoAuthoringContext(
+  input: BuildRepoAuthoringContextInput,
+): Promise<RepoAuthoringContext> {
+  const repoRoot = resolve(input.repoRoot)
+  const packageManifests = collectPackageManifests(
+    repoRoot,
+    input.rootPackageJsonPath,
+    input.workspacePackageJsonPaths,
+  )
+  const repoFiles = input.repoRelativeFilePaths
+    ? sanitizeRepoRelativeFilePaths(repoRoot, input.repoRelativeFilePaths)
+    : collectRepoFiles(repoRoot)
+  const candidateAllowedFiles = collectCandidateAllowedFiles(resolveIssueText(input), repoFiles)
+
+  return {
+    candidateValidationCommands: collectCandidateValidationCommands(repoRoot, packageManifests),
+    candidateAllowedFiles,
+    candidateForbiddenFiles: collectCandidateForbiddenFiles(
+      repoFiles,
+      candidateAllowedFiles,
+      packageManifests.map((manifest) => manifest.dir),
+    ),
+  }
+}
+
+function collectCandidateValidationCommands(
+  repoRoot: string,
+  manifests: PackageManifest[],
+): string[] {
+  const commands = new Set<string>()
+
+  for (const manifest of manifests) {
+    for (const [scriptName, scriptCommand] of Object.entries(manifest.scripts).sort(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      if (!looksLikeValidationScript(scriptName, scriptCommand)) {
+        continue
+      }
+
+      const normalized = normalizeValidationCommand(repoRoot, manifest.dir, scriptCommand)
+      if (normalized) {
+        commands.add(normalized)
+      }
+    }
+  }
+
+  return [...commands].sort((left, right) => left.localeCompare(right))
+}
+
+function looksLikeValidationScript(name: string, command: string): boolean {
+  return VALIDATION_SCRIPT_PATTERN.test(name) || VALIDATION_SCRIPT_PATTERN.test(command)
+}
+
+function normalizeValidationCommand(
+  repoRoot: string,
+  packageDir: string,
+  command: string,
+): string | null {
+  const tokens = tokenizeCommand(command)
+  if (tokens.length === 0) {
+    return null
+  }
+
+  let commandCwd = resolve(repoRoot, packageDir)
+  const normalizedTokens: string[] = []
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = stripWrappingQuotes(tokens[index] ?? '')
+    if (!token) {
+      continue
+    }
+
+    if ((token === '--cwd' || token === '-C' || token === 'cd') && tokens[index + 1]) {
+      const cwdToken = stripWrappingQuotes(tokens[index + 1] ?? '')
+      const resolvedCwd = resolveCommandPath(repoRoot, commandCwd, cwdToken)
+      if (!resolvedCwd) {
+        return null
+      }
+
+      commandCwd = resolvedCwd
+      normalizedTokens.push(token)
+      normalizedTokens.push(toRepoRelativePath(repoRoot, resolvedCwd) || '.')
+      index += 1
+      continue
+    }
+
+    if (looksLikePathToken(token)) {
+      const resolvedPath = resolveCommandPath(repoRoot, commandCwd, token)
+      if (!resolvedPath) {
+        return null
+      }
+
+      normalizedTokens.push(toRepoRelativePath(repoRoot, resolvedPath) || '.')
+      continue
+    }
+
+    normalizedTokens.push(token)
+  }
+
+  return normalizedTokens.join(' ')
+}
+
+function tokenizeCommand(command: string): string[] {
+  return command.match(/"[^"]*"|'[^']*'|\S+/g) ?? []
+}
+
+function stripWrappingQuotes(token: string): string {
+  return token.replace(/^['"]|['"]$/g, '')
+}
+
+function looksLikePathToken(token: string): boolean {
+  if (!token || token.startsWith('-')) {
+    return false
+  }
+
+  if (token.includes('...')) {
+    return false
+  }
+
+  if (token === '.' || token === '..') {
+    return true
+  }
+
+  if (/^[A-Z_][A-Z0-9_]*=/.test(token)) {
+    return false
+  }
+
+  if (/^[A-Za-z0-9_.-]+$/.test(token) && !token.includes('.') && !token.includes('/')) {
+    return false
+  }
+
+  return token.includes('/') || token.includes('\\') || /\.[A-Za-z0-9]+$/.test(token)
+}
+
+function resolveCommandPath(
+  repoRoot: string,
+  commandCwd: string,
+  token: string,
+): string | null {
+  const absolutePath = token.startsWith('/')
+    ? resolve(token)
+    : resolve(commandCwd, token.replace(/\\/g, '/'))
+
+  if (!isPathInsideRepo(repoRoot, absolutePath)) {
+    return null
+  }
+
+  return absolutePath
+}
+
+function collectCandidateAllowedFiles(
+  issueText: string,
+  repoFiles: string[],
+): string[] {
+  const keywords = extractIssueKeywords(issueText)
+  if (keywords.length === 0) {
+    return []
+  }
+
+  const wantsTests = TEST_INTENT_PATTERN.test(issueText)
+  const rankedFiles = repoFiles
+    .map((path) => ({
+      path,
+      score: scoreRepoFile(path, keywords, wantsTests),
+    }))
+    .filter((candidate) => candidate.score > 0)
+    .sort(compareScoredCandidates)
+
+  const orderedCandidates: string[] = []
+  const seen = new Set<string>()
+
+  for (const candidate of rankedFiles) {
+    pushUniquePath(orderedCandidates, seen, candidate.path)
+    for (const related of collectRelatedAllowedFiles(candidate.path, repoFiles, wantsTests)) {
+      pushUniquePath(orderedCandidates, seen, related)
+    }
+
+    if (orderedCandidates.length >= MAX_ALLOWED_FILE_CANDIDATES) {
+      break
+    }
+  }
+
+  return orderedCandidates.slice(0, MAX_ALLOWED_FILE_CANDIDATES)
+}
+
+function compareScoredCandidates(left: ScoredFileCandidate, right: ScoredFileCandidate): number {
+  if (right.score !== left.score) {
+    return right.score - left.score
+  }
+
+  if (isTestFile(left.path) !== isTestFile(right.path)) {
+    return isTestFile(left.path) ? 1 : -1
+  }
+
+  return left.path.localeCompare(right.path)
+}
+
+function scoreRepoFile(
+  path: string,
+  keywords: string[],
+  wantsTests: boolean,
+): number {
+  const normalizedPath = path.toLowerCase()
+  const fileName = basename(normalizedPath)
+  const fileStem = normalizeFileStem(normalizedPath)
+  let score = 0
+
+  for (const keyword of keywords) {
+    if (fileStem === keyword) {
+      score += 24
+      continue
+    }
+
+    if (fileName.startsWith(`${keyword}.`) || fileName.includes(`${keyword}.`)) {
+      score += 18
+      continue
+    }
+
+    if (keyword.length >= 5 && fileName.includes(keyword)) {
+      score += 12
+    } else if (normalizedPath.includes(`/${keyword}/`)) {
+      score += 8
+    } else if (keyword.length >= 5 && normalizedPath.includes(keyword)) {
+      score += 6
+    }
+  }
+
+  if (score > 0 && SOURCE_FILE_PATTERN.test(path)) {
+    score += 1
+  }
+
+  if (isTestFile(path)) {
+    score -= 1
+    if (wantsTests) {
+      score += 1
+    }
+  }
+
+  return score
+}
+
+function collectRelatedAllowedFiles(
+  path: string,
+  repoFiles: string[],
+  wantsTests: boolean,
+): string[] {
+  const targetDirectory = dirname(path)
+  const targetStem = normalizeFileStem(path)
+
+  return repoFiles
+    .filter((candidate) => candidate !== path)
+    .filter((candidate) => dirname(candidate) === targetDirectory)
+    .filter((candidate) => normalizeFileStem(candidate) === targetStem)
+    .filter((candidate) => wantsTests || !isTestFile(candidate))
+    .sort((left, right) => {
+      if (isTestFile(left) !== isTestFile(right)) {
+        return isTestFile(left) ? 1 : -1
+      }
+
+      return left.localeCompare(right)
+    })
+}
+
+function normalizeFileStem(path: string): string {
+  return basename(path, extname(path)).replace(/\.(test|spec)$/i, '')
+}
+
+function isTestFile(path: string): boolean {
+  return /\.(test|spec)\.[^.]+$/i.test(path)
+}
+
+function extractIssueKeywords(issueText: string): string[] {
+  const keywords = new Set<string>()
+
+  for (const match of issueText.matchAll(/[A-Za-z][A-Za-z0-9._-]{1,}/g)) {
+    addKeywordTerms(keywords, match[0])
+  }
+
+  for (const match of issueText.matchAll(/[A-Za-z0-9_.-]+\.[A-Za-z0-9]+/g)) {
+    addKeywordTerms(keywords, match[0])
+  }
+
+  return [...keywords]
+    .filter((value) => value.length >= 2)
+    .sort((left, right) => right.length - left.length || left.localeCompare(right))
+}
+
+function addKeywordTerms(keywords: Set<string>, rawValue: string): void {
+  const normalized = rawValue.trim().replace(/^['"`]+|['"`]+$/g, '')
+  if (!normalized) {
+    return
+  }
+
+  const lowered = normalized.toLowerCase()
+  keywords.add(lowered)
+
+  const withoutExtension = lowered.replace(/\.[a-z0-9]+$/i, '')
+  if (withoutExtension !== lowered) {
+    keywords.add(withoutExtension)
+  }
+
+  const identifierParts = normalized
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[^A-Za-z0-9]+/)
+    .map((part) => part.toLowerCase())
+    .filter((part) => part.length >= 2)
+
+  for (const part of identifierParts) {
+    keywords.add(part)
+  }
+}
+
+function collectCandidateForbiddenFiles(
+  repoFiles: string[],
+  allowedFiles: string[],
+  packageDirs: string[],
+): string[] {
+  if (allowedFiles.length === 0) {
+    return []
+  }
+
+  const relevantPackageDirs = resolveRelevantPackageDirs(allowedFiles, packageDirs)
+  const allowedSet = new Set(allowedFiles)
+
+  return repoFiles
+    .filter((path) => !allowedSet.has(path))
+    .filter((path) => relevantPackageDirs.some((packageDir) =>
+      packageDir === '.' || path.startsWith(`${packageDir}/`),
+    ))
+    .filter((path) => BROAD_SCOPE_FILE_PATTERNS.some((pattern) => pattern.test(path)))
+    .sort((left, right) => left.localeCompare(right))
+    .slice(0, MAX_FORBIDDEN_FILE_CANDIDATES)
+}
+
+function resolveRelevantPackageDirs(
+  allowedFiles: string[],
+  packageDirs: string[],
+): string[] {
+  const sortedPackageDirs = [...packageDirs].sort((left, right) => right.length - left.length)
+  const relevant = new Set<string>()
+
+  for (const allowedFile of allowedFiles) {
+    const matchedPackage = sortedPackageDirs.find((packageDir) =>
+      packageDir === '.' || allowedFile.startsWith(`${packageDir}/`),
+    )
+
+    if (matchedPackage) {
+      relevant.add(matchedPackage)
+    }
+  }
+
+  return [...relevant].sort((left, right) => left.localeCompare(right))
+}
+
+function pushUniquePath(target: string[], seen: Set<string>, path: string): void {
+  if (seen.has(path)) {
+    return
+  }
+
+  seen.add(path)
+  target.push(path)
+}
+
+function resolveIssueText(input: BuildRepoAuthoringContextInput): string {
+  const explicitIssueText = input.issueText.trim()
+  if (explicitIssueText) {
+    return explicitIssueText
+  }
+
+  return [input.issueTitle, input.issueBody]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join('\n')
+}
+
+function sanitizeRepoRelativeFilePaths(
+  repoRoot: string,
+  repoRelativeFilePaths: string[],
+): string[] {
+  const seen = new Set<string>()
+  const sanitized: string[] = []
+
+  for (const value of repoRelativeFilePaths) {
+    const normalized = value.trim().replace(/\\/g, '/').replace(/^\.\/?/, '')
+    if (!normalized || normalized.startsWith('/')) {
+      continue
+    }
+
+    const absolutePath = resolve(repoRoot, normalized)
+    if (!isPathInsideRepo(repoRoot, absolutePath)) {
+      continue
+    }
+
+    const repoRelativePath = toRepoRelativePath(repoRoot, absolutePath)
+    if (seen.has(repoRelativePath)) {
+      continue
+    }
+
+    seen.add(repoRelativePath)
+    sanitized.push(repoRelativePath)
+  }
+
+  return sanitized.sort((left, right) => left.localeCompare(right))
+}
+
+function collectPackageManifests(
+  repoRoot: string,
+  rootPackageJsonPath?: string,
+  workspacePackageJsonPaths?: string[],
+): PackageManifest[] {
+  const explicitRootPackageJsonPath = rootPackageJsonPath?.trim() || 'package.json'
+  const rootPackage = readPackageManifest(join(repoRoot, explicitRootPackageJsonPath))
+  const manifests: PackageManifest[] = []
+  const packageJsonPaths = new Set<string>([explicitRootPackageJsonPath])
+
+  for (const workspacePackageJsonPath of workspacePackageJsonPaths ?? []) {
+    const normalized = workspacePackageJsonPath.trim()
+    if (normalized) {
+      packageJsonPaths.add(normalized)
+    }
+  }
+
+  if (rootPackage) {
+    manifests.push({
+      dir: '.',
+      scripts: rootPackage.scripts,
+    })
+
+    for (const workspaceDir of expandWorkspacePatterns(repoRoot, extractWorkspacePatterns(rootPackage.raw))) {
+      packageJsonPaths.add(join(workspaceDir, 'package.json').replace(/\\/g, '/'))
+    }
+  }
+
+  for (const packageJsonPath of [...packageJsonPaths].sort((left, right) => left.localeCompare(right))) {
+    if (packageJsonPath === explicitRootPackageJsonPath) {
+      continue
+    }
+
+    const manifest = readPackageManifest(join(repoRoot, packageJsonPath))
+    if (!manifest) {
+      continue
+    }
+
+    const packageDir = dirname(packageJsonPath).replace(/\\/g, '/')
+    manifests.push({
+      dir: packageDir === '.' ? '.' : packageDir,
+      scripts: manifest.scripts,
+    })
+  }
+
+  return manifests
+    .filter((manifest, index, allManifests) =>
+      allManifests.findIndex((candidate) => candidate.dir === manifest.dir) === index,
+    )
+    .sort((left, right) => left.dir.localeCompare(right.dir))
+}
+
+function readPackageManifest(path: string): { raw: PackageManifestRecord; scripts: Record<string, string> } | null {
+  const parsed = readJsonFile<PackageManifestRecord>(path)
+  if (!parsed) {
+    return null
+  }
+
+  return {
+    raw: parsed,
+    scripts: toStringRecord(parsed.scripts),
+  }
+}
+
+function readJsonFile<T>(path: string): T | null {
+  if (!existsSync(path)) {
+    return null
+  }
+
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T
+  } catch {
+    return null
+  }
+}
+
+function toStringRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object') {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  )
+}
+
+function extractWorkspacePatterns(manifest: PackageManifestRecord): string[] {
+  if (Array.isArray(manifest.workspaces)) {
+    return manifest.workspaces.filter((value): value is string => typeof value === 'string')
+  }
+
+  const packages = manifest.workspaces?.packages
+  if (!Array.isArray(packages)) {
+    return []
+  }
+
+  return packages.filter((value): value is string => typeof value === 'string')
+}
+
+function expandWorkspacePatterns(repoRoot: string, patterns: string[]): string[] {
+  const matches = new Set<string>()
+
+  for (const pattern of patterns) {
+    const normalizedPattern = pattern.trim().replace(/\\/g, '/').replace(/^\.\/?/, '').replace(/\/$/, '')
+    if (!normalizedPattern) {
+      continue
+    }
+
+    if (!normalizedPattern.includes('*')) {
+      const literalPath = join(repoRoot, normalizedPattern)
+      if (existsSync(join(literalPath, 'package.json'))) {
+        matches.add(normalizedPattern)
+      }
+      continue
+    }
+
+    const segments = normalizedPattern.split('/').filter(Boolean)
+    visitWorkspacePattern(repoRoot, repoRoot, segments, 0, matches)
+  }
+
+  return [...matches].sort((left, right) => left.localeCompare(right))
+}
+
+function visitWorkspacePattern(
+  repoRoot: string,
+  currentPath: string,
+  segments: string[],
+  index: number,
+  matches: Set<string>,
+): void {
+  if (index >= segments.length) {
+    if (existsSync(join(currentPath, 'package.json'))) {
+      matches.add(toRepoRelativePath(repoRoot, currentPath))
+    }
+    return
+  }
+
+  const segment = segments[index]
+  if (!segment) {
+    return
+  }
+
+  if (segment === '**') {
+    visitWorkspacePattern(repoRoot, currentPath, segments, index + 1, matches)
+    for (const child of listChildDirectories(currentPath)) {
+      visitWorkspacePattern(repoRoot, child, segments, index, matches)
+    }
+    return
+  }
+
+  if (segment === '*') {
+    for (const child of listChildDirectories(currentPath)) {
+      visitWorkspacePattern(repoRoot, child, segments, index + 1, matches)
+    }
+    return
+  }
+
+  const nextPath = join(currentPath, segment)
+  if (existsSync(nextPath)) {
+    visitWorkspacePattern(repoRoot, nextPath, segments, index + 1, matches)
+  }
+}
+
+function listChildDirectories(path: string): string[] {
+  return readdirSync(path, { withFileTypes: true })
+    .filter((entry: Dirent) => entry.isDirectory())
+    .filter((entry: Dirent) => !IGNORED_DIRECTORY_NAMES.has(entry.name))
+    .map((entry: Dirent) => join(path, entry.name))
+    .sort((left, right) => left.localeCompare(right))
+}
+
+function collectRepoFiles(repoRoot: string): string[] {
+  const files: string[] = []
+
+  const visit = (currentPath: string): void => {
+    for (const entry of readdirSync(currentPath, { withFileTypes: true })
+      .sort((left: Dirent, right: Dirent) => left.name.localeCompare(right.name))) {
+      const entryPath = join(currentPath, entry.name)
+
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRECTORY_NAMES.has(entry.name)) {
+          continue
+        }
+
+        visit(entryPath)
+        continue
+      }
+
+      if (entry.isFile()) {
+        files.push(toRepoRelativePath(repoRoot, entryPath))
+      }
+    }
+  }
+
+  visit(repoRoot)
+  return files.sort((left, right) => left.localeCompare(right))
+}
+
+function toRepoRelativePath(repoRoot: string, absolutePath: string): string {
+  return relative(repoRoot, absolutePath).split(sep).join('/')
+}
+
+function isPathInsideRepo(repoRoot: string, absolutePath: string): boolean {
+  const normalizedRoot = resolve(repoRoot)
+  const normalizedPath = resolve(absolutePath)
+  return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}${sep}`)
+}

--- a/apps/agent-daemon/src/issue-authoring.test.ts
+++ b/apps/agent-daemon/src/issue-authoring.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildIssueRewritePrompt,
+  normalizeIssueRewriteMarkdown,
+  rewriteIssueDraft,
+} from './issue-authoring'
+
+describe('rewriteIssueDraft', () => {
+  test('falls back to an empty authoring context when repoRoot does not exist', async () => {
+    const output = await rewriteIssueDraft({
+      issueText: '修复 ready gate 对 Validation 缺失路径的提示，并补测试',
+      repoRoot: '/tmp/nonexistent-agent-loop-repo',
+      runAgent: async () => ({
+        responseText: `## 用户故事
+
+作为 维护者，我希望 ready gate 能明确指出 validation 引用缺失的路径，从而更快修复不可执行 issue。
+
+## Context
+
+### Dependencies
+\`\`\`json
+{"dependsOn":[]}
+\`\`\`
+
+### Constraints
+- 只修 ready gate 的 validation path 提示
+
+### AllowedFiles
+- apps/agent-daemon/src/ready-gate.ts
+- apps/agent-daemon/src/ready-gate.test.ts
+
+### ForbiddenFiles
+- apps/agent-daemon/src/daemon.ts
+
+### MustPreserve
+- 已有 hard validation 错误语义保持不变
+
+### OutOfScope
+- issue simulate
+
+### RequiredSemantics
+- 缺失路径时错误里包含 repo-relative path
+
+### ReviewHints
+- 检查 path 解析是否只影响 validation target 分支
+
+### Validation
+- \`bun test apps/agent-daemon/src/ready-gate.test.ts\`
+- \`git diff --stat origin/main...HEAD\`
+
+## RED 测试
+
+\`\`\`ts
+throw new Error('red')
+\`\`\`
+
+## 实现步骤
+
+1. 先补失败测试
+2. 再补最小实现
+3. 最后跑验证
+
+## 验收
+
+- [ ] 只改 ready gate 相关文件
+- [ ] RED 测试转绿`,
+      }),
+    })
+
+    expect(output.validation.valid).toBe(true)
+    expect(output.markdown.startsWith('## 用户故事')).toBe(true)
+  })
+
+  test('returns canonical executable contract markdown validated against local rules', async () => {
+    let capturedPrompt = ''
+
+    const output = await rewriteIssueDraft({
+      issueText: '修复 ready gate 对 Validation 缺失路径的提示，并补测试',
+      repoRoot: '/tmp/repo',
+      buildAuthoringContext: async () => ({
+        candidateValidationCommands: [
+          'bun test apps/agent-daemon/src/ready-gate.test.ts',
+        ],
+        candidateAllowedFiles: [
+          'apps/agent-daemon/src/ready-gate.ts',
+          'apps/agent-daemon/src/ready-gate.test.ts',
+        ],
+        candidateForbiddenFiles: [
+          'apps/agent-daemon/src/daemon.ts',
+        ],
+      }),
+      runAgent: async ({ prompt }) => {
+        capturedPrompt = prompt
+
+        return {
+          responseText: `## 用户故事
+
+作为 维护者，我希望 ready gate 能明确指出 validation 引用缺失的路径，从而更快修复不可执行 issue。
+
+## Context
+
+### Dependencies
+\`\`\`json
+{"dependsOn":[]}
+\`\`\`
+
+### Constraints
+- 只修 ready gate 的 validation path 提示
+
+### AllowedFiles
+- apps/agent-daemon/src/ready-gate.ts
+- apps/agent-daemon/src/ready-gate.test.ts
+
+### ForbiddenFiles
+- apps/agent-daemon/src/daemon.ts
+
+### MustPreserve
+- 已有 hard validation 错误语义保持不变
+
+### OutOfScope
+- issue simulate
+
+### RequiredSemantics
+- 缺失路径时错误里包含 repo-relative path
+
+### ReviewHints
+- 检查 path 解析是否只影响 validation target 分支
+
+### Validation
+- \`bun test apps/agent-daemon/src/ready-gate.test.ts\`
+- \`git diff --stat origin/main...HEAD\`
+
+## RED 测试
+
+\`\`\`ts
+throw new Error('red')
+\`\`\`
+
+## 实现步骤
+
+1. 先补失败测试
+2. 再补最小实现
+3. 最后跑验证
+
+## 验收
+
+- [ ] 只改 ready gate 相关文件
+- [ ] RED 测试转绿`,
+        }
+      },
+    })
+
+    expect(output.validation.valid).toBe(true)
+    expect(output.markdown.startsWith('## 用户故事')).toBe(true)
+    expect(output.markdown).toContain('### Dependencies')
+    expect(output.markdown).toContain('### AllowedFiles')
+    expect(capturedPrompt).toContain('Candidate Validation Commands')
+    expect(capturedPrompt).toContain('apps/agent-daemon/src/ready-gate.ts')
+  })
+
+  test('fails with explicit local contract validation errors when agent output is invalid', async () => {
+    await expect(rewriteIssueDraft({
+      issueText: '修复 ready gate 对 Validation 缺失路径的提示，并补测试',
+      repoRoot: '/tmp/repo',
+      buildAuthoringContext: async () => ({
+        candidateValidationCommands: [],
+        candidateAllowedFiles: [],
+        candidateForbiddenFiles: [],
+      }),
+      runAgent: async () => ({
+        responseText: `## 用户故事
+
+作为 维护者，我希望 rewrite 失败时给出具体错误。`,
+      }),
+    })).rejects.toThrow('rewrite output failed contract validation')
+  })
+
+  test('strips a single outer markdown fence so the result can be pasted directly into GitHub', async () => {
+    const output = await rewriteIssueDraft({
+      issueText: '修复 ready gate 对 Validation 缺失路径的提示，并补测试',
+      repoRoot: '/tmp/repo',
+      buildAuthoringContext: async () => ({
+        candidateValidationCommands: [],
+        candidateAllowedFiles: [],
+        candidateForbiddenFiles: [],
+      }),
+      runAgent: async () => ({
+        responseText: `\`\`\`markdown
+## 用户故事
+
+作为 维护者，我希望 rewrite 输出不带外层 fence。
+
+## Context
+
+### Dependencies
+\`\`\`json
+{"dependsOn":[]}
+\`\`\`
+
+### Constraints
+- 只支持本地输入
+
+### AllowedFiles
+- apps/agent-daemon/src/issue-authoring.ts
+
+### ForbiddenFiles
+- apps/agent-daemon/src/daemon.ts
+
+### MustPreserve
+- 默认保持只读
+
+### OutOfScope
+- 自动修改远程 issue
+
+### RequiredSemantics
+- 输出 markdown 本体
+
+### ReviewHints
+- 检查输出前后没有说明 prose
+
+### Validation
+- \`bun test apps/agent-daemon/src/issue-authoring.test.ts\`
+- \`git diff --stat origin/main...HEAD\`
+
+## RED 测试
+
+\`\`\`ts
+throw new Error('red')
+\`\`\`
+
+## 实现步骤
+
+1. 先规范输出
+2. 再验证合同
+
+## 验收
+
+- [ ] markdown 可直接粘贴
+\`\`\``,
+      }),
+    })
+
+    expect(output.markdown.startsWith('## 用户故事')).toBe(true)
+    expect(output.markdown).not.toContain('```markdown')
+  })
+})
+
+describe('issue-authoring helpers', () => {
+  test('buildIssueRewritePrompt embeds repo-grounded suggestions', () => {
+    const prompt = buildIssueRewritePrompt({
+      issueText: '修复 ready gate 对 Validation 缺失路径的提示，并补测试',
+      authoringContext: {
+        candidateValidationCommands: ['bun test apps/agent-daemon/src/ready-gate.test.ts'],
+        candidateAllowedFiles: ['apps/agent-daemon/src/ready-gate.ts'],
+        candidateForbiddenFiles: ['apps/agent-daemon/src/daemon.ts'],
+      },
+    })
+
+    expect(prompt).toContain('Candidate Validation Commands')
+    expect(prompt).toContain('apps/agent-daemon/src/ready-gate.ts')
+    expect(prompt).toContain('### Dependencies')
+  })
+
+  test('normalizeIssueRewriteMarkdown removes one outer fence and trims whitespace', () => {
+    expect(normalizeIssueRewriteMarkdown('\n```md\n## 用户故事\n```\n')).toBe('## 用户故事')
+  })
+})

--- a/apps/agent-daemon/src/issue-authoring.ts
+++ b/apps/agent-daemon/src/issue-authoring.ts
@@ -1,0 +1,172 @@
+import { existsSync } from 'node:fs'
+import {
+  buildIssueQualityReport,
+  parseIssueContract,
+  type AgentConfig,
+  type IssueQualityReport,
+} from '@agent/shared'
+import { runConfiguredAgent } from './cli-agent'
+import {
+  buildRepoAuthoringContext,
+  type RepoAuthoringContext,
+} from './issue-authoring-context'
+
+export interface IssueAuthoringAgentRunInput {
+  prompt: string
+  repoRoot: string
+  config?: AgentConfig
+}
+
+export interface IssueAuthoringAgentRunResult {
+  responseText: string
+}
+
+export interface RewriteIssueDraftInput {
+  issueText: string
+  repoRoot: string
+  config?: AgentConfig
+  buildAuthoringContext?: (input: {
+    repoRoot: string
+    issueText: string
+  }) => Promise<RepoAuthoringContext>
+  runAgent?: (
+    input: IssueAuthoringAgentRunInput,
+  ) => Promise<IssueAuthoringAgentRunResult>
+}
+
+export interface RewriteIssueDraftResult {
+  markdown: string
+  validation: IssueQualityReport
+}
+
+export async function rewriteIssueDraft(
+  input: RewriteIssueDraftInput,
+): Promise<RewriteIssueDraftResult> {
+  const buildContext = input.buildAuthoringContext ?? defaultBuildAuthoringContext
+  const runAgent = input.runAgent ?? defaultRunIssueAuthoringAgent
+  const authoringContext = await buildContext({
+    repoRoot: input.repoRoot,
+    issueText: input.issueText,
+  })
+  const prompt = buildIssueRewritePrompt({
+    issueText: input.issueText,
+    authoringContext,
+  })
+  const agentResult = await runAgent({
+    prompt,
+    repoRoot: input.repoRoot,
+    config: input.config,
+  })
+  const markdown = normalizeIssueRewriteMarkdown(agentResult.responseText)
+
+  if (!markdown.startsWith('## 用户故事') && !markdown.startsWith('## User Story')) {
+    throw new Error('rewrite output must be canonical markdown only and start with ## 用户故事 / User Story')
+  }
+
+  const validation = buildIssueQualityReport(parseIssueContract(markdown))
+  if (!validation.valid) {
+    throw new Error(`rewrite output failed contract validation: ${validation.errors.join(' | ')}`)
+  }
+
+  return {
+    markdown,
+    validation,
+  }
+}
+
+export function buildIssueRewritePrompt(input: {
+  issueText: string
+  authoringContext: RepoAuthoringContext
+}): string {
+  const blocks = [
+    '你是 agent-loop 的 issue rewrite worker。',
+    '把下面的模糊 issue 草稿重写成 canonical executable contract markdown。',
+    '输出要求：',
+    '- 只输出 markdown 合同本体，不要在前后加解释性 prose。',
+    '- 不要把整份输出再包一层 ```markdown fenced code block。',
+    '- 必须使用现有 canonical section 结构，并保留 `### Dependencies` 的 fenced JSON。',
+    '- `### Validation` 必须只包含可执行命令。',
+    '- 优先使用 repo-grounded authoring context 提供的候选路径和命令，不要猜宽泛 scope。',
+    'Canonical section order:',
+    '1. `## 用户故事`',
+    '2. `## Context`',
+    '3. `### Dependencies`',
+    '4. `### Constraints`',
+    '5. `### AllowedFiles`',
+    '6. `### ForbiddenFiles`',
+    '7. `### MustPreserve`',
+    '8. `### OutOfScope`',
+    '9. `### RequiredSemantics`',
+    '10. `### ReviewHints`',
+    '11. `### Validation`',
+    '12. `## RED 测试`',
+    '13. `## 实现步骤`',
+    '14. `## 验收`',
+    renderSuggestionBlock('Candidate Validation Commands', input.authoringContext.candidateValidationCommands),
+    renderSuggestionBlock('Candidate Allowed Files', input.authoringContext.candidateAllowedFiles),
+    renderSuggestionBlock('Candidate Forbidden Files', input.authoringContext.candidateForbiddenFiles),
+    'Draft issue text:',
+    '```markdown',
+    input.issueText.trim(),
+    '```',
+  ]
+
+  return blocks.filter(Boolean).join('\n\n')
+}
+
+export function normalizeIssueRewriteMarkdown(responseText: string): string {
+  const trimmed = responseText.trim()
+  const fencedMatch = trimmed.match(/^```(?:markdown|md)?\s*\n([\s\S]*?)\n```$/i)
+  return (fencedMatch?.[1] ?? trimmed).trim()
+}
+
+function renderSuggestionBlock(title: string, values: string[]): string {
+  if (values.length === 0) {
+    return `${title}:\n- (none found; keep the rewrite explicit and tightly scoped)`
+  }
+
+  return `${title}:\n${values.map((value) => `- ${value}`).join('\n')}`
+}
+
+async function defaultBuildAuthoringContext(input: {
+  repoRoot: string
+  issueText: string
+}): Promise<RepoAuthoringContext> {
+  if (!existsSync(input.repoRoot)) {
+    return {
+      candidateValidationCommands: [],
+      candidateAllowedFiles: [],
+      candidateForbiddenFiles: [],
+    }
+  }
+
+  return buildRepoAuthoringContext({
+    repoRoot: input.repoRoot,
+    issueText: input.issueText,
+  })
+}
+
+async function defaultRunIssueAuthoringAgent(
+  input: IssueAuthoringAgentRunInput,
+): Promise<IssueAuthoringAgentRunResult> {
+  if (!input.config) {
+    throw new Error('rewriteIssueDraft requires config when no custom runAgent is provided')
+  }
+
+  const result = await runConfiguredAgent({
+    prompt: input.prompt,
+    worktreePath: input.repoRoot,
+    timeoutMs: input.config.agent.timeoutMs,
+    config: input.config,
+    allowWrites: false,
+  })
+
+  if (!result.ok) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.exitCode}`
+    throw new Error(`issue rewrite agent failed: ${detail}`)
+  }
+
+  return {
+    responseText: result.responseText,
+  }
+}

--- a/apps/agent-daemon/src/issue-splitter.test.ts
+++ b/apps/agent-daemon/src/issue-splitter.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildTrackingIssueSplitPrompt,
+  parseTrackingIssueSplitPlan,
+  splitTrackingIssue,
+} from './issue-splitter'
+
+describe('splitTrackingIssue', () => {
+  test('returns ordered child issue contracts with explicit dependsOn arrays', async () => {
+    const result = await splitTrackingIssue({
+      title: '[AL-EPIC] 把 issue 质量能力接入 agent-loop',
+      body: '需要补 issue lint、rewrite、split 和 simulate 四块能力',
+      repoRoot: '/tmp/repo',
+      buildAuthoringContext: async () => ({
+        candidateValidationCommands: [
+          'bun test apps/agent-daemon/src/issue-splitter.test.ts',
+        ],
+        candidateAllowedFiles: [
+          'apps/agent-daemon/src/issue-splitter.ts',
+          'apps/agent-daemon/src/issue-splitter.test.ts',
+        ],
+        candidateForbiddenFiles: [
+          'apps/agent-daemon/src/daemon.ts',
+        ],
+      }),
+      runAgent: async () => ({
+        responseText: `1. [AL-X] 引入 issue lint
+2. [AL-Y] 增加 rewrite CLI
+3. [AL-Z] 增加 split CLI`,
+      }),
+      issueNumberAllocator: (() => {
+        let current = 17
+        return () => current++
+      })(),
+    })
+
+    expect(result.children).toHaveLength(3)
+    expect(result.children[0]?.body).toContain('"dependsOn":[]')
+    expect(result.children[1]?.body).toContain('"dependsOn":[17]')
+    expect(result.children[2]?.body).toContain('"dependsOn":[17,18]')
+    for (const child of result.children) {
+      const outsideDependencyJson = child.body.replace(
+        /###\s+Dependencies\s*\n```json\s*\n[\s\S]*?\n```/m,
+        '',
+      )
+      expect(outsideDependencyJson).not.toContain('dependsOn')
+    }
+    expect(result.children.every((child) => child.body.includes('## RED 测试'))).toBe(true)
+    expect(result.markdown).toContain('## Parent Summary')
+    expect(result.markdown).toContain('1. #17 [AL-X] 引入 issue lint')
+    expect(result.markdown).not.toContain('(dependsOn:')
+    expect(result.markdown.split('## Child Issue #')[0]).not.toContain('dependsOn')
+  })
+
+  test('uses explicit dependency ids from strict JSON plans', async () => {
+    const result = await splitTrackingIssue({
+      title: '[AL-EPIC] issue authoring pipeline',
+      body: '父 issue 负责串起 lint、rewrite、split 三条子线。',
+      repoRoot: '/tmp/repo',
+      buildAuthoringContext: async () => ({
+        candidateValidationCommands: [
+          'bun test apps/agent-daemon/src/issue-splitter.test.ts',
+          'bun run typecheck',
+        ],
+        candidateAllowedFiles: [
+          'apps/agent-daemon/src/issue-splitter.ts',
+          'apps/agent-daemon/src/issue-authoring.ts',
+          'apps/agent-daemon/src/index.ts',
+        ],
+        candidateForbiddenFiles: [
+          'apps/agent-daemon/src/daemon.ts',
+        ],
+      }),
+      runAgent: async () => ({
+        responseText: `\`\`\`json
+{
+  "parentSummary": "按 lint -> rewrite -> split 的顺序推进 child issues。",
+  "children": [
+    {
+      "id": "lint",
+      "title": "[AL-LINT] 引入 issue lint",
+      "summary": "让维护者先看到 child contract 的质量报告",
+      "allowedFiles": ["apps/agent-daemon/src/issue-splitter.ts"],
+      "outOfScope": ["rewrite CLI"],
+      "requiredSemantics": ["输出可读的质量报告"],
+      "dependsOn": []
+    },
+    {
+      "id": "rewrite",
+      "title": "[AL-REWRITE] 增加 rewrite CLI",
+      "summary": "让维护者能把模糊草稿重写成 canonical contract",
+      "allowedFiles": ["apps/agent-daemon/src/issue-authoring.ts"],
+      "outOfScope": ["split CLI"],
+      "requiredSemantics": ["输出 canonical executable contract"],
+      "dependsOn": ["lint"]
+    },
+    {
+      "id": "split",
+      "title": "[AL-SPLIT] 增加 split CLI",
+      "summary": "让维护者能把 tracking parent 拆成 child contracts",
+      "allowedFiles": ["apps/agent-daemon/src/index.ts"],
+      "outOfScope": ["issue simulate"],
+      "requiredSemantics": ["回填最终 dependsOn 图"],
+      "dependsOn": ["rewrite"]
+    }
+  ]
+}
+\`\`\``,
+      }),
+      rewriteIssueDraft: async ({ issueText }) => {
+        if (issueText.includes('[AL-LINT]')) {
+          return buildCanonicalRewriteResult('[AL-LINT] 引入 issue lint', 'apps/agent-daemon/src/issue-splitter.ts')
+        }
+
+        if (issueText.includes('[AL-REWRITE]')) {
+          return buildCanonicalRewriteResult('[AL-REWRITE] 增加 rewrite CLI', 'apps/agent-daemon/src/issue-authoring.ts')
+        }
+
+        return buildCanonicalRewriteResult('[AL-SPLIT] 增加 split CLI', 'apps/agent-daemon/src/index.ts')
+      },
+      issueNumberAllocator: (() => {
+        let current = 41
+        return () => current++
+      })(),
+    })
+
+    expect(result.parentSummary).toContain('lint -> rewrite -> split')
+    expect(result.children).toHaveLength(3)
+    expect(result.children[0]?.dependsOn).toEqual([])
+    expect(result.children[1]?.dependsOn).toEqual([41])
+    expect(result.children[2]?.dependsOn).toEqual([42])
+    expect(result.children[2]?.body).toContain('"dependsOn":[42]')
+  })
+
+  test('rejects child markdown that still carries issue quality warnings', async () => {
+    await expect(splitTrackingIssue({
+      title: '[AL-EPIC] 质量守门',
+      body: '确保 split 输出不能带宽泛 AllowedFiles。',
+      repoRoot: '/tmp/repo',
+      buildAuthoringContext: async () => ({
+        candidateValidationCommands: ['bun test apps/agent-daemon/src/issue-splitter.test.ts'],
+        candidateAllowedFiles: ['apps/agent-daemon/src/issue-splitter.ts'],
+        candidateForbiddenFiles: ['apps/agent-daemon/src/daemon.ts'],
+      }),
+      runAgent: async () => ({
+        responseText: '1. [AL-X] 收紧 AllowedFiles',
+      }),
+      rewriteIssueDraft: async () => buildCanonicalRewriteResult('[AL-X] 收紧 AllowedFiles', 'frontend files'),
+    })).rejects.toThrow('failed quality checks')
+  })
+
+  test('rejects child markdown that mentions dependsOn outside the dependency json block', async () => {
+    await expect(splitTrackingIssue({
+      title: '[AL-EPIC] 依赖约束',
+      body: '确保 split 输出只在机器可读 JSON 中携带 dependsOn。',
+      repoRoot: '/tmp/repo',
+      buildAuthoringContext: async () => ({
+        candidateValidationCommands: ['bun test apps/agent-daemon/src/issue-splitter.test.ts'],
+        candidateAllowedFiles: ['apps/agent-daemon/src/issue-splitter.ts'],
+        candidateForbiddenFiles: ['apps/agent-daemon/src/daemon.ts'],
+      }),
+      runAgent: async () => ({
+        responseText: '1. [AL-X] 收紧依赖输出',
+      }),
+      rewriteIssueDraft: async () => ({
+        ...buildCanonicalRewriteResult('[AL-X] 收紧依赖输出', 'apps/agent-daemon/src/issue-splitter.ts'),
+        markdown: `${buildCanonicalRewriteResult('[AL-X] 收紧依赖输出', 'apps/agent-daemon/src/issue-splitter.ts').markdown}\n\n额外说明：不要在 prose 里重复 dependsOn。`,
+      }),
+    })).rejects.toThrow('mentions dependsOn outside the ### Dependencies fenced JSON block')
+  })
+
+  test('rejects child markdown that omits canonical child contract sections', async () => {
+    await expect(splitTrackingIssue({
+      title: '[AL-EPIC] contract 完整性',
+      body: '确保 split 输出缺少必需 section 时会被本地拒绝。',
+      repoRoot: '/tmp/repo',
+      buildAuthoringContext: async () => ({
+        candidateValidationCommands: ['bun test apps/agent-daemon/src/issue-splitter.test.ts'],
+        candidateAllowedFiles: ['apps/agent-daemon/src/issue-splitter.ts'],
+        candidateForbiddenFiles: ['apps/agent-daemon/src/daemon.ts'],
+      }),
+      runAgent: async () => ({
+        responseText: '1. [AL-X] 收紧 child contract',
+      }),
+      rewriteIssueDraft: async () => ({
+        ...buildCanonicalRewriteResult('[AL-X] 收紧 child contract', 'apps/agent-daemon/src/issue-splitter.ts'),
+        markdown: buildCanonicalRewriteResult('[AL-X] 收紧 child contract', 'apps/agent-daemon/src/issue-splitter.ts')
+          .markdown
+          .replace('### OutOfScope\n- sibling child 的后续工作\n\n', ''),
+      }),
+    })).rejects.toThrow('missing required section ### OutOfScope')
+  })
+})
+
+describe('issue-splitter helpers', () => {
+  test('buildTrackingIssueSplitPrompt embeds repo-grounded suggestions and strict JSON guidance', () => {
+    const prompt = buildTrackingIssueSplitPrompt({
+      title: '[AL-EPIC] issue authoring pipeline',
+      body: '父 issue 负责串起 lint、rewrite、split 三条子线。',
+      issueText: '父 issue 负责串起 lint、rewrite、split 三条子线。',
+      authoringContext: {
+        candidateValidationCommands: ['bun test apps/agent-daemon/src/issue-splitter.test.ts'],
+        candidateAllowedFiles: ['apps/agent-daemon/src/issue-splitter.ts'],
+        candidateForbiddenFiles: ['apps/agent-daemon/src/daemon.ts'],
+      },
+    })
+
+    expect(prompt).toContain('strict JSON object')
+    expect(prompt).toContain('Candidate Allowed Files')
+    expect(prompt).toContain('apps/agent-daemon/src/issue-splitter.ts')
+  })
+
+  test('parseTrackingIssueSplitPlan falls back to numbered-list parsing', () => {
+    const plan = parseTrackingIssueSplitPlan(`1. [AL-X] 引入 issue lint
+2. [AL-Y] 增加 rewrite CLI`)
+
+    expect(plan.children).toHaveLength(2)
+    expect(plan.children[0]?.title).toBe('[AL-X] 引入 issue lint')
+    expect(plan.children[1]?.hasExplicitDependencies).toBe(false)
+  })
+})
+
+function buildCanonicalRewriteResult(title: string, allowedFile: string) {
+  return {
+    markdown: `## 用户故事
+
+作为 \`agent-loop\` 维护者，我希望 ${title}，从而让 split 输出保持 canonical issue contract。
+
+## Context
+
+### Dependencies
+\`\`\`json
+{"dependsOn":[]}
+\`\`\`
+
+### Constraints
+- 只实现当前 child 对应的功能切片
+
+### AllowedFiles
+- ${allowedFile}
+
+### ForbiddenFiles
+- apps/agent-daemon/src/daemon.ts
+
+### MustPreserve
+- parent issue 仍然是 tracking-only
+
+### OutOfScope
+- sibling child 的后续工作
+
+### RequiredSemantics
+- 输出当前 child 对应的代码变更与测试
+
+### ReviewHints
+- 检查 scope 是否仍然足够具体
+
+### Validation
+- \`bun test apps/agent-daemon/src/issue-splitter.test.ts\`
+- \`git diff --stat origin/main...HEAD\`
+
+## RED 测试
+
+\`\`\`ts
+throw new Error('red')
+\`\`\`
+
+## 实现步骤
+
+1. 先补失败测试
+2. 再补最小实现
+3. 最后运行验证
+
+## 验收
+
+- [ ] 只修改 AllowedFiles 内文件
+- [ ] Validation 中命令执行通过`,
+    validation: {
+      valid: true,
+      score: 100,
+      errors: [],
+      warnings: [],
+    },
+  }
+}

--- a/apps/agent-daemon/src/issue-splitter.ts
+++ b/apps/agent-daemon/src/issue-splitter.ts
@@ -1,0 +1,903 @@
+import { existsSync } from 'node:fs'
+import {
+  buildIssueQualityReport,
+  parseIssueContract,
+  renderIssueContractForPrompt,
+  type AgentConfig,
+  type IssueQualityReport,
+} from '@agent/shared'
+import { runConfiguredAgent } from './cli-agent'
+import { rewriteIssueDraft, type RewriteIssueDraftInput, type RewriteIssueDraftResult } from './issue-authoring'
+import {
+  buildRepoAuthoringContext,
+  type RepoAuthoringContext,
+} from './issue-authoring-context'
+
+type DependencyReference = string | number
+
+export interface TrackingIssueSplitPlanChild {
+  id: string
+  title: string
+  summary: string
+  scopeHints: string[]
+  allowedFiles: string[]
+  outOfScope: string[]
+  requiredSemantics: string[]
+  dependencyReferences: DependencyReference[]
+  hasExplicitDependencies: boolean
+}
+
+export interface TrackingIssueSplitPlan {
+  parentSummary: string
+  children: TrackingIssueSplitPlanChild[]
+}
+
+interface AllocatedTrackingIssueSplitPlanChild extends TrackingIssueSplitPlanChild {
+  number: number
+}
+
+export interface IssueSplitterAgentRunInput {
+  prompt: string
+  repoRoot: string
+  config?: AgentConfig
+}
+
+export interface IssueSplitterAgentRunResult {
+  responseText: string
+}
+
+export interface SplitTrackingIssueInput {
+  title?: string
+  body?: string
+  issueText?: string
+  repoRoot: string
+  config?: AgentConfig
+  issueNumberAllocator?: () => number
+  buildAuthoringContext?: (input: {
+    repoRoot: string
+    issueText: string
+    issueTitle?: string
+    issueBody?: string
+  }) => Promise<RepoAuthoringContext>
+  runAgent?: (
+    input: IssueSplitterAgentRunInput,
+  ) => Promise<IssueSplitterAgentRunResult>
+  rewriteIssueDraft?: (
+    input: RewriteIssueDraftInput,
+  ) => Promise<RewriteIssueDraftResult>
+}
+
+export interface SplitTrackingIssueChildResult {
+  number: number
+  title: string
+  body: string
+  dependsOn: number[]
+  validation: IssueQualityReport
+}
+
+export interface SplitTrackingIssueResult {
+  parentSummary: string
+  children: SplitTrackingIssueChildResult[]
+  markdown: string
+}
+
+const MAX_CHILD_ISSUES = 8
+const REQUIRED_CHILD_CONTRACT_SECTIONS = [
+  '## 用户故事',
+  '## Context',
+  '### Dependencies',
+  '### Constraints',
+  '### AllowedFiles',
+  '### ForbiddenFiles',
+  '### MustPreserve',
+  '### OutOfScope',
+  '### RequiredSemantics',
+  '### ReviewHints',
+  '### Validation',
+  '## RED 测试',
+  '## 实现步骤',
+  '## 验收',
+] as const
+
+export async function splitTrackingIssue(
+  input: SplitTrackingIssueInput,
+): Promise<SplitTrackingIssueResult> {
+  const buildContext = input.buildAuthoringContext ?? defaultBuildAuthoringContext
+  const runAgent = input.runAgent ?? defaultRunIssueSplitterAgent
+  const rewrite = input.rewriteIssueDraft ?? rewriteIssueDraft
+  const source = resolveTrackingIssueSource(input)
+  const authoringContext = await buildContext({
+    repoRoot: input.repoRoot,
+    issueText: source.issueText,
+    issueTitle: source.title,
+    issueBody: source.body,
+  })
+  const parentContract = parseIssueContract(source.body)
+  const planPrompt = buildTrackingIssueSplitPrompt({
+    title: source.title,
+    body: source.body,
+    issueText: source.issueText,
+    authoringContext,
+  })
+  const agentResult = await runAgent({
+    prompt: planPrompt,
+    repoRoot: input.repoRoot,
+    config: input.config,
+  })
+  const splitPlan = parseTrackingIssueSplitPlan(agentResult.responseText)
+  const allocator = input.issueNumberAllocator ?? createSequentialIssueNumberAllocator()
+  const allocatedChildren = allocateChildIssueNumbers(splitPlan.children, allocator)
+  const dependencyNumbersByChild = resolveChildDependencyNumbers(allocatedChildren)
+  const childResults: SplitTrackingIssueChildResult[] = []
+  const shouldUseRewrite = Boolean(input.rewriteIssueDraft || input.config)
+
+  for (let index = 0; index < allocatedChildren.length; index += 1) {
+    const child = allocatedChildren[index]!
+    const dependsOn = dependencyNumbersByChild[index] ?? []
+    const draftedMarkdown = shouldUseRewrite
+      ? (await rewrite({
+        issueText: buildChildIssueDraft({
+          parentTitle: source.title,
+          parentBody: source.body,
+          child,
+        }),
+        repoRoot: input.repoRoot,
+        config: input.config,
+      })).markdown
+      : renderDeterministicChildIssue({
+        parentTitle: source.title,
+        parentContract,
+        authoringContext,
+        child,
+        siblingTitles: allocatedChildren.map((candidate) => candidate.title),
+        dependsOn,
+      })
+    const finalizedMarkdown = applyIssueDependencies(draftedMarkdown, dependsOn)
+    const splitValidationErrors = validateSplitChildContract(finalizedMarkdown)
+
+    if (splitValidationErrors.length > 0) {
+      throw new Error(`split child ${child.title} failed contract validation: ${splitValidationErrors.join(' | ')}`)
+    }
+
+    const validation = buildIssueQualityReport(parseIssueContract(finalizedMarkdown))
+
+    if (!validation.valid) {
+      throw new Error(`split child ${child.title} failed contract validation: ${validation.errors.join(' | ')}`)
+    }
+
+    if (validation.warnings.length > 0) {
+      throw new Error(`split child ${child.title} failed quality checks: ${validation.warnings.join(' | ')}`)
+    }
+
+    childResults.push({
+      number: child.number,
+      title: child.title,
+      body: finalizedMarkdown,
+      dependsOn,
+      validation,
+    })
+  }
+
+  const parentSummary = splitPlan.parentSummary.trim() || buildFallbackParentSummary({
+    title: source.title,
+    children: childResults,
+  })
+
+  return {
+    parentSummary,
+    children: childResults,
+    markdown: formatTrackingIssueSplitResult({
+      parentTitle: source.title,
+      parentSummary,
+      children: childResults,
+    }),
+  }
+}
+
+export function buildTrackingIssueSplitPrompt(input: {
+  title: string
+  body: string
+  issueText: string
+  authoringContext: RepoAuthoringContext
+}): string {
+  const parentContract = renderIssueContractForPrompt(input.body)
+  const blocks = [
+    '你是 agent-loop 的 tracking issue split worker。',
+    '把一个 tracking parent issue 拆成 execution-sized child issue plans，再交给 rewrite worker 生成 canonical executable contracts。',
+    '输出要求：',
+    '- 只输出 strict JSON object，不要输出 markdown、解释、前后缀 prose。',
+    '- `children` 必须保持执行顺序；每个 child 都必须是 code-producing slice，而不是 investigation-only task。',
+    '- `dependsOn` 只能引用更早的 sibling child，优先使用 child `id`；没有依赖就输出 `[]`。',
+    '- `allowedFiles`、`outOfScope`、`requiredSemantics` 要尽量具体，能支撑 reviewer 和 auto-fix。',
+    '- parent issue 仍然是 tracking-only，不进入 `agent:ready`。',
+    'JSON schema:',
+    '```json',
+    JSON.stringify({
+      parentSummary: '一段 tracking summary，概括 parent 如何串起下面的 child issues',
+      children: [
+        {
+          id: 'issue-lint',
+          title: '[AL-X] 引入 issue lint',
+          summary: '一句话描述这个 child 的目标与价值',
+          scopeHints: ['实现范围提示'],
+          allowedFiles: ['apps/agent-daemon/src/example.ts'],
+          outOfScope: ['不属于这个 child 的后续工作'],
+          requiredSemantics: ['必须保留或新增的行为'],
+          dependsOn: [],
+        },
+      ],
+    }, null, 2),
+    '```',
+    renderSuggestionBlock('Candidate Validation Commands', input.authoringContext.candidateValidationCommands),
+    renderSuggestionBlock('Candidate Allowed Files', input.authoringContext.candidateAllowedFiles),
+    renderSuggestionBlock('Candidate Forbidden Files', input.authoringContext.candidateForbiddenFiles),
+    'Parsed parent contract:',
+    parentContract || '(no structured parent contract detected; still keep the split concrete and code-producing)',
+    `Parent title: ${input.title}`,
+    'Parent issue body:',
+    '```markdown',
+    input.body.trim() || input.issueText.trim(),
+    '```',
+  ]
+
+  return blocks.filter(Boolean).join('\n\n')
+}
+
+export function parseTrackingIssueSplitPlan(responseText: string): TrackingIssueSplitPlan {
+  const normalized = normalizeSplitPlanText(responseText)
+  const jsonValue = tryParseSplitPlanJson(normalized)
+
+  if (jsonValue !== null) {
+    return parseTrackingIssueSplitPlanJson(jsonValue)
+  }
+
+  return parseTrackingIssueSplitPlanList(normalized)
+}
+
+export function createSequentialIssueNumberAllocator(startNumber = 1): () => number {
+  if (!Number.isSafeInteger(startNumber) || startNumber <= 0) {
+    throw new Error('issue number allocator startNumber must be a positive integer')
+  }
+
+  let current = startNumber
+  return () => current++
+}
+
+export function buildChildIssueDraft(input: {
+  parentTitle: string
+  parentBody: string
+  child: Pick<
+    TrackingIssueSplitPlanChild,
+    'title' | 'summary' | 'scopeHints' | 'allowedFiles' | 'outOfScope' | 'requiredSemantics'
+  >
+}): string {
+  const blocks = [
+    input.child.title.trim(),
+    input.child.summary.trim(),
+    `Parent tracking issue: ${input.parentTitle}`,
+    renderSuggestionBlock('Scope Hints', input.child.scopeHints),
+    renderSuggestionBlock('Allowed File Hints', input.child.allowedFiles),
+    renderSuggestionBlock('Out Of Scope For This Child', input.child.outOfScope),
+    renderSuggestionBlock('Required Semantics For This Child', input.child.requiredSemantics),
+    'Inherited parent contract:',
+    renderIssueContractForPrompt(input.parentBody) || input.parentBody.trim(),
+    '要求：',
+    '- 这条 child issue 必须是 code-producing contract，并包含 RED 测试、实现步骤、验收和可执行 Validation 命令。',
+    '- 保留 canonical executable contract section order。',
+    '- 先保留一个合法的 `### Dependencies` fenced JSON block；最终 `dependsOn` 数组会在 split pipeline 里回填。',
+    '- 不要把 sibling 的未来工作偷偷混进当前 child 的 RequiredSemantics 或 AllowedFiles。',
+  ]
+
+  return blocks.filter(Boolean).join('\n\n')
+}
+
+export function applyIssueDependencies(markdown: string, dependsOn: number[]): string {
+  const dependencyBlockPattern = /(###\s+Dependencies\s*\n```json\s*\n)([\s\S]*?)(\n```)/m
+
+  if (!dependencyBlockPattern.test(markdown)) {
+    throw new Error('split child is missing a ### Dependencies fenced JSON block')
+  }
+
+  return markdown.replace(
+    dependencyBlockPattern,
+    `$1${JSON.stringify({ dependsOn })}$3`,
+  )
+}
+
+function validateSplitChildContract(markdown: string): string[] {
+  const errors: string[] = []
+  const dependencyBlockPattern = /###\s+Dependencies\s*\n```json\s*\n[\s\S]*?\n```/gm
+  const dependencyBlocks = markdown.match(dependencyBlockPattern) ?? []
+
+  if (dependencyBlocks.length === 0) {
+    errors.push('split child is missing a ### Dependencies fenced JSON block')
+  }
+
+  const outsideDependencyBlock = markdown.replace(dependencyBlockPattern, '')
+  if (/\bdependsOn\b/.test(outsideDependencyBlock)) {
+    errors.push('split child mentions dependsOn outside the ### Dependencies fenced JSON block')
+  }
+
+  for (const heading of REQUIRED_CHILD_CONTRACT_SECTIONS) {
+    if (!markdown.includes(heading)) {
+      errors.push(`split child is missing required section ${heading}`)
+    }
+  }
+
+  return errors
+}
+
+export function formatTrackingIssueSplitResult(input: {
+  parentTitle: string
+  parentSummary: string
+  children: SplitTrackingIssueChildResult[]
+}): string {
+  const childBlocks = input.children.flatMap((child) => [
+    `## Child Issue #${child.number}: ${child.title}`,
+    child.body,
+  ])
+
+  return [
+    '## Parent Summary',
+    `Parent issue: ${input.parentTitle}`,
+    input.parentSummary.trim(),
+    '### Planned Children',
+    input.children
+      .map((child, index) => `${index + 1}. #${child.number} ${child.title}`)
+      .join('\n'),
+    ...childBlocks,
+  ].filter(Boolean).join('\n\n')
+}
+
+function normalizeSplitPlanText(responseText: string): string {
+  const trimmed = responseText.trim()
+  const fencedMatch = trimmed.match(/^```(?:json|markdown|md)?\s*\n([\s\S]*?)\n```$/i)
+  return (fencedMatch?.[1] ?? trimmed).trim()
+}
+
+function tryParseSplitPlanJson(text: string): unknown | null {
+  const candidates = [
+    text,
+    extractOuterJson(text, '{', '}'),
+    extractOuterJson(text, '[', ']'),
+  ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate)
+    } catch {
+      // fall through to the next candidate
+    }
+  }
+
+  return null
+}
+
+function extractOuterJson(text: string, startToken: '{' | '[' , endToken: '}' | ']'): string | null {
+  const start = text.indexOf(startToken)
+  const end = text.lastIndexOf(endToken)
+
+  if (start === -1 || end === -1 || end <= start) {
+    return null
+  }
+
+  return text.slice(start, end + 1).trim()
+}
+
+function parseTrackingIssueSplitPlanJson(value: unknown): TrackingIssueSplitPlan {
+  if (Array.isArray(value)) {
+    return {
+      parentSummary: '',
+      children: normalizeSplitPlanChildren(value),
+    }
+  }
+
+  if (!value || typeof value !== 'object') {
+    throw new Error('split plan JSON must be an object or an array of children')
+  }
+
+  const raw = value as Record<string, unknown>
+  return {
+    parentSummary: typeof raw.parentSummary === 'string'
+      ? raw.parentSummary.trim()
+      : typeof raw.summary === 'string'
+        ? raw.summary.trim()
+        : '',
+    children: normalizeSplitPlanChildren(raw.children),
+  }
+}
+
+function parseTrackingIssueSplitPlanList(text: string): TrackingIssueSplitPlan {
+  const children = text
+    .split('\n')
+    .map((line) => line.trim().match(/^(?:\d+[.)]|[-*•])\s+(.+)$/)?.[1]?.trim() ?? '')
+    .filter((line) => line.length >= 2)
+    .map((title, index) => ({
+      id: `child-${index + 1}`,
+      title,
+      summary: title,
+      scopeHints: [],
+      allowedFiles: [],
+      outOfScope: [],
+      requiredSemantics: [],
+      dependencyReferences: [],
+      hasExplicitDependencies: false,
+    }))
+
+  if (children.length === 0) {
+    throw new Error('split plan must contain at least one child issue')
+  }
+
+  return {
+    parentSummary: '',
+    children,
+  }
+}
+
+function normalizeSplitPlanChildren(value: unknown): TrackingIssueSplitPlanChild[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('split plan must include a non-empty children array')
+  }
+
+  if (value.length > MAX_CHILD_ISSUES) {
+    throw new Error(`split plan cannot contain more than ${MAX_CHILD_ISSUES} child issues`)
+  }
+
+  const normalized = value.map((entry, index) => normalizeSplitPlanChild(entry, index))
+  const seenTitles = new Set<string>()
+  const seenIds = new Set<string>()
+
+  for (const child of normalized) {
+    const titleKey = normalizeReferenceKey(child.title)
+    const idKey = normalizeReferenceKey(child.id)
+    if (seenTitles.has(titleKey)) {
+      throw new Error(`split plan contains duplicate child title: ${child.title}`)
+    }
+    if (seenIds.has(idKey)) {
+      throw new Error(`split plan contains duplicate child id: ${child.id}`)
+    }
+    seenTitles.add(titleKey)
+    seenIds.add(idKey)
+  }
+
+  return normalized
+}
+
+function normalizeSplitPlanChild(value: unknown, index: number): TrackingIssueSplitPlanChild {
+  if (!value || typeof value !== 'object') {
+    throw new Error(`split child #${index + 1} must be an object`)
+  }
+
+  const raw = value as Record<string, unknown>
+  const title = typeof raw.title === 'string' ? raw.title.trim() : ''
+
+  if (!title) {
+    throw new Error(`split child #${index + 1} is missing a title`)
+  }
+
+  return {
+    id: typeof raw.id === 'string' && raw.id.trim().length > 0
+      ? raw.id.trim()
+      : `child-${index + 1}`,
+    title,
+    summary: typeof raw.summary === 'string'
+      ? raw.summary.trim()
+      : typeof raw.goal === 'string'
+        ? raw.goal.trim()
+        : title,
+    scopeHints: normalizeStringArray(raw.scopeHints ?? raw.scope),
+    allowedFiles: normalizeStringArray(raw.allowedFiles ?? raw.allowedFileHints),
+    outOfScope: normalizeStringArray(raw.outOfScope),
+    requiredSemantics: normalizeStringArray(raw.requiredSemantics ?? raw.mustPreserve),
+    dependencyReferences: normalizeDependencyReferences(raw.dependsOn),
+    hasExplicitDependencies: Array.isArray(raw.dependsOn),
+  }
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const result: string[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      continue
+    }
+
+    const trimmed = entry.trim()
+    if (!trimmed) {
+      continue
+    }
+
+    const key = normalizeReferenceKey(trimmed)
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    result.push(trimmed)
+  }
+
+  return result
+}
+
+function normalizeDependencyReferences(value: unknown): DependencyReference[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((entry): entry is DependencyReference =>
+    (typeof entry === 'number' && Number.isSafeInteger(entry) && entry > 0)
+    || (typeof entry === 'string' && entry.trim().length > 0),
+  )
+}
+
+function allocateChildIssueNumbers(
+  children: TrackingIssueSplitPlanChild[],
+  allocator: () => number,
+): AllocatedTrackingIssueSplitPlanChild[] {
+  const seen = new Set<number>()
+
+  return children.map((child) => {
+    const number = allocator()
+
+    if (!Number.isSafeInteger(number) || number <= 0) {
+      throw new Error(`issue number allocator returned an invalid issue number: ${number}`)
+    }
+
+    if (seen.has(number)) {
+      throw new Error(`issue number allocator returned a duplicate issue number: ${number}`)
+    }
+
+    seen.add(number)
+
+    return {
+      ...child,
+      number,
+    }
+  })
+}
+
+function resolveChildDependencyNumbers(
+  children: AllocatedTrackingIssueSplitPlanChild[],
+): number[][] {
+  return children.map((child, index) => {
+    if (!child.hasExplicitDependencies) {
+      return children.slice(0, index).map((candidate) => candidate.number)
+    }
+
+    const previousChildren = children.slice(0, index)
+    const dependencyNumbers = child.dependencyReferences.map((reference) =>
+      resolveChildDependencyReference(reference, previousChildren, index),
+    )
+
+    return [...new Set(dependencyNumbers)].sort((left, right) => left - right)
+  })
+}
+
+function resolveChildDependencyReference(
+  reference: DependencyReference,
+  previousChildren: AllocatedTrackingIssueSplitPlanChild[],
+  childIndex: number,
+): number {
+  if (typeof reference === 'number') {
+    const byAllocatedNumber = previousChildren.find((candidate) => candidate.number === reference)
+    if (byAllocatedNumber) {
+      return byAllocatedNumber.number
+    }
+
+    const byOrder = previousChildren[reference - 1]
+    if (byOrder) {
+      return byOrder.number
+    }
+
+    throw new Error(`split child #${childIndex + 1} references unknown dependency number: ${reference}`)
+  }
+
+  const normalizedReference = normalizeReferenceKey(reference)
+  if (!normalizedReference) {
+    throw new Error(`split child #${childIndex + 1} contains an empty dependency reference`)
+  }
+
+  if (/^#\d+$/.test(reference.trim())) {
+    const issueNumber = Number.parseInt(reference.trim().slice(1), 10)
+    const byIssueNumber = previousChildren.find((candidate) => candidate.number === issueNumber)
+    if (byIssueNumber) {
+      return byIssueNumber.number
+    }
+  }
+
+  const matchedChild = previousChildren.find((candidate) =>
+    normalizeReferenceKey(candidate.id) === normalizedReference
+    || normalizeReferenceKey(candidate.title) === normalizedReference,
+  )
+
+  if (!matchedChild) {
+    throw new Error(`split child #${childIndex + 1} references unknown dependency: ${reference}`)
+  }
+
+  return matchedChild.number
+}
+
+function normalizeReferenceKey(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+function buildFallbackParentSummary(input: {
+  title: string
+  children: Array<Pick<SplitTrackingIssueChildResult, 'number' | 'title'>>
+}): string {
+  const childTitles = input.children.map((child) => `#${child.number} ${child.title}`).join(' -> ')
+
+  if (!childTitles) {
+    return `Keep ${input.title} as the tracking parent issue.`
+  }
+
+  return `Keep ${input.title} as the tracking parent issue and sequence the execution through ${childTitles}.`
+}
+
+function resolveTrackingIssueSource(input: SplitTrackingIssueInput): {
+  title: string
+  body: string
+  issueText: string
+} {
+  const trimmedIssueText = input.issueText?.trim() ?? ''
+  const trimmedTitle = input.title?.trim() ?? ''
+  const trimmedBody = input.body?.trim() ?? ''
+  const issueText = trimmedIssueText || [trimmedTitle, trimmedBody].filter(Boolean).join('\n\n').trim()
+
+  if (!issueText) {
+    throw new Error('splitTrackingIssue requires issueText or a non-empty title/body pair')
+  }
+
+  return {
+    title: trimmedTitle || '(untitled tracking issue)',
+    body: trimmedBody || issueText,
+    issueText,
+  }
+}
+
+function renderSuggestionBlock(title: string, values: string[]): string {
+  if (values.length === 0) {
+    return `${title}:\n- (none found; keep the split explicit and tightly scoped)`
+  }
+
+  return `${title}:\n${values.map((value) => `- ${value}`).join('\n')}`
+}
+
+async function defaultBuildAuthoringContext(input: {
+  repoRoot: string
+  issueText: string
+  issueTitle?: string
+  issueBody?: string
+}): Promise<RepoAuthoringContext> {
+  if (!existsSync(input.repoRoot)) {
+    return {
+      candidateValidationCommands: [],
+      candidateAllowedFiles: [],
+      candidateForbiddenFiles: [],
+    }
+  }
+
+  return buildRepoAuthoringContext({
+    repoRoot: input.repoRoot,
+    issueText: input.issueText,
+    issueTitle: input.issueTitle,
+    issueBody: input.issueBody,
+  })
+}
+
+async function defaultRunIssueSplitterAgent(
+  input: IssueSplitterAgentRunInput,
+): Promise<IssueSplitterAgentRunResult> {
+  if (!input.config) {
+    throw new Error('splitTrackingIssue requires config when no custom runAgent is provided')
+  }
+
+  const result = await runConfiguredAgent({
+    prompt: input.prompt,
+    worktreePath: input.repoRoot,
+    timeoutMs: input.config.agent.timeoutMs,
+    config: input.config,
+    allowWrites: false,
+  })
+
+  if (!result.ok) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.exitCode}`
+    throw new Error(`issue split agent failed: ${detail}`)
+  }
+
+  return {
+    responseText: result.responseText,
+  }
+}
+
+function renderDeterministicChildIssue(input: {
+  parentTitle: string
+  parentContract: ReturnType<typeof parseIssueContract>
+  authoringContext: RepoAuthoringContext
+  child: AllocatedTrackingIssueSplitPlanChild
+  siblingTitles: string[]
+  dependsOn: number[]
+}): string {
+  const allowedFiles = uniqueStrings([
+    ...input.child.allowedFiles.filter(isConcretePathHint),
+    ...input.authoringContext.candidateAllowedFiles.filter(isConcretePathHint),
+    ...input.parentContract.allowedFiles.filter(isConcretePathHint),
+  ]).slice(0, 8)
+
+  if (allowedFiles.length === 0) {
+    throw new Error(`split child ${input.child.title} is missing concrete AllowedFiles hints`)
+  }
+
+  const forbiddenFiles = uniqueStrings([
+    ...input.parentContract.forbiddenFiles.filter(isConcretePathHint),
+    ...input.authoringContext.candidateForbiddenFiles.filter(isConcretePathHint),
+  ]).slice(0, 8)
+  const constraints = uniqueStrings([
+    ...input.parentContract.constraints,
+    ...input.child.scopeHints,
+    `只实现 ${input.child.title} 这条 child issue 对应的代码路径`,
+  ]).slice(0, 8)
+  const mustPreserve = uniqueStrings([
+    'parent issue 仍然是 tracking-only，不进入 `agent:ready`',
+    ...input.parentContract.mustPreserve,
+  ]).slice(0, 8)
+  const outOfScope = uniqueStrings([
+    ...input.child.outOfScope,
+    ...input.siblingTitles
+      .filter((title) => title !== input.child.title)
+      .map((title) => `不在本 child 内完成 ${title}`),
+    ...input.parentContract.outOfScope,
+  ]).slice(0, 8)
+  const requiredSemantics = uniqueStrings([
+    ...input.child.requiredSemantics,
+    `产出 ${input.child.title} 对应的代码实现与测试`,
+    ...input.child.scopeHints,
+  ]).slice(0, 8)
+  const reviewHints = uniqueStrings([
+    '优先检查 AllowedFiles 与 OutOfScope 是否仍然足够具体',
+    '优先检查 child issue 的执行顺序是否与拆分计划一致',
+    ...input.parentContract.reviewHints,
+  ]).slice(0, 8)
+  const validationCommands = selectValidationCommands(
+    input.parentContract.validation,
+    input.authoringContext.candidateValidationCommands,
+  )
+  const userStoryGoal = input.child.summary.trim() || input.child.title.trim()
+  const redTestTitle = input.child.title.replace(/`/g, '').replace(/'/g, "\\'")
+
+  return [
+    '## 用户故事',
+    '',
+    `作为 \`agent-loop\` 维护者，我希望 ${userStoryGoal}，从而把 ${input.parentTitle} 拆成可执行的 child issue。`,
+    '',
+    '## Context',
+    '',
+    '### Dependencies',
+    '```json',
+    JSON.stringify({ dependsOn: input.dependsOn }),
+    '```',
+    '',
+    renderBulletSection('### Constraints', constraints),
+    '',
+    renderBulletSection('### AllowedFiles', allowedFiles),
+    '',
+    renderBulletSection('### ForbiddenFiles', forbiddenFiles),
+    '',
+    renderBulletSection('### MustPreserve', mustPreserve),
+    '',
+    renderBulletSection('### OutOfScope', outOfScope),
+    '',
+    renderBulletSection('### RequiredSemantics', requiredSemantics),
+    '',
+    renderBulletSection('### ReviewHints', reviewHints),
+    '',
+    renderBulletSection('### Validation', validationCommands),
+    '',
+    '## RED 测试',
+    '',
+    '```ts',
+    `describe('${redTestTitle}', () => {`,
+    `  test('RED: ${userStoryGoal.replace(/'/g, "\\'")}', () => {`,
+    `    throw new Error('RED: implement ${userStoryGoal.replace(/'/g, "\\'")}')`,
+    '  })',
+    '})',
+    '```',
+    '',
+    renderNumberedSection('## 实现步骤', [
+      `先为 ${input.child.title} 补失败测试或 contract 校验`,
+      '再补最小实现，并把变更限制在 AllowedFiles 内',
+      '最后运行 Validation，并确认 OutOfScope 和 contract 结构没有回归',
+    ]),
+    '',
+    renderCheckboxSection('## 验收', [
+      '只修改 AllowedFiles 内文件',
+      'Validation 中命令执行通过',
+    ]),
+  ].join('\n')
+}
+
+function renderBulletSection(title: string, items: string[]): string {
+  if (items.length === 0) {
+    return `${title}\n`
+  }
+
+  return `${title}\n${items.map((item) => `- ${item}`).join('\n')}`
+}
+
+function renderNumberedSection(title: string, items: string[]): string {
+  return `${title}\n${items.map((item, index) => `${index + 1}. ${item}`).join('\n')}`
+}
+
+function renderCheckboxSection(title: string, items: string[]): string {
+  return `${title}\n${items.map((item) => `- [ ] ${item}`).join('\n')}`
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const result: string[] = []
+  const seen = new Set<string>()
+
+  for (const value of values) {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      continue
+    }
+
+    const key = normalizeReferenceKey(trimmed)
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    result.push(trimmed)
+  }
+
+  return result
+}
+
+function isConcretePathHint(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return false
+  }
+
+  const segments = trimmed.split('/').filter(Boolean)
+  return segments.length >= 2
+}
+
+function selectValidationCommands(
+  parentValidation: string[],
+  candidateValidationCommands: string[],
+): string[] {
+  const normalized = uniqueStrings([
+    ...parentValidation.map(stripWrappingBackticks),
+    ...candidateValidationCommands.map(stripWrappingBackticks),
+  ])
+  const commands = [...normalized]
+  const hasExecutableTestCommand = commands.some((command) =>
+    /\b(test|tests|check|build|lint|verify|typecheck|coverage)\b/i.test(command),
+  )
+
+  if (!hasExecutableTestCommand) {
+    commands.unshift('bun test')
+  }
+
+  if (!commands.some((command) => command === 'git diff --stat origin/main...HEAD')) {
+    commands.push('git diff --stat origin/main...HEAD')
+  }
+
+  return uniqueStrings(commands).map((command) => `\`${command}\``)
+}
+
+function stripWrappingBackticks(value: string): string {
+  const trimmed = value.trim()
+  if (trimmed.startsWith('`') && trimmed.endsWith('`')) {
+    return trimmed.slice(1, -1).trim()
+  }
+
+  return trimmed
+}


### PR DESCRIPTION
## Summary
- add `splitTrackingIssue` plus a new `issue-splitter.ts` flow that parses ordered split plans, allocates child issue numbers, injects final `dependsOn` JSON, and rejects low-quality child contracts locally
- add local `--split-file` / `--split-start-number` CLI support in `index.ts` so tracking parent issue markdown can be split into ordered child issue bodies from the terminal
- cover numbered-list fallback, strict JSON dependency plans, quality-gate failures, and CLI behavior with focused tests

## Validation
- bun test apps/agent-daemon/src/issue-splitter.test.ts apps/agent-daemon/src/issue-authoring.test.ts apps/agent-daemon/src/index.test.ts
- bun run typecheck

## Notes
- this PR replaces the polluted stacked implementation in #47 with a clean branch based on the rebuilt #38 chain