### PR TITLE
fix: stop infinite failed-issue recovery loops after preflight failures

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -1799,8 +1799,8 @@ describe('daemon merge recovery helpers', () => {
     )).toBe(false)
   })
 
-  test('clears resumable failure cooldown tracking only for terminal finalize failures', () => {
-    expect(shouldClearFailedIssueResumeTrackingAfterFinalize('failed')).toBe(true)
+  test('preserves resumable failure cooldown tracking after finalize failures', () => {
+    expect(shouldClearFailedIssueResumeTrackingAfterFinalize('failed')).toBe(false)
     expect(shouldClearFailedIssueResumeTrackingAfterFinalize('completed')).toBe(false)
     expect(shouldClearFailedIssueResumeTrackingAfterFinalize('recoverable')).toBe(false)
   })

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -4534,7 +4534,7 @@ export function getFailedIssueResumeBlock(
 export function shouldClearFailedIssueResumeTrackingAfterFinalize(
   status: 'completed' | 'failed' | 'recoverable',
 ): boolean {
-  return status === 'failed'
+  return false
 }
 
 export function buildBlockedIssueResumeEscalationComment(


### PR DESCRIPTION
## Summary
- keep failed issue resume attempt tracking after finalize preflight failures
- preserve the cooldown/max-resume guard so the daemon stops retrying the same failed issue forever
- add a regression expectation covering the finalize-failure tracking behavior

## Testing
- bun test apps/agent-daemon/src/daemon.test.ts
- bun run typecheck