### PR TITLE
Fix #62: [AL-19] Codex reasoning effort 配置化并把默认档位提升到 high

### DIFF
--- a/apps/agent-daemon/src/cli-agent.test.ts
+++ b/apps/agent-daemon/src/cli-agent.test.ts
@@ -46,6 +46,7 @@ const baseConfig: AgentConfig = {
     fallback: 'claude',
     claudePath: 'claude',
     codexPath: 'codex',
+    codexReasoningEffort: 'high',
     timeoutMs: 60_000,
   },
   git: {
@@ -79,7 +80,7 @@ describe('cli-agent', () => {
       '--output-last-message',
       '/tmp/last-message.txt',
       '-c',
-      'model_reasoning_effort="medium"',
+      'model_reasoning_effort="high"',
       '--dangerously-bypass-approvals-and-sandbox',
       '-',
     ])
@@ -94,9 +95,24 @@ describe('cli-agent', () => {
       '--output-last-message',
       '/tmp/review-message.txt',
       '-c',
-      'model_reasoning_effort="medium"',
+      'model_reasoning_effort="high"',
       '--sandbox',
       'read-only',
+      '-',
+    ])
+  })
+
+  test('builds Codex command with an explicit reasoning effort override', () => {
+    expect(buildAgentCommand('codex', 'codex', '/tmp/last-message.txt', true, 'medium')).toEqual([
+      'codex',
+      'exec',
+      '--color',
+      'never',
+      '--output-last-message',
+      '/tmp/last-message.txt',
+      '-c',
+      'model_reasoning_effort="medium"',
+      '--dangerously-bypass-approvals-and-sandbox',
       '-',
     ])
   })
@@ -127,6 +143,7 @@ describe('cli-agent', () => {
           PATH: '/opt/homebrew/bin:/usr/bin',
           HTTPS_PROXY: 'http://127.0.0.1:7890',
         },
+        'medium',
         null,
       )
 
