### PR TITLE
Fix #64: [AL-20] blocked human-needed PR 刷新重审后不再进入 auto-fix，并释放 ready 队列

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -32,6 +32,7 @@ import {
   shouldDeferResumableIssueForActiveLinkedPrLease,
   shouldClearFailedIssueResumeTrackingAfterFinalize,
   classifyApprovedPrMergeChecksGate,
+  classifyStandalonePrReviewFollowup,
   classifyLinkedIssueApprovedMergeOutcome,
   shouldEscalateBlockedIssueResume,
   shouldRefreshBlockedHumanNeededPr,
@@ -2000,6 +2001,33 @@ describe('daemon merge recovery helpers', () => {
       true,
       true,
     )).toBe(false)
+  })
+
+  test('keeps blocked refresh rerun rejections in human-needed follow-up', () => {
+    expect(classifyStandalonePrReviewFollowup({
+      approved: false,
+      canMerge: false,
+    }, {
+      blockedRefreshRerun: true,
+    })).toBe('human-needed')
+  })
+
+  test('still allows one retry auto-fix follow-up for ordinary standalone rejections', () => {
+    expect(classifyStandalonePrReviewFollowup({
+      approved: false,
+      canMerge: false,
+    }, {
+      blockedRefreshRerun: false,
+    })).toBe('retry')
+  })
+
+  test('keeps blocked refresh rerun approvals on the approved follow-up path', () => {
+    expect(classifyStandalonePrReviewFollowup({
+      approved: true,
+      canMerge: true,
+    }, {
+      blockedRefreshRerun: true,
+    })).toBe('approved')
   })
 
   test('suppresses repeated PR refresh retries when head and base are unchanged since the last failure', () => {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -2009,7 +2009,11 @@ describe('daemon merge recovery helpers', () => {
       canMerge: false,
     }, {
       blockedRefreshRerun: true,
-    })).toBe('human-needed')
+    })).toEqual({
+      nextReviewLabel: 'human-needed',
+      shouldRunAutoFix: false,
+      shouldMarkIssueFailed: false,
+    })
   })
 
   test('still allows one retry auto-fix follow-up for ordinary standalone rejections', () => {
@@ -2018,7 +2022,11 @@ describe('daemon merge recovery helpers', () => {
       canMerge: false,
     }, {
       blockedRefreshRerun: false,
-    })).toBe('retry')
+    })).toEqual({
+      nextReviewLabel: 'retry',
+      shouldRunAutoFix: true,
+      shouldMarkIssueFailed: false,
+    })
   })
 
   test('keeps blocked refresh rerun approvals on the approved follow-up path', () => {
@@ -2027,7 +2035,11 @@ describe('daemon merge recovery helpers', () => {
       canMerge: true,
     }, {
       blockedRefreshRerun: true,
-    })).toBe('approved')
+    })).toEqual({
+      nextReviewLabel: 'approved',
+      shouldRunAutoFix: false,
+      shouldMarkIssueFailed: false,
+    })
   })
 
   test('suppresses repeated PR refresh retries when head and base are unchanged since the last failure', () => {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -2042,6 +2042,66 @@ describe('daemon merge recovery helpers', () => {
     })
   })
 
