### PR TITLE
fix(issue-recovery): count finalize failures toward resume caps

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -31,6 +31,7 @@ import {
   shouldDeferResumableIssueForActiveLinkedPrTask,
   shouldDeferResumableIssueForActiveLinkedPrLease,
   shouldClearFailedIssueResumeTrackingAfterFinalize,
+  shouldRegisterFailedIssueResumeAfterFinalize,
   classifyApprovedPrMergeChecksGate,
   classifyStandalonePrReviewFollowup,
   classifyLinkedIssueApprovedMergeOutcome,
@@ -1803,6 +1804,12 @@ describe('daemon merge recovery helpers', () => {
     expect(shouldClearFailedIssueResumeTrackingAfterFinalize('failed')).toBe(false)
     expect(shouldClearFailedIssueResumeTrackingAfterFinalize('completed')).toBe(false)
     expect(shouldClearFailedIssueResumeTrackingAfterFinalize('recoverable')).toBe(false)
+  })
+
+  test('registers failed issue resume attempts after finalize failures only', () => {
+    expect(shouldRegisterFailedIssueResumeAfterFinalize('failed')).toBe(true)
+    expect(shouldRegisterFailedIssueResumeAfterFinalize('completed')).toBe(false)
+    expect(shouldRegisterFailedIssueResumeAfterFinalize('recoverable')).toBe(false)
   })
 
   test('resets linked PR labels back to retry when issue recovery resumes', () => {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -2814,6 +2814,9 @@ export class AgentDaemon {
         this.activeWorktrees.delete(issueNumber)
         this.syncRuntimeMetrics()
       } else {
+        if (shouldRegisterFailedIssueResumeAfterFinalize(finalized.status)) {
+          this.registerFailedIssueResume(issueNumber)
+        }
         if (shouldClearFailedIssueResumeTrackingAfterFinalize(finalized.status)) {
           this.failedIssueResumeAttempts.delete(issueNumber)
           this.failedIssueResumeCooldownUntil.delete(issueNumber)
@@ -4535,6 +4538,12 @@ export function shouldClearFailedIssueResumeTrackingAfterFinalize(
   status: 'completed' | 'failed' | 'recoverable',
 ): boolean {
   return false
+}
+
+export function shouldRegisterFailedIssueResumeAfterFinalize(
+  status: 'completed' | 'failed' | 'recoverable',
+): boolean {
+  return status === 'failed'
 }
 
 export function buildBlockedIssueResumeEscalationComment(


### PR DESCRIPTION
## Summary\n- register failed issue resume attempts when finalizeIssueFromBranch returns status 'failed'\n- preserve cleanup for successful and blocked finalize paths\n- add regression coverage so finalize failures count toward the failed-resume cap\n\n## Testing\n- bun test apps/agent-daemon/src/daemon.test.ts\n- bun run typecheck