### PR TITLE
test: fix codex reasoning config fixtures

### DIFF
--- a/apps/agent-daemon/src/audit-issue-contracts.test.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.test.ts
@@ -193,6 +193,7 @@ describe('audit-issue-contracts', () => {
           fallback: 'claude',
           claudePath: 'claude',
           codexPath: 'codex',
+          codexReasoningEffort: 'high',
           timeoutMs: 300_000,
         },
         git: {

--- a/apps/agent-daemon/src/claimer.test.ts
+++ b/apps/agent-daemon/src/claimer.test.ts
@@ -43,6 +43,7 @@ function buildConfig(): AgentConfig {
       fallback: null,
       claudePath: 'claude',
       codexPath: 'codex',
+      codexReasoningEffort: 'high',
       timeoutMs: 1_800_000,
     },
     git: {

--- a/apps/agent-daemon/src/config.test.ts
+++ b/apps/agent-daemon/src/config.test.ts
@@ -191,20 +191,13 @@ describe('buildConfig', () => {
   })
 
   test('defaults Codex reasoning effort to high when neither home nor repo-local config sets it', () => {
+    const fileConfig = structuredClone(baseFileConfig) as Partial<AgentConfig>
+    delete (fileConfig.agent as Partial<AgentConfig['agent']>).codexReasoningEffort
+
     const config = buildConfig(
       {},
       {
-        fileConfig: {
-          ...baseFileConfig,
-          agent: {
-            primary: 'claude',
-            fallback: 'codex',
-            claudePath: 'claude-home',
-            codexPath: 'codex-home',
-            codexReasoningEffort: undefined,
-            timeoutMs: 90_000,
-          },
-        },
+        fileConfig,
         repoConfig: {},
         env: {},
         homeDir: '/tmp/agent-loop-home',

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -101,6 +101,7 @@ function createTestDaemon(
       fallback: 'claude',
       claudePath: 'claude',
       codexPath: 'codex',
+      codexReasoningEffort: 'high',
       timeoutMs: 60_000,
     },
     git: {
@@ -1151,6 +1152,7 @@ describe('daemon merge recovery helpers', () => {
           fallback: 'claude',
           claudePath: 'claude',
           codexPath: 'codex',
+          codexReasoningEffort: 'high',
           timeoutMs: 60_000,
         },
         git: {
@@ -1613,6 +1615,7 @@ describe('daemon merge recovery helpers', () => {
         fallback: 'claude',
         claudePath: 'claude',
         codexPath: 'codex',
+        codexReasoningEffort: 'high',
         timeoutMs: 60_000,
       },
       git: {
@@ -2483,6 +2486,7 @@ describe('daemon merge recovery helpers', () => {
           fallback: null,
           claudePath: 'claude',
           codexPath: 'codex',
+          codexReasoningEffort: 'high',
           timeoutMs: 60_000,
         },
         git: {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -157,6 +157,7 @@ describe('index helpers', () => {
             fallback: 'claude',
             claudePath: 'claude',
             codexPath: 'codex',
+            codexReasoningEffort: 'high',
             timeoutMs: 300_000,
           },
           git: {
@@ -400,6 +401,7 @@ describe('index helpers', () => {
             fallback: 'claude',
             claudePath: 'claude',
             codexPath: 'codex',
+            codexReasoningEffort: 'high',
             timeoutMs: 300_000,
           },
           git: {

--- a/apps/agent-daemon/src/join-project.test.ts
+++ b/apps/agent-daemon/src/join-project.test.ts
@@ -42,6 +42,7 @@ const baseResolvedConfig: AgentConfig = {
     fallback: 'claude',
     claudePath: 'claude',
     codexPath: 'codex',
+    codexReasoningEffort: 'high',
     timeoutMs: 1_800_000,
   },
   git: {
@@ -71,6 +72,7 @@ describe('join-project helpers', () => {
           fallback: 'claude',
           claudePath: 'claude',
           codexPath: 'codex',
+          codexReasoningEffort: 'high',
           timeoutMs: 90_000,
         },
       },

--- a/apps/agent-daemon/src/lease.test.ts
+++ b/apps/agent-daemon/src/lease.test.ts
@@ -36,6 +36,7 @@ const TEST_CONFIG: AgentConfig = {
     fallback: null,
     claudePath: 'claude',
     codexPath: 'codex',
+    codexReasoningEffort: 'high',
     timeoutMs: 60_000,
   },
   git: {

--- a/apps/agent-daemon/src/pr-reporter.test.ts
+++ b/apps/agent-daemon/src/pr-reporter.test.ts
@@ -58,6 +58,7 @@ const TEST_CONFIG: AgentConfig = {
     fallback: 'claude',
     claudePath: 'claude',
     codexPath: 'codex',
+    codexReasoningEffort: 'high',
     timeoutMs: 60_000,
   },
   git: {

--- a/apps/agent-daemon/src/pr-reviewer.test.ts
+++ b/apps/agent-daemon/src/pr-reviewer.test.ts
@@ -64,6 +64,7 @@ const TEST_CONFIG: AgentConfig = {
     fallback: null,
     claudePath: 'claude',
     codexPath: 'codex',
+    codexReasoningEffort: 'high',
     timeoutMs: 60_000,
   },
   git: {

--- a/apps/agent-daemon/src/presence.test.ts
+++ b/apps/agent-daemon/src/presence.test.ts
@@ -57,6 +57,7 @@ const TEST_CONFIG: AgentConfig = {
     fallback: null,
     claudePath: 'claude',
     codexPath: 'codex',
+    codexReasoningEffort: 'high',
     timeoutMs: 60_000,
   },
   git: {

--- a/apps/agent-daemon/src/subtask-executor.test.ts
+++ b/apps/agent-daemon/src/subtask-executor.test.ts
@@ -48,6 +48,7 @@ const TEST_CONFIG: AgentConfig = {
     fallback: null,
     claudePath: 'claude',
     codexPath: 'codex',
+    codexReasoningEffort: 'high',
     timeoutMs: 60_000,
   },
   git: {

--- a/apps/agent-daemon/src/version.test.ts
+++ b/apps/agent-daemon/src/version.test.ts
@@ -44,6 +44,7 @@ const TEST_CONFIG: AgentConfig = {
     fallback: null,
     claudePath: 'claude',
     codexPath: 'codex',
+    codexReasoningEffort: 'high',
     timeoutMs: 60_000,
   },
   git: {

--- a/apps/agent-daemon/src/worktree-manager.test.ts
+++ b/apps/agent-daemon/src/worktree-manager.test.ts
@@ -183,6 +183,7 @@ describe('createWorktree', () => {
           fallback: null,
           claudePath: 'claude',
           codexPath: 'codex',
+          codexReasoningEffort: 'high',
           timeoutMs: 60_000,
         },
         git: {


### PR DESCRIPTION
## Summary
- add missing `codexReasoningEffort` fixtures to agent-daemon tests
- model the missing-home-config case by deleting the field from a cloned config object
- restore strict `bun run typecheck` for the current approved-merge gate snapshot

## Testing
- bun run typecheck
- bun test apps/agent-daemon/src/daemon.test.ts apps/agent-daemon/src/config.test.ts apps/agent-daemon/src/version.test.ts