@@ -138,7 +155,7 @@ describe('cli-agent', () => {
       expect(existsSync(join(homeDir, '.zshenv'))).toBe(true)
       expect(existsSync(join(homeDir, '.bash_profile'))).toBe(true)
       expect(readFileSync(join(codexHomeDir, 'config.toml'), 'utf-8')).toBe(
-        buildIsolatedCodexConfig('http://127.0.0.1:18777/v1'),
+        buildIsolatedCodexConfig('http://127.0.0.1:18777/v1', 'medium'),
       )
       expect(readFileSync(join(codexHomeDir, 'auth.json'), 'utf-8')).toBe(
         '{\n  "OPENAI_API_KEY": "sk-local-proxy"\n}\n',
@@ -240,7 +257,7 @@ printf 'fake codex ok\n' > "$response_file"
         expect(result.responseText).toBe('fake codex ok')
 
         expect(readFileSync(configCapturePath, 'utf-8')).toBe(
-          buildIsolatedCodexConfig('http://127.0.0.1:18777/v1'),
+          buildIsolatedCodexConfig('http://127.0.0.1:18777/v1', 'high'),
         )
         const argv = readFileSync(argvCapturePath, 'utf-8').trim().split('\n')
         expect(argv[0]).toBe('exec')
@@ -249,7 +266,7 @@ printf 'fake codex ok\n' > "$response_file"
         expect(argv[3]).toBe('--output-last-message')
         expect(argv[4]).toEndWith('/last-message.txt')
         expect(argv[5]).toBe('-c')
-        expect(argv[6]).toBe('model_reasoning_effort="medium"')
+        expect(argv[6]).toBe('model_reasoning_effort="high"')
         expect(argv[7]).toBe('--dangerously-bypass-approvals-and-sandbox')
         expect(argv[8]).toBe('-')
         expect(readFileSync(envCapturePath, 'utf-8')).toContain('OPENAI_BASE_URL=__UNSET__')

--- a/apps/agent-daemon/src/cli-agent.test.ts
+++ b/apps/agent-daemon/src/cli-agent.test.ts
@@ -117,6 +117,32 @@ describe('cli-agent', () => {
     ])
   })
 
+  test('keeps the same explicit reasoning effort across write-enabled, read-only, and isolated Codex config', () => {
+    const reasoningEffort = 'low'
+    const writeEnabledCommand = buildAgentCommand(
+      'codex',
+      'codex',
+      '/tmp/write-last-message.txt',
+      true,
+      reasoningEffort,
+    )
+    const readOnlyCommand = buildAgentCommand(
+      'codex',
+      'codex',
+      '/tmp/review-last-message.txt',
+      false,
+      reasoningEffort,
+    )
+    const isolatedConfig = buildIsolatedCodexConfig('http://127.0.0.1:18777/v1', reasoningEffort)
+
+    expect(writeEnabledCommand).toContain('model_reasoning_effort="low"')
+    expect(writeEnabledCommand).toContain('--dangerously-bypass-approvals-and-sandbox')
+    expect(readOnlyCommand).toContain('model_reasoning_effort="low"')
+    expect(readOnlyCommand).toContain('--sandbox')
+    expect(readOnlyCommand).toContain('read-only')
+    expect(isolatedConfig).toContain('model_reasoning_effort = "low"')
+  })
+
   test('prefers environment auth for isolated Codex runtime', () => {
     expect(resolveCodexAuthJson(
       { OPENAI_API_KEY: 'sk-proxy' },

--- a/apps/agent-daemon/src/cli-agent.ts
+++ b/apps/agent-daemon/src/cli-agent.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
-import type { AgentConfig, AgentExitCode } from '@agent/shared'
+import type { AgentConfig, AgentExitCode, CodexReasoningEffort } from '@agent/shared'
 
 export type AgentKind = AgentConfig['agent']['primary']
 
@@ -73,6 +73,7 @@ export function buildAgentCommand(
   binaryPath: string,
   responseFilePath: string,
   allowWrites: boolean,
+  codexReasoningEffort: CodexReasoningEffort = 'high',
 ): string[] {
   if (agent === 'claude') {
     return [binaryPath, '--print', '--permission-mode', 'bypassPermissions']
@@ -86,13 +87,16 @@ export function buildAgentCommand(
     '--output-last-message',
     responseFilePath,
     '-c',
-    'model_reasoning_effort="medium"',
+    `model_reasoning_effort="${codexReasoningEffort}"`,
     ...(allowWrites ? ['--dangerously-bypass-approvals-and-sandbox'] : ['--sandbox', 'read-only']),
     '-',
   ]
 }
 
-export function buildIsolatedCodexConfig(baseUrl?: string | null): string {
+export function buildIsolatedCodexConfig(
+  baseUrl?: string | null,
+  codexReasoningEffort: CodexReasoningEffort = 'high',
+): string {
   const providerLines = [
     '[model_providers.custom]',
     'name = "custom"',
@@ -103,7 +107,7 @@ export function buildIsolatedCodexConfig(baseUrl?: string | null): string {
 
   return `model_provider = "custom"
 model = "gpt-5.4"
-model_reasoning_effort = "medium"
+model_reasoning_effort = "${codexReasoningEffort}"
 network_access = "enabled"
 disable_response_storage = true
 
@@ -126,6 +130,7 @@ export function resolveCodexAuthJson(
 export function createIsolatedCodexHome(
   tempDir: string,
   env: Record<string, string>,
+  codexReasoningEffort: CodexReasoningEffort = 'high',
   fallbackAuthJson: string | null = readLocalCodexAuthJson(),
 ): { homeDir: string; codexHomeDir: string } {
   const homeDir = join(tempDir, 'home')
@@ -134,7 +139,7 @@ export function createIsolatedCodexHome(
   mkdirSync(codexHomeDir, { recursive: true })
   writeFileSync(
     join(codexHomeDir, 'config.toml'),
-    buildIsolatedCodexConfig(env.OPENAI_BASE_URL ?? null),
+    buildIsolatedCodexConfig(env.OPENAI_BASE_URL ?? null, codexReasoningEffort),
     'utf-8',
   )
 
@@ -200,6 +205,7 @@ async function runSingleAgent(
     binaryPath,
     responseFilePath,
     options.allowWrites ?? true,
+    options.config.agent.codexReasoningEffort ?? 'high',
   )
 
   let proc: ReturnType<typeof Bun.spawn> | null = null
@@ -625,7 +631,11 @@ function buildRuntimeEnv(
     return cleanEnv
   }
 
-  const { homeDir, codexHomeDir } = createIsolatedCodexHome(tempDir, cleanEnv)
+  const { homeDir, codexHomeDir } = createIsolatedCodexHome(
+    tempDir,
+    cleanEnv,
+    config.agent.codexReasoningEffort ?? 'high',
+  )
 
   delete cleanEnv.OPENAI_BASE_URL
   delete cleanEnv.OPENAI_API_BASE

--- a/apps/agent-daemon/src/config.test.ts
+++ b/apps/agent-daemon/src/config.test.ts
@@ -41,7 +41,7 @@ const baseFileConfig: Partial<AgentConfig> = {
     fallback: 'codex',
     claudePath: 'claude-home',
     codexPath: 'codex-home',
-    codexReasoningEffort: 'medium',
+    codexReasoningEffort: 'high',
     timeoutMs: 90_000,
   },
   git: {
@@ -129,7 +129,7 @@ describe('buildConfig', () => {
     ])
     expect(config.project.maxConcurrency).toBeUndefined()
     expect(config.agent.primary).toBe('claude')
-    expect(config.agent.codexReasoningEffort).toBe('medium')
+    expect(config.agent.codexReasoningEffort).toBe('high')
     expect(config.git.defaultBranch).toBe('master')
     expect(config.requestedConcurrency).toBe(1)
     expect(config.concurrency).toBe(1)
@@ -232,6 +232,34 @@ describe('buildConfig', () => {
     expect(config.agent.codexReasoningEffort).toBe('high')
     expect(config.agent.primary).toBe('claude')
     expect(config.agent.fallback).toBe('codex')
+  })
+
+  test('ignores unsupported Codex reasoning effort values from config sources', () => {
+    const config = buildConfig(
+      {},
+      {
+        fileConfig: {
+          ...baseFileConfig,
+          agent: {
+            primary: 'claude',
+            fallback: 'codex',
+            claudePath: 'claude-home',
+            codexPath: 'codex-home',
+            codexReasoningEffort: 'unsupported' as unknown as AgentConfig['agent']['codexReasoningEffort'],
+            timeoutMs: 90_000,
+          },
+        },
+        repoConfig: {
+          agent: {
+            codexReasoningEffort: 'also-unsupported' as never,
+          },
+        },
+        env: {},
+        homeDir: '/tmp/agent-loop-home',
+      },
+    )
+
+    expect(config.agent.codexReasoningEffort).toBe('high')
   })
 
   test('lets CLI override the idle backstop poll interval but never below the active poll interval', () => {

--- a/apps/agent-daemon/src/config.test.ts
+++ b/apps/agent-daemon/src/config.test.ts
@@ -41,6 +41,7 @@ const baseFileConfig: Partial<AgentConfig> = {
     fallback: 'codex',
     claudePath: 'claude-home',
     codexPath: 'codex-home',
+    codexReasoningEffort: 'medium',
     timeoutMs: 90_000,
   },
   git: {
@@ -128,6 +129,7 @@ describe('buildConfig', () => {
     ])
     expect(config.project.maxConcurrency).toBeUndefined()
     expect(config.agent.primary).toBe('claude')
+    expect(config.agent.codexReasoningEffort).toBe('medium')
     expect(config.git.defaultBranch).toBe('master')
     expect(config.requestedConcurrency).toBe(1)
     expect(config.concurrency).toBe(1)
@@ -186,6 +188,50 @@ describe('buildConfig', () => {
 
     expect(config.agent.primary).toBe('codex')
     expect(config.agent.fallback).toBeNull()
+  })
+
+  test('defaults Codex reasoning effort to high when neither home nor repo-local config sets it', () => {
+    const config = buildConfig(
+      {},
+      {
+        fileConfig: {
+          ...baseFileConfig,
+          agent: {
+            primary: 'claude',
+            fallback: 'codex',
+            claudePath: 'claude-home',
+            codexPath: 'codex-home',
+            codexReasoningEffort: undefined,
+            timeoutMs: 90_000,
+          },
+        },
+        repoConfig: {},
+        env: {},
+        homeDir: '/tmp/agent-loop-home',
+      },
+    )
+
+    expect(config.agent.codexReasoningEffort).toBe('high')
+  })
+
+  test('lets repo-local Codex reasoning effort override the home config value', () => {
+    const config = buildConfig(
+      {},
+      {
+        fileConfig: baseFileConfig,
+        repoConfig: {
+          agent: {
+            codexReasoningEffort: 'high',
+          },
+        },
+        env: {},
+        homeDir: '/tmp/agent-loop-home',
+      },
+    )
+
+    expect(config.agent.codexReasoningEffort).toBe('high')
+    expect(config.agent.primary).toBe('claude')
+    expect(config.agent.fallback).toBe('codex')
   })
 
   test('lets CLI override the idle backstop poll interval but never below the active poll interval', () => {

--- a/apps/agent-daemon/src/config.ts
+++ b/apps/agent-daemon/src/config.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path'
 import { execFileSync } from 'node:child_process'
 import type {
   AgentConfig,
+  CodexReasoningEffort,
   ProjectProfileName,
   ProjectPromptContext,
   ProjectPromptGuidanceOverrides,
@@ -27,6 +28,7 @@ export interface RepoLocalConfig {
   agent?: {
     primary?: AgentConfig['agent']['primary']
     fallback?: AgentConfig['agent']['fallback']
+    codexReasoningEffort?: CodexReasoningEffort
   }
   git?: {
     defaultBranch?: string
@@ -212,6 +214,10 @@ export function buildConfig(
       fallback: agentFallback,
       claudePath: fileConfig.agent?.claudePath ?? 'claude',
       codexPath: fileConfig.agent?.codexPath ?? 'codex',
+      codexReasoningEffort:
+        repoConfig.agent?.codexReasoningEffort
+        ?? fileConfig.agent?.codexReasoningEffort
+        ?? 'high',
       codexBaseUrl:
         env.OPENAI_BASE_URL ??
         env.OPENAI_API_BASE ??

--- a/apps/agent-daemon/src/config.ts
+++ b/apps/agent-daemon/src/config.ts
@@ -18,6 +18,11 @@ const CONFIG_DIR = resolve(homedir(), '.agent-loop')
 const CONFIG_PATH = resolve(CONFIG_DIR, 'config.json')
 const REPO_CONFIG_DIR = '.agent-loop'
 const REPO_CONFIG_FILE = 'project.json'
+const SUPPORTED_CODEX_REASONING_EFFORTS: readonly CodexReasoningEffort[] = [
+  'low',
+  'medium',
+  'high',
+]
 
 export interface RepoLocalConfig {
   project?: {
@@ -215,8 +220,8 @@ export function buildConfig(
       claudePath: fileConfig.agent?.claudePath ?? 'claude',
       codexPath: fileConfig.agent?.codexPath ?? 'codex',
       codexReasoningEffort:
-        repoConfig.agent?.codexReasoningEffort
-        ?? fileConfig.agent?.codexReasoningEffort
+        normalizeCodexReasoningEffort(repoConfig.agent?.codexReasoningEffort)
+        ?? normalizeCodexReasoningEffort(fileConfig.agent?.codexReasoningEffort)
         ?? 'high',
       codexBaseUrl:
         env.OPENAI_BASE_URL ??
@@ -429,6 +434,16 @@ function normalizeNonEmptyString(value: unknown): string | null {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeCodexReasoningEffort(value: unknown): CodexReasoningEffort | null {
+  if (typeof value !== 'string') return null
+
+  return isCodexReasoningEffort(value) ? value : null
+}
+
+function isCodexReasoningEffort(value: string): value is CodexReasoningEffort {
+  return (SUPPORTED_CODEX_REASONING_EFFORTS as readonly string[]).includes(value)
 }
 
 export { CONFIG_DIR, CONFIG_PATH, REPO_CONFIG_DIR, REPO_CONFIG_FILE }

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -152,7 +152,13 @@ export interface AgentLoopBuildMetadata {
   revision: string | null
 }
 
-export type CodexReasoningEffort = 'minimal' | 'low' | 'medium' | 'high'
+export const CODEX_REASONING_EFFORTS = [
+  'low',
+  'medium',
+  'high',
+] as const
+
+export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORTS)[number]
 
 export type AgentLoopUpgradeStatusKind =
   | 'disabled'
@@ -313,7 +319,7 @@ export interface AgentConfig {
     claudePath: string
     codexPath: string
     codexBaseUrl?: string
-    codexReasoningEffort?: CodexReasoningEffort
+    codexReasoningEffort: CodexReasoningEffort
     // Agent 执行超时（毫秒）
     timeoutMs: number
   }

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -152,6 +152,8 @@ export interface AgentLoopBuildMetadata {
   revision: string | null
 }
 
+export type CodexReasoningEffort = 'minimal' | 'low' | 'medium' | 'high'
+
 export type AgentLoopUpgradeStatusKind =
   | 'disabled'
   | 'unknown'
@@ -311,6 +313,7 @@ export interface AgentConfig {
     claudePath: string
     codexPath: string
     codexBaseUrl?: string
+    codexReasoningEffort?: CodexReasoningEffort
     // Agent 执行超时（毫秒）
     timeoutMs: number
   }


### PR DESCRIPTION
## Summary

Fixes #62

## Metadata

```json
{
  "issue": 62,
  "machine": "codex-dev",
  "generated_by": "agent-loop"
}
```

## Test Plan

- [ ] tested locally
- [ ] CI passes