+  test('releases ready issue claim opportunities once a blocked refresh rerun review settles back to human-needed', async () => {
+    const daemon = createTestDaemon({
+      concurrency: 1,
+      requestedConcurrency: 1,
+      concurrencyPolicy: {
+        requested: 1,
+        effective: 1,
+        repoCap: null,
+        profileCap: null,
+        projectCap: null,
+      },
+    })
+    let finishReview!: () => void
+    const reviewFinished = new Promise<void>((resolve) => {
+      finishReview = resolve
+    })
+    let claimAttempts = 0
+
+    ;(daemon as any).running = true
+    ;(daemon as any).refreshObservability = () => undefined
+    ;(daemon as any).processStandalonePrReview = async () => {
+      await reviewFinished
+    }
+    ;(daemon as any).maybeStartResumableIssue = async () => false
+    ;(daemon as any).maybeStartStandaloneApprovedPrMerge = async () => false
+    ;(daemon as any).maybeRequeueFailedIssue = async () => false
+    ;(daemon as any).maybeStartClaimedIssue = async () => {
+      claimAttempts += 1
+      return false
+    }
+    ;(daemon as any).maybeStartStandalonePrReview = async () => false
+    ;(daemon as any).maybeAutoApplyAgentLoopUpgrade = async () => false
+    ;(daemon as any).scheduleNextPoll = () => undefined
+
+    const started = (daemon as any).startStandalonePrReview({
+      number: 110,
+      title: 'Issue #110: blocked rerun',
+      url: 'https://example.com/pulls/110',
+      headRefName: 'agent/110/codex-dev',
+      headRefOid: 'abc1234',
+      labels: [PR_REVIEW_LABELS.HUMAN_NEEDED, PR_REVIEW_LABELS.FAILED],
+      isDraft: false,
+    })
+
+    expect(started).toBe(true)
+    expect((daemon as any).activePrReviews.has(110)).toBe(true)
+
+    await (daemon as any).pollCycle()
+    expect(claimAttempts).toBe(0)
+
+    finishReview()
+    await Promise.all(Array.from((daemon as any).inFlightPrTasks))
+
+    expect((daemon as any).activePrReviews.has(110)).toBe(false)
+
+    claimAttempts = 0
+    await (daemon as any).pollCycle()
+    expect(claimAttempts).toBe(1)
+  })
+
   test('suppresses repeated PR refresh retries when head and base are unchanged since the last failure', () => {
     const refreshFailure = buildPrReviewRefreshFailureComment(
       110,

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -2012,7 +2012,7 @@ describe('daemon merge recovery helpers', () => {
     })).toEqual({
       nextReviewLabel: 'human-needed',
       shouldRunAutoFix: false,
-      shouldMarkIssueFailed: false,
+      shouldMarkIssueFailed: true,
     })
   })
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -2295,7 +2295,7 @@ export class AgentDaemon {
 
         const followup = classifyStandalonePrReviewFollowup(firstReview, { blockedRefreshRerun })
 
-        if (followup === 'approved') {
+        if (followup.nextReviewLabel === 'approved') {
           await commentOnPr(
             pr.number,
             buildPrReviewComment(pr.number, firstReview, nextAttempt, 'approved', currentHeadRefOid, linkedIssue?.body ?? null),
@@ -2331,13 +2331,24 @@ export class AgentDaemon {
           return
         }
 
-        if (followup === 'human-needed') {
+        if (!followup.shouldRunAutoFix) {
+          const finalReviewLabel: 'human-needed' = 'human-needed'
           await commentOnPr(
             pr.number,
-            buildPrReviewComment(pr.number, firstReview, nextAttempt, 'human-needed', currentHeadRefOid, linkedIssue?.body ?? null),
+            buildPrReviewComment(
+              pr.number,
+              firstReview,
+              nextAttempt,
+              finalReviewLabel,
+              currentHeadRefOid,
+              linkedIssue?.body ?? null,
+            ),
             this.config,
           )
-          await setManagedPrReviewLabels(pr.number, 'human-needed', this.config)
+          await setManagedPrReviewLabels(pr.number, finalReviewLabel, this.config)
+          if (followup.shouldMarkIssueFailed && issueNumber !== null) {
+            await this.transitionStandaloneIssue(issueNumber, ISSUE_LABELS.FAILED, firstReview.reason)
+          }
           this.logger.log(`[pr-review-subagent] PR #${pr.number} remains human-needed after blocked refresh rerun`)
           return
         }
@@ -5351,10 +5362,32 @@ export function classifyStandalonePrReviewFollowup(
   options: {
     blockedRefreshRerun: boolean
   },
-): 'approved' | 'retry' | 'human-needed' {
-  if (review.approved && review.canMerge) return 'approved'
-  if (options.blockedRefreshRerun) return 'human-needed'
-  return 'retry'
+): {
+  nextReviewLabel: 'approved' | 'retry' | 'human-needed'
+  shouldRunAutoFix: boolean
+  shouldMarkIssueFailed: boolean
+} {
+  if (review.approved && review.canMerge) {
+    return {
+      nextReviewLabel: 'approved',
+      shouldRunAutoFix: false,
+      shouldMarkIssueFailed: false,
+    }
+  }
+
+  if (options.blockedRefreshRerun) {
+    return {
+      nextReviewLabel: 'human-needed',
+      shouldRunAutoFix: false,
+      shouldMarkIssueFailed: false,
+    }
+  }
+
+  return {
+    nextReviewLabel: 'retry',
+    shouldRunAutoFix: true,
+    shouldMarkIssueFailed: false,
+  }
 }
 
 function extractIssuePreflightFailureComment(body: string): IssuePreflightFailureCommentPayload | null {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -5379,7 +5379,7 @@ export function classifyStandalonePrReviewFollowup(
     return {
       nextReviewLabel: 'human-needed',
       shouldRunAutoFix: false,
-      shouldMarkIssueFailed: false,
+      shouldMarkIssueFailed: true,
     }
   }
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -2149,19 +2149,18 @@ export class AgentDaemon {
         detached.worktreePath,
         this.config.git.defaultBranch,
       )
-      if (
-        shouldRefreshBlockedHumanNeededPr(
-          pr,
-          linkedIssue,
-          resumableHumanNeededReview,
-          worktreeBaseSyncState.behindDefault,
-          canRetryPrReviewRefresh(
-            priorComments,
-            worktreeBaseSyncState.headRefOid,
-            worktreeBaseSyncState.baseRefOid,
-          ),
-        )
-      ) {
+      const blockedRefreshRerun = shouldRefreshBlockedHumanNeededPr(
+        pr,
+        linkedIssue,
+        resumableHumanNeededReview,
+        worktreeBaseSyncState.behindDefault,
+        canRetryPrReviewRefresh(
+          priorComments,
+          worktreeBaseSyncState.headRefOid,
+          worktreeBaseSyncState.baseRefOid,
+        ),
+      )
+      if (blockedRefreshRerun) {
         this.logger.log(
           `[pr-review-subagent] refreshing blocked PR #${pr.number} onto origin/${this.config.git.defaultBranch} before rerunning automated review`,
         )
@@ -2294,7 +2293,9 @@ export class AgentDaemon {
           return
         }
 
-        if (firstReview.approved && firstReview.canMerge) {
+        const followup = classifyStandalonePrReviewFollowup(firstReview, { blockedRefreshRerun })
+
+        if (followup === 'approved') {
           await commentOnPr(
             pr.number,
             buildPrReviewComment(pr.number, firstReview, nextAttempt, 'approved', currentHeadRefOid, linkedIssue?.body ?? null),
@@ -2327,6 +2328,17 @@ export class AgentDaemon {
           )
           await setManagedPrReviewLabels(pr.number, 'human-needed', this.config)
           this.logger.warn(`[pr-review-subagent] PR #${pr.number} rejected without auto-fix: could not infer issue number`)
+          return
+        }
+
+        if (followup === 'human-needed') {
+          await commentOnPr(
+            pr.number,
+            buildPrReviewComment(pr.number, firstReview, nextAttempt, 'human-needed', currentHeadRefOid, linkedIssue?.body ?? null),
+            this.config,
+          )
+          await setManagedPrReviewLabels(pr.number, 'human-needed', this.config)
+          this.logger.log(`[pr-review-subagent] PR #${pr.number} remains human-needed after blocked refresh rerun`)
           return
         }
 
@@ -5332,6 +5344,17 @@ export function shouldRefreshBlockedHumanNeededPr(
 
   const labels = new Set(pr.labels)
   return labels.has(PR_REVIEW_LABELS.HUMAN_NEEDED) && !canResumeHumanNeededReview
+}
+
+export function classifyStandalonePrReviewFollowup(
+  review: Pick<PrReviewResult, 'approved' | 'canMerge'>,
+  options: {
+    blockedRefreshRerun: boolean
+  },
+): 'approved' | 'retry' | 'human-needed' {
+  if (review.approved && review.canMerge) return 'approved'
+  if (options.blockedRefreshRerun) return 'human-needed'
+  return 'retry'
 }
 
 function extractIssuePreflightFailureComment(body: string): IssuePreflightFailureCommentPayload | null {


### PR DESCRIPTION
## Summary

Fixes #64

## Metadata

```json
{
  "issue": 64,
  "machine": "codex-dev",
  "generated_by": "agent-loop"
}
```

## Test Plan

- [ ] tested locally
- [ ] CI passes