### PR TITLE
fix: clean up timed out process trees

### DIFF
--- a/apps/agent-daemon/src/audit-issue-contracts.test.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.test.ts
@@ -1,13 +1,51 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  auditIssues,
   buildGhIssueViewArgs,
   buildIssueLintReport,
   fetchRemoteIssueDocument,
+  formatAuditOutput,
   formatAuditLine,
   formatInvalidReadySection,
   formatIssueLintReport,
   formatIssueLintReportJson,
 } from './audit-issue-contracts'
+
+const VALID_CONTRACT = [
+  '## 用户故事',
+  '作为维护者，我希望批量审计 issue contract。',
+  '',
+  '## Context',
+  '### Dependencies',
+  '```json',
+  '{ "dependsOn": [] }',
+  '```',
+  '### AllowedFiles',
+  '- apps/agent-daemon/src/audit-issue-contracts.ts',
+  '### ForbiddenFiles',
+  '- apps/agent-daemon/src/dashboard.ts',
+  '### MustPreserve',
+  '- 默认 human-readable 输出仍可用',
+  '### OutOfScope',
+  '- dashboard 可视化',
+  '### RequiredSemantics',
+  '- 支持 repo-level 审计摘要',
+  '### ReviewHints',
+  '- 检查 JSON 输出是否稳定',
+  '### Validation',
+  '- `bun test apps/agent-daemon/src/audit-issue-contracts.test.ts`',
+  '',
+  '## RED 测试',
+  '```ts',
+  'expect(true).toBe(false)',
+  '```',
+  '',
+  '## 实现步骤',
+  '1. 增加 repo-level summary',
+  '',
+  '## 验收',
+  '- [ ] repo-level summary 可用',
+].join('\n')
 
 describe('audit-issue-contracts', () => {
   test('builds a lint report that keeps warnings separate from hard errors', () => {
@@ -107,12 +145,30 @@ describe('audit-issue-contracts', () => {
         number: 51,
         title: '[CI-A1] 固定登录相关 smoke tests',
         state: 'ready',
+        labels: ['agent:ready'],
         isClaimable: false,
         hasExecutableContract: false,
         claimBlockedBy: [49, 50],
         contractValidationErrors: ['missing ## RED 测试 / RED Tests'],
         qualityScore: 75,
         contractWarnings: ['AllowedFiles should use exact paths or tightly scoped directories: frontend files'],
+        contract: {
+          source: {
+            kind: 'issue',
+            issueNumber: 51,
+            repo: 'JamesWuHK/agent-loop',
+          },
+          valid: false,
+          readyGateBlocked: true,
+          readyGateStatus: 'blocked',
+          readyGateSummary: 'ready gate would still block on hard validation errors',
+          score: 75,
+          errors: ['missing ## RED 测试 / RED Tests'],
+          warnings: ['AllowedFiles should use exact paths or tightly scoped directories: frontend files'],
+          contract: {
+            allowedFiles: ['frontend files'],
+          },
+        } as any,
       }),
     ).toBe(
       '#51 state=ready claimable=false contract=false score=75 warnings=1 blockedBy=49,50 errors=missing ## RED 测试 / RED Tests',
@@ -125,6 +181,7 @@ describe('audit-issue-contracts', () => {
         number: 52,
         title: '[CI-A2] Sprint A 发布前最小检查清单',
         state: 'ready',
+        labels: ['agent:ready'],
         isClaimable: false,
         hasExecutableContract: false,
         claimBlockedBy: [],
@@ -136,6 +193,28 @@ describe('audit-issue-contracts', () => {
         contractWarnings: [
           'AllowedFiles should use exact paths or tightly scoped directories: frontend files',
         ],
+        contract: {
+          source: {
+            kind: 'issue',
+            issueNumber: 52,
+            repo: 'JamesWuHK/agent-loop',
+          },
+          valid: false,
+          readyGateBlocked: true,
+          readyGateStatus: 'blocked',
+          readyGateSummary: 'ready gate would still block on hard validation errors',
+          score: 40,
+          errors: [
+            'missing ### Dependencies JSON block',
+            'missing executable scope contract (AllowedFiles/ForbiddenFiles/MustPreserve/OutOfScope/RequiredSemantics)',
+          ],
+          warnings: [
+            'AllowedFiles should use exact paths or tightly scoped directories: frontend files',
+          ],
+          contract: {
+            allowedFiles: ['frontend files'],
+          },
+        } as any,
       },
     ])
 
@@ -219,6 +298,54 @@ describe('audit-issue-contracts', () => {
       title: '[AL-6] 引入 issue quality report 与 lint CLI',
       body: '## 用户故事\n作为维护者，我希望 lint 输出稳定 JSON。',
       url: 'https://github.com/JamesWuHK/agent-loop/issues/36',
+    })
+  })
+
+  test('returns stable repo summary and issue quality findings in json mode', async () => {
+    const result = await auditIssues({
+      issues: [
+        {
+          number: 71,
+          title: '[AL-X] invalid contract',
+          body: '## 用户故事\n只有用户故事',
+          state: 'ready',
+          labels: ['agent:ready'],
+          isClaimable: true,
+          claimBlockedBy: [],
+          hasExecutableContract: false,
+          contractValidationErrors: ['missing ### Dependencies JSON block'],
+        },
+        {
+          number: 72,
+          title: '[AL-Y] valid contract',
+          body: VALID_CONTRACT,
+          state: 'ready',
+          labels: ['agent:ready'],
+          isClaimable: true,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      repo: 'JamesWuHK/agent-loop',
+      includeSimulation: false,
+    })
+
+    expect(result.summary).toEqual({
+      auditedIssueCount: 2,
+      invalidIssueCount: 1,
+      invalidReadyIssueCount: 1,
+      lowScoreIssueCount: 1,
+      warningIssueCount: 0,
+    })
+    expect(result.issues[0]?.contract.errors).toContain('missing ### Dependencies JSON block')
+    const parsed = JSON.parse(formatAuditOutput(result, true))
+    expect(parsed.summary).toMatchObject({
+      invalidIssueCount: 1,
+    })
+    expect(parsed.issues[0]).toMatchObject({
+      number: 71,
+      state: 'ready',
     })
   })
 })

--- a/apps/agent-daemon/src/audit-issue-contracts.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.ts
@@ -46,6 +46,14 @@ export interface IssueOpsSummary {
   warningIssueCount: number
 }
 
+export interface AuditIssueSummary {
+  managedIssueCount: number
+  readyIssueCount: number
+  invalidReadyIssueCount: number
+  lowScoreIssueCount: number
+  warningIssueCount: number
+}
+
 export interface AuditIssuesReport {
   summary: AuditIssuesSummary
   issues: AuditedIssue[]
@@ -223,6 +231,39 @@ export async function auditIssues(
   return {
     summary: buildAuditSummary(issues),
     issues,
+  }
+}
+
+export function buildAuditedIssue(issue: Pick<
+  AgentIssue,
+  | 'number'
+  | 'title'
+  | 'body'
+  | 'state'
+  | 'labels'
+  | 'isClaimable'
+  | 'claimBlockedBy'
+  | 'hasExecutableContract'
+  | 'contractValidationErrors'
+>): AuditedIssue {
+  const contract = buildIssueLintReport(issue.body, {
+    kind: 'issue',
+    issueNumber: issue.number,
+    repo: '',
+  }, issue.title)
+
+  return {
+    number: issue.number,
+    title: issue.title,
+    state: issue.state,
+    labels: [...issue.labels],
+    isClaimable: issue.isClaimable,
+    hasExecutableContract: issue.hasExecutableContract,
+    claimBlockedBy: [...issue.claimBlockedBy],
+    contractValidationErrors: [...issue.contractValidationErrors],
+    qualityScore: contract.score,
+    contractWarnings: [...contract.warnings],
+    contract,
   }
 }
 
@@ -409,6 +450,23 @@ export function buildIssueOpsSummary(input: Array<{
     invalidReadyIssueCount: input.filter((issue) => issue.state === 'ready' && issue.readyGateBlocked).length,
     lowScoreIssueCount: input.filter((issue) => issue.qualityScore < LOW_ISSUE_QUALITY_SCORE_THRESHOLD).length,
     warningIssueCount: input.filter((issue) => issue.warningCount > 0).length,
+  }
+}
+
+export function buildAuditIssueSummary(
+  issues: AuditedIssue[],
+  options: {
+    lowScoreThreshold?: number
+  } = {},
+): AuditIssueSummary {
+  const lowScoreThreshold = options.lowScoreThreshold ?? LOW_ISSUE_QUALITY_SCORE_THRESHOLD
+
+  return {
+    managedIssueCount: issues.length,
+    readyIssueCount: issues.filter((issue) => issue.state === 'ready').length,
+    invalidReadyIssueCount: issues.filter((issue) => issue.state === 'ready' && !issue.hasExecutableContract).length,
+    lowScoreIssueCount: issues.filter((issue) => issue.qualityScore < lowScoreThreshold).length,
+    warningIssueCount: issues.filter((issue) => issue.contractWarnings.length > 0).length,
   }
 }
 

--- a/apps/agent-daemon/src/audit-issue-contracts.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.ts
@@ -8,29 +8,62 @@ import {
 import { parseIssueContract, summarizeIssueContract } from '../../../packages/agent-shared/src/issue-contract'
 import { buildIssueQualityReport } from '../../../packages/agent-shared/src/issue-quality'
 import { loadConfig, type CliArgs } from './config'
+import { runConfiguredAgent } from './cli-agent'
+import {
+  simulateIssueExecutability,
+  type IssueSimulationPlannerRunner,
+  type IssueSimulationResult,
+} from './issue-simulate'
+
+export const LOW_ISSUE_QUALITY_SCORE_THRESHOLD = 80
 
 export interface AuditedIssue {
   number: number
   title: string
   state: string
+  labels: string[]
   isClaimable: boolean
   hasExecutableContract: boolean
   claimBlockedBy: number[]
   contractValidationErrors: string[]
   qualityScore: number
   contractWarnings: string[]
+  contract: IssueLintReport
+  simulation?: IssueSimulationResult
 }
 
-export interface AuditIssueContractsJsonReport {
-  totals: {
-    managedIssues: number
-    readyIssues: number
-    invalidReadyIssues: number
-    issuesWithWarnings: number
-  }
-  issues: Array<AuditedIssue & {
-    readyGateBlocked: boolean
-  }>
+export interface AuditIssuesSummary {
+  auditedIssueCount: number
+  invalidIssueCount: number
+  invalidReadyIssueCount: number
+  lowScoreIssueCount: number
+  warningIssueCount: number
+}
+
+export interface AuditIssuesReport {
+  summary: AuditIssuesSummary
+  issues: AuditedIssue[]
+}
+
+export type AuditIssueContractsJsonReport = AuditIssuesReport
+
+export interface AuditIssuesInput {
+  issues: Array<Pick<
+    AgentIssue,
+    | 'number'
+    | 'title'
+    | 'body'
+    | 'state'
+    | 'labels'
+    | 'isClaimable'
+    | 'claimBlockedBy'
+    | 'hasExecutableContract'
+    | 'contractValidationErrors'
+  >>
+  repo: string
+  includeSimulation?: boolean
+  repoRoot?: string
+  runPlanner?: IssueSimulationPlannerRunner
 }
 
 export type IssueLintSource =
@@ -64,6 +97,11 @@ export interface RemoteIssueDocument {
   url: string
 }
 
+interface LoadIssuesForAuditDependencies {
+  listOpenAgentIssues: typeof listOpenAgentIssues
+  getAgentIssueByNumber: typeof getAgentIssueByNumber
+}
+
 interface RemoteIssueViewCommandResult {
   stdout: string
   stderr: string
@@ -75,6 +113,11 @@ interface RemoteIssueFetchDependencies {
     args: string[],
     config: AgentConfig,
   ) => Promise<RemoteIssueViewCommandResult>
+}
+
+const DEFAULT_LOAD_ISSUES_FOR_AUDIT_DEPENDENCIES: LoadIssuesForAuditDependencies = {
+  listOpenAgentIssues,
+  getAgentIssueByNumber,
 }
 
 const DEFAULT_REMOTE_ISSUE_FETCH_DEPENDENCIES: RemoteIssueFetchDependencies = {
@@ -109,31 +152,82 @@ export function buildIssueLintReport(
   }
 }
 
-export function buildAuditedIssue(
-  issue: Pick<AgentIssue, 'number' | 'title' | 'state' | 'isClaimable' | 'hasExecutableContract' | 'claimBlockedBy' | 'contractValidationErrors' | 'body'>,
-): AuditedIssue {
-  const report = buildIssueLintReport(issue.body, {
-    kind: 'issue',
-    issueNumber: issue.number,
-    repo: 'unknown',
-  }, issue.title)
+export async function loadIssuesForAudit(
+  input: {
+    config: AgentConfig
+    issueNumbers?: number[]
+  },
+  deps: LoadIssuesForAuditDependencies = DEFAULT_LOAD_ISSUES_FOR_AUDIT_DEPENDENCIES,
+): Promise<AgentIssue[]> {
+  const issueNumbers = dedupeIssueNumbers(input.issueNumbers ?? [])
+
+  if (issueNumbers.length === 0) {
+    return deps.listOpenAgentIssues(input.config)
+  }
+
+  const issues = await Promise.all(issueNumbers.map(async (issueNumber) => {
+    const issue = await deps.getAgentIssueByNumber(issueNumber, input.config)
+    if (!issue) {
+      throw new Error(`Issue #${issueNumber} was not found in ${input.config.repo}`)
+    }
+    return issue
+  }))
+
+  return issues
+}
+
+export async function auditIssues(
+  input: AuditIssuesInput,
+): Promise<AuditIssuesReport> {
+  if (input.includeSimulation && !input.runPlanner) {
+    throw new Error('auditIssues includeSimulation requires runPlanner')
+  }
+
+  const issues = await Promise.all(input.issues.map(async (issue) => {
+    const contract = buildIssueLintReport(issue.body, {
+      kind: 'issue',
+      issueNumber: issue.number,
+      repo: input.repo,
+    }, issue.title)
+    const simulation = input.includeSimulation
+      ? await simulateIssueExecutability({
+          issueTitle: issue.title,
+          issueBody: issue.body,
+          repoRoot: input.repoRoot,
+          runPlanner: input.runPlanner!,
+        })
+      : undefined
+
+    return {
+      number: issue.number,
+      title: issue.title,
+      state: issue.state,
+      labels: [...issue.labels],
+      isClaimable: issue.isClaimable,
+      hasExecutableContract: contract.valid,
+      claimBlockedBy: [...issue.claimBlockedBy],
+      contractValidationErrors: [...contract.errors],
+      qualityScore: contract.score,
+      contractWarnings: [...contract.warnings],
+      contract,
+      simulation,
+    }
+  }))
 
   return {
-    number: issue.number,
-    title: issue.title,
-    state: issue.state,
-    isClaimable: issue.isClaimable,
-    hasExecutableContract: issue.hasExecutableContract,
-    claimBlockedBy: [...issue.claimBlockedBy],
-    contractValidationErrors: [...issue.contractValidationErrors],
-    qualityScore: report.score,
-    contractWarnings: report.warnings,
+    summary: buildAuditSummary(issues),
+    issues,
   }
 }
 
 export function formatAuditLine(issue: AuditedIssue): string {
+  const simulationStatus = issue.simulation
+    ? ` simulate=${issue.simulation.valid ? 'pass' : 'fail'}`
+    : ''
+
   return `#${issue.number} state=${issue.state} claimable=${issue.isClaimable} `
-    + `contract=${issue.hasExecutableContract} score=${issue.qualityScore} warnings=${issue.contractWarnings.length} `
+    + `contract=${issue.hasExecutableContract} score=${issue.qualityScore} warnings=${issue.contractWarnings.length}`
+    + `${simulationStatus} `
     + `blockedBy=${issue.claimBlockedBy.join(',') || '-'} `
     + `errors=${issue.contractValidationErrors.join(' | ') || '-'}`
 }
@@ -149,29 +243,60 @@ export function formatInvalidReadySection(issues: AuditedIssue[]): string {
       `#${issue.number} ${issue.title}`,
       ...issue.contractValidationErrors.map((error) => `- ${error}`),
       ...issue.contractWarnings.map((warning) => `- warning: ${warning}`),
+      ...(issue.simulation?.valid === false
+        ? issue.simulation.failures.map((failure) => `- simulate: ${failure}`)
+        : []),
     ]),
   ].join('\n')
 }
 
 export function buildAuditIssueContractsJsonReport(
-  issues: AuditedIssue[],
+  input: AuditedIssue[] | AuditIssuesReport,
 ): AuditIssueContractsJsonReport {
+  if ('summary' in input) {
+    return input
+  }
+
   return {
-    totals: {
-      managedIssues: issues.length,
-      readyIssues: issues.filter((issue) => issue.state === 'ready').length,
-      invalidReadyIssues: issues.filter((issue) => issue.state === 'ready' && !issue.hasExecutableContract).length,
-      issuesWithWarnings: issues.filter((issue) => issue.contractWarnings.length > 0).length,
-    },
-    issues: issues.map((issue) => ({
-      ...issue,
-      readyGateBlocked: issue.contractValidationErrors.length > 0,
-    })),
+    summary: buildAuditSummary(input),
+    issues: input,
   }
 }
 
-export function formatAuditJsonReport(issues: AuditedIssue[]): string {
-  return JSON.stringify(buildAuditIssueContractsJsonReport(issues), null, 2)
+export function formatAuditJsonReport(
+  input: AuditedIssue[] | AuditIssuesReport,
+): string {
+  return JSON.stringify(buildAuditIssueContractsJsonReport(input), null, 2)
+}
+
+export function formatAuditOutput(
+  report: AuditIssuesReport,
+  asJson = false,
+): string {
+  if (asJson) {
+    return formatAuditJsonReport(report)
+  }
+
+  const lines = [
+    `audited issues: ${report.summary.auditedIssueCount}`,
+    `invalid issues: ${report.summary.invalidIssueCount}`,
+    `invalid ready issues: ${report.summary.invalidReadyIssueCount}`,
+    `low score issues: ${report.summary.lowScoreIssueCount}`,
+    `warning issues: ${report.summary.warningIssueCount}`,
+  ]
+
+  if (report.issues.length > 0) {
+    lines.push('', ...report.issues.map(formatAuditLine))
+  }
+
+  const invalidReadySection = formatInvalidReadySection(
+    report.issues.filter((issue) => issue.state === 'ready' && !issue.hasExecutableContract),
+  )
+  if (invalidReadySection) {
+    lines.push('', invalidReadySection)
+  }
+
+  return lines.join('\n')
 }
 
 export function formatIssueLintReportJson(report: IssueLintReport): string {
@@ -268,9 +393,47 @@ export async function buildIssueLintReportFromRemoteIssue(input: {
   }, issue.title)
 }
 
-function parseArgs(argv: string[]): CliArgs & { json?: boolean } {
+function buildAuditSummary(issues: AuditedIssue[]): AuditIssuesSummary {
+  return {
+    auditedIssueCount: issues.length,
+    invalidIssueCount: issues.filter((issue) => !issue.contract.valid).length,
+    invalidReadyIssueCount: issues.filter((issue) => issue.state === 'ready' && !issue.contract.valid).length,
+    lowScoreIssueCount: issues.filter((issue) => issue.contract.score < LOW_ISSUE_QUALITY_SCORE_THRESHOLD).length,
+    warningIssueCount: issues.filter((issue) => issue.contract.warnings.length > 0).length,
+  }
+}
+
+function dedupeIssueNumbers(issueNumbers: number[]): number[] {
+  const seen = new Set<number>()
+  const deduped: number[] = []
+
+  for (const issueNumber of issueNumbers) {
+    if (seen.has(issueNumber)) continue
+    seen.add(issueNumber)
+    deduped.push(issueNumber)
+  }
+
+  return deduped
+}
+
+function parseIssueNumber(value: string, flag: string): number {
+  const trimmed = value.trim()
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`${flag} must be a positive integer`)
+  }
+
+  return parseInt(trimmed, 10)
+}
+
+function parseArgs(argv: string[]): CliArgs & {
+  json?: boolean
+  issueNumbers?: number[]
+  simulate?: boolean
+} {
   let repo: string | undefined
   let json = false
+  let simulate = false
+  const issueNumbers: number[] = []
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
@@ -279,35 +442,64 @@ function parseArgs(argv: string[]): CliArgs & { json?: boolean } {
       index += 1
     } else if (arg === '--json') {
       json = true
+    } else if (arg === '--simulate') {
+      simulate = true
+    } else if (arg === '--issue') {
+      const value = argv[index + 1]
+      if (typeof value !== 'string') {
+        throw new Error('--issue requires a number')
+      }
+      issueNumbers.push(parseIssueNumber(value, '--issue'))
+      index += 1
     }
   }
 
-  return { repo, json }
+  return {
+    repo,
+    json,
+    simulate,
+    issueNumbers: dedupeIssueNumbers(issueNumbers),
+  }
 }
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2))
   const config = loadConfig(args)
-  const issues = await listOpenAgentIssues(config)
-  const managedIssues = issues
-    .filter((issue) => issue.labels.some((label) => label.startsWith('agent:')))
-    .map(buildAuditedIssue)
+  const issues = await loadIssuesForAudit({
+    config,
+    issueNumbers: args.issueNumbers,
+  })
+  const report = await auditIssues({
+    issues,
+    repo: config.repo,
+    includeSimulation: args.simulate,
+    repoRoot: process.cwd(),
+    runPlanner: args.simulate
+      ? async ({ prompt, repoRoot }) => {
+          const result = await runConfiguredAgent({
+            prompt,
+            worktreePath: repoRoot,
+            timeoutMs: config.agent.timeoutMs,
+            config,
+            logger: console,
+            allowWrites: false,
+          })
 
-  if (args.json) {
-    console.log(formatAuditJsonReport(managedIssues))
-    return
-  }
+          if (!result.ok) {
+            throw new Error(result.stderr || result.stdout || 'Issue audit simulation agent execution failed')
+          }
 
-  console.log(`managed issues: ${managedIssues.length}`)
+          return {
+            responseText: result.responseText,
+          }
+        }
+      : undefined,
+  })
 
-  for (const issue of managedIssues) {
-    console.log(formatAuditLine(issue))
-  }
+  console.log(formatAuditOutput(report, args.json))
 
-  const invalidReady = managedIssues.filter((issue) => issue.state === 'ready' && !issue.hasExecutableContract)
-  const invalidReadySection = formatInvalidReadySection(invalidReady)
-  if (invalidReadySection) {
-    console.log(`\n${invalidReadySection}`)
+  if ((args.issueNumbers?.length ?? 0) > 0 && report.summary.invalidIssueCount > 0) {
+    process.exitCode = 1
   }
 }
 

--- a/apps/agent-daemon/src/audit-issue-contracts.ts
+++ b/apps/agent-daemon/src/audit-issue-contracts.ts
@@ -40,6 +40,12 @@ export interface AuditIssuesSummary {
   warningIssueCount: number
 }
 
+export interface IssueOpsSummary {
+  invalidReadyIssueCount: number
+  lowScoreIssueCount: number
+  warningIssueCount: number
+}
+
 export interface AuditIssuesReport {
   summary: AuditIssuesSummary
   issues: AuditedIssue[]
@@ -393,13 +399,33 @@ export async function buildIssueLintReportFromRemoteIssue(input: {
   }, issue.title)
 }
 
+export function buildIssueOpsSummary(input: Array<{
+  state: string
+  readyGateBlocked: boolean
+  qualityScore: number
+  warningCount: number
+}>): IssueOpsSummary {
+  return {
+    invalidReadyIssueCount: input.filter((issue) => issue.state === 'ready' && issue.readyGateBlocked).length,
+    lowScoreIssueCount: input.filter((issue) => issue.qualityScore < LOW_ISSUE_QUALITY_SCORE_THRESHOLD).length,
+    warningIssueCount: input.filter((issue) => issue.warningCount > 0).length,
+  }
+}
+
 function buildAuditSummary(issues: AuditedIssue[]): AuditIssuesSummary {
+  const issueOpsSummary = buildIssueOpsSummary(issues.map((issue) => ({
+    state: issue.state,
+    readyGateBlocked: issue.contract.readyGateBlocked,
+    qualityScore: issue.qualityScore,
+    warningCount: issue.contractWarnings.length,
+  })))
+
   return {
     auditedIssueCount: issues.length,
     invalidIssueCount: issues.filter((issue) => !issue.contract.valid).length,
-    invalidReadyIssueCount: issues.filter((issue) => issue.state === 'ready' && !issue.contract.valid).length,
-    lowScoreIssueCount: issues.filter((issue) => issue.contract.score < LOW_ISSUE_QUALITY_SCORE_THRESHOLD).length,
-    warningIssueCount: issues.filter((issue) => issue.contract.warnings.length > 0).length,
+    invalidReadyIssueCount: issueOpsSummary.invalidReadyIssueCount,
+    lowScoreIssueCount: issueOpsSummary.lowScoreIssueCount,
+    warningIssueCount: issueOpsSummary.warningIssueCount,
   }
 }
 

--- a/apps/agent-daemon/src/bootstrap-convergence.test.ts
+++ b/apps/agent-daemon/src/bootstrap-convergence.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildBootstrapConvergenceReportForRepo,
+  formatBootstrapConvergenceReport,
+  resolveBootstrapConvergenceExitCode,
+} from './bootstrap-convergence'
+
+describe('buildBootstrapConvergenceReportForRepo', () => {
+  test('aggregates suppressed issue and PR drift into actionable convergence items', async () => {
+    const report = await buildBootstrapConvergenceReportForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      buildBootstrapGateReportForRepo: async () => ({
+        version: 'v0.2',
+        ready: true,
+        blockers: [],
+        suppressedBlockers: [
+          {
+            issueNumber: 37,
+            state: 'failed',
+            labels: ['agent:failed'],
+            title: '[AL-7] repo grounded context',
+            implementedLocally: true,
+            localImplementationHeadline: 'feat(#37): add repo authoring context',
+            suppressionKind: 'local_implementation',
+          },
+        ],
+        requiredEvidence: [],
+        blockingReasons: [],
+      }),
+      buildBootstrapScorecardForRepo: async () => ({
+        ready: true,
+        categoryCounts: {
+          contract_failure: 0,
+          runtime_failure: 0,
+          pr_lifecycle_failure: 0,
+          review_failure: 0,
+          github_transport_failure: 0,
+          release_process_failure: 0,
+        },
+        topBlockers: [],
+        suppressedCategoryCounts: {
+          contract_failure: 0,
+          runtime_failure: 0,
+          pr_lifecycle_failure: 1,
+          review_failure: 1,
+          github_transport_failure: 0,
+          release_process_failure: 0,
+        },
+        suppressedBlockers: [
+          {
+            category: 'pr_lifecycle_failure',
+            issueNumber: 61,
+            prNumber: 73,
+            reason: 'linked PR #73 is in terminal agent:human-needed',
+            suppressionKind: 'local_implementation',
+            localImplementationHeadline: 'Fix #61 gate approved PR merges on check status',
+          },
+          {
+            category: 'review_failure',
+            issueNumber: 61,
+            prNumber: 73,
+            reason: 'checks gate previously misclassified failing checks',
+            suppressionKind: 'local_implementation',
+            localImplementationHeadline: 'Fix #61 gate approved PR merges on check status',
+          },
+        ],
+        auditSummary: {
+          managedIssueCount: 0,
+          readyIssueCount: 0,
+          invalidReadyIssueCount: 0,
+          lowScoreIssueCount: 0,
+          warningIssueCount: 0,
+        },
+      }),
+    })
+
+    expect(report.gateReady).toBe(true)
+    expect(report.scorecardReady).toBe(true)
+    expect(report.converged).toBe(false)
+    expect(report.summary).toEqual({
+      totalActions: 2,
+      issueActions: 1,
+      pullRequestActions: 1,
+    })
+    expect(report.actions).toEqual([
+      expect.objectContaining({
+        kind: 'issue_state_sync',
+        issueNumber: 37,
+        remoteState: 'failed',
+        recommendedAction: 'sync_issue_state',
+      }),
+      expect.objectContaining({
+        kind: 'pull_request_cleanup',
+        issueNumber: 61,
+        prNumber: 73,
+        recommendedAction: 'close_or_supersede_pr',
+        categories: ['pr_lifecycle_failure', 'review_failure'],
+        reasons: [
+          'linked PR #73 is in terminal agent:human-needed',
+          'checks gate previously misclassified failing checks',
+        ],
+      }),
+    ])
+    expect(resolveBootstrapConvergenceExitCode(report)).toBe(1)
+    expect(formatBootstrapConvergenceReport(report)).toContain('Bootstrap Convergence')
+    expect(formatBootstrapConvergenceReport(report)).toContain('pull_request_cleanup')
+  })
+
+  test('reports convergence when no suppressed remote drift remains', async () => {
+    const report = await buildBootstrapConvergenceReportForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      buildBootstrapGateReportForRepo: async () => ({
+        version: 'v0.2',
+        ready: true,
+        blockers: [],
+        suppressedBlockers: [],
+        requiredEvidence: [],
+        blockingReasons: [],
+      }),
+      buildBootstrapScorecardForRepo: async () => ({
+        ready: true,
+        categoryCounts: {
+          contract_failure: 0,
+          runtime_failure: 0,
+          pr_lifecycle_failure: 0,
+          review_failure: 0,
+          github_transport_failure: 0,
+          release_process_failure: 0,
+        },
+        topBlockers: [],
+        suppressedCategoryCounts: {
+          contract_failure: 0,
+          runtime_failure: 0,
+          pr_lifecycle_failure: 0,
+          review_failure: 0,
+          github_transport_failure: 0,
+          release_process_failure: 0,
+        },
+        suppressedBlockers: [],
+        auditSummary: {
+          managedIssueCount: 0,
+          readyIssueCount: 0,
+          invalidReadyIssueCount: 0,
+          lowScoreIssueCount: 0,
+          warningIssueCount: 0,
+        },
+      }),
+    })
+
+    expect(report.converged).toBe(true)
+    expect(report.actions).toEqual([])
+    expect(resolveBootstrapConvergenceExitCode(report)).toBe(0)
+  })
+})

--- a/apps/agent-daemon/src/bootstrap-convergence.ts
+++ b/apps/agent-daemon/src/bootstrap-convergence.ts
@@ -1,0 +1,249 @@
+import { type AgentConfig } from '@agent/shared'
+import {
+  buildBootstrapGateReportForRepo,
+  type BootstrapGateReport,
+} from './bootstrap-gate'
+import {
+  buildBootstrapScorecardForRepo,
+  type BootstrapFailureKind,
+  type BootstrapScorecard,
+} from './bootstrap-scorecard'
+
+export type BootstrapConvergenceActionKind =
+  | 'issue_state_sync'
+  | 'pull_request_cleanup'
+
+export interface BootstrapConvergenceAction {
+  kind: BootstrapConvergenceActionKind
+  issueNumber?: number | null
+  prNumber?: number | null
+  remoteState?: string | null
+  categories: BootstrapFailureKind[]
+  reasons: string[]
+  localImplementationHeadline?: string | null
+  recommendedAction: string
+  summary: string
+}
+
+export interface BootstrapConvergenceReportSummary {
+  totalActions: number
+  issueActions: number
+  pullRequestActions: number
+}
+
+export interface BootstrapConvergenceReport {
+  gateReady: boolean
+  scorecardReady: boolean
+  converged: boolean
+  summary: BootstrapConvergenceReportSummary
+  actions: BootstrapConvergenceAction[]
+}
+
+interface BuildBootstrapConvergenceReportForRepoInput {
+  config: AgentConfig
+  repoRoot?: string
+}
+
+interface BootstrapConvergenceDependencies {
+  buildBootstrapGateReportForRepo: typeof buildBootstrapGateReportForRepo
+  buildBootstrapScorecardForRepo: typeof buildBootstrapScorecardForRepo
+}
+
+const DEFAULT_BOOTSTRAP_CONVERGENCE_DEPENDENCIES: BootstrapConvergenceDependencies = {
+  buildBootstrapGateReportForRepo,
+  buildBootstrapScorecardForRepo,
+}
+
+export async function buildBootstrapConvergenceReportForRepo(
+  input: BuildBootstrapConvergenceReportForRepoInput,
+  deps: BootstrapConvergenceDependencies = DEFAULT_BOOTSTRAP_CONVERGENCE_DEPENDENCIES,
+): Promise<BootstrapConvergenceReport> {
+  const [gate, scorecard] = await Promise.all([
+    deps.buildBootstrapGateReportForRepo({
+      config: input.config,
+      repoRoot: input.repoRoot,
+    }),
+    deps.buildBootstrapScorecardForRepo({
+      config: input.config,
+      repoRoot: input.repoRoot,
+    }),
+  ])
+
+  const actions = buildBootstrapConvergenceActions(gate, scorecard)
+
+  return {
+    gateReady: gate.ready,
+    scorecardReady: scorecard.ready,
+    converged: actions.length === 0,
+    summary: {
+      totalActions: actions.length,
+      issueActions: actions.filter((action) => action.kind === 'issue_state_sync').length,
+      pullRequestActions: actions.filter((action) => action.kind === 'pull_request_cleanup').length,
+    },
+    actions,
+  }
+}
+
+export function formatBootstrapConvergenceReport(
+  report: BootstrapConvergenceReport,
+): string {
+  return [
+    'Bootstrap Convergence',
+    `gateReady=${report.gateReady}`,
+    `scorecardReady=${report.scorecardReady}`,
+    `converged=${report.converged}`,
+    `summary: total=${report.summary.totalActions} issueActions=${report.summary.issueActions} pullRequestActions=${report.summary.pullRequestActions}`,
+    'actions:',
+    ...(report.actions.length > 0
+      ? report.actions.map((action) => `- ${action.kind}: ${formatBootstrapConvergenceAction(action)}`)
+      : ['- none']),
+  ].join('\n')
+}
+
+export function formatBootstrapConvergenceReportJson(
+  report: BootstrapConvergenceReport,
+): string {
+  return JSON.stringify(report, null, 2)
+}
+
+export function resolveBootstrapConvergenceExitCode(
+  report: Pick<BootstrapConvergenceReport, 'converged'>,
+): number {
+  return report.converged ? 0 : 1
+}
+
+function buildBootstrapConvergenceActions(
+  gate: BootstrapGateReport,
+  scorecard: BootstrapScorecard,
+): BootstrapConvergenceAction[] {
+  const actionsByKey = new Map<string, BootstrapConvergenceAction>()
+
+  for (const blocker of gate.suppressedBlockers) {
+    const key = `issue:${blocker.issueNumber}`
+    const existing = actionsByKey.get(key)
+    if (existing) {
+      if (!existing.remoteState) {
+        existing.remoteState = blocker.state
+      }
+      continue
+    }
+
+    actionsByKey.set(key, {
+      kind: 'issue_state_sync',
+      issueNumber: blocker.issueNumber,
+      prNumber: null,
+      remoteState: blocker.state,
+      categories: [],
+      reasons: [],
+      localImplementationHeadline: blocker.localImplementationHeadline ?? null,
+      recommendedAction: 'sync_issue_state',
+      summary: `Issue #${blocker.issueNumber} is still ${blocker.state} remotely even though the current branch already contains the implementation.`,
+    })
+  }
+
+  for (const blocker of scorecard.suppressedBlockers) {
+    const key = blocker.prNumber !== null
+      ? `pr:${blocker.issueNumber ?? 'unknown'}:${blocker.prNumber}`
+      : `issue:${blocker.issueNumber ?? 'unknown'}`
+    const existing = actionsByKey.get(key)
+
+    if (existing) {
+      appendBootstrapFailureCategory(existing.categories, blocker.category)
+      appendUniqueReason(existing.reasons, blocker.reason)
+      if (!existing.localImplementationHeadline && blocker.localImplementationHeadline) {
+        existing.localImplementationHeadline = blocker.localImplementationHeadline
+      }
+      existing.summary = buildBootstrapConvergenceSummary(existing)
+      continue
+    }
+
+    const action: BootstrapConvergenceAction = {
+      kind: blocker.prNumber !== null ? 'pull_request_cleanup' : 'issue_state_sync',
+      issueNumber: blocker.issueNumber ?? null,
+      prNumber: blocker.prNumber ?? null,
+      remoteState: null,
+      categories: [blocker.category],
+      reasons: [blocker.reason],
+      localImplementationHeadline: blocker.localImplementationHeadline ?? null,
+      recommendedAction: blocker.prNumber !== null ? 'close_or_supersede_pr' : 'sync_issue_state',
+      summary: '',
+    }
+    action.summary = buildBootstrapConvergenceSummary(action)
+    actionsByKey.set(key, action)
+  }
+
+  return [...actionsByKey.values()].sort(compareBootstrapConvergenceActions)
+}
+
+function buildBootstrapConvergenceSummary(
+  action: Pick<BootstrapConvergenceAction, 'kind' | 'issueNumber' | 'prNumber' | 'remoteState' | 'categories'>,
+): string {
+  const categorySuffix = action.categories.length > 0
+    ? ` suppressed categories=${action.categories.join(',')}`
+    : ''
+
+  if (action.kind === 'pull_request_cleanup') {
+    return `PR #${action.prNumber ?? '?'} for issue #${action.issueNumber ?? '?'} still needs remote cleanup because the current branch already contains the implementation.${categorySuffix}`
+  }
+
+  const remoteState = action.remoteState ? ` is still ${action.remoteState} remotely` : ' still has remote drift'
+  return `Issue #${action.issueNumber ?? '?'}${remoteState} even though the current branch already contains the implementation.${categorySuffix}`
+}
+
+function formatBootstrapConvergenceAction(
+  action: BootstrapConvergenceAction,
+): string {
+  const refs: string[] = []
+  if (action.issueNumber !== null && action.issueNumber !== undefined) {
+    refs.push(`issue#${action.issueNumber}`)
+  }
+  if (action.prNumber !== null && action.prNumber !== undefined) {
+    refs.push(`pr#${action.prNumber}`)
+  }
+
+  return [
+    refs.join(' '),
+    action.remoteState ? `remoteState=${action.remoteState}` : null,
+    action.categories.length > 0 ? `categories=${action.categories.join(',')}` : null,
+    `recommended=${action.recommendedAction}`,
+    action.localImplementationHeadline ? `localCommit=${action.localImplementationHeadline}` : null,
+    `summary=${action.summary}`,
+    action.reasons.length > 0 ? `reasons=${action.reasons.join(' | ')}` : null,
+  ].filter((part): part is string => part !== null && part.length > 0).join(' ')
+}
+
+function appendBootstrapFailureCategory(
+  categories: BootstrapFailureKind[],
+  category: BootstrapFailureKind,
+): void {
+  if (!categories.includes(category)) {
+    categories.push(category)
+  }
+}
+
+function appendUniqueReason(reasons: string[], reason: string): void {
+  if (!reasons.includes(reason)) {
+    reasons.push(reason)
+  }
+}
+
+function compareBootstrapConvergenceActions(
+  left: BootstrapConvergenceAction,
+  right: BootstrapConvergenceAction,
+): number {
+  const leftKindWeight = left.kind === 'issue_state_sync' ? 0 : 1
+  const rightKindWeight = right.kind === 'issue_state_sync' ? 0 : 1
+  if (leftKindWeight !== rightKindWeight) {
+    return leftKindWeight - rightKindWeight
+  }
+
+  const leftIssue = left.issueNumber ?? Number.MAX_SAFE_INTEGER
+  const rightIssue = right.issueNumber ?? Number.MAX_SAFE_INTEGER
+  if (leftIssue !== rightIssue) {
+    return leftIssue - rightIssue
+  }
+
+  const leftPr = left.prNumber ?? Number.MAX_SAFE_INTEGER
+  const rightPr = right.prNumber ?? Number.MAX_SAFE_INTEGER
+  return leftPr - rightPr
+}

--- a/apps/agent-daemon/src/bootstrap-gate.test.ts
+++ b/apps/agent-daemon/src/bootstrap-gate.test.ts
@@ -40,6 +40,7 @@ describe('buildBootstrapGateReport', () => {
     expect(report.ready).toBe(true)
     expect(report.blockingReasons).toEqual([])
     expect(resolveBootstrapGateExitCode(report)).toBe(0)
+    expect(report.suppressedBlockers).toEqual([])
     expect(formatBootstrapGateReport(report)).toContain('ready=true')
   })
 
@@ -62,7 +63,14 @@ describe('buildBootstrapGateReport', () => {
 
     expect(report.ready).toBe(true)
     expect(report.blockingReasons).toEqual([])
+    expect(report.suppressedBlockers).toEqual([
+      expect.objectContaining({
+        issueNumber: 37,
+        suppressionKind: 'local_implementation',
+      }),
+    ])
     expect(formatBootstrapGateReport(report)).toContain('locallyImplemented=true')
+    expect(formatBootstrapGateReport(report)).toContain('suppressedBlockers:')
   })
 })
 
@@ -152,6 +160,15 @@ describe('buildBootstrapGateReportForRepo', () => {
             prNumber: 81,
             reason: 'auto-fix changed files outside AllowedFiles',
           }],
+          suppressedCategoryCounts: {
+            contract_failure: 0,
+            runtime_failure: 0,
+            pr_lifecycle_failure: 0,
+            review_failure: 0,
+            github_transport_failure: 0,
+            release_process_failure: 0,
+          },
+          suppressedBlockers: [],
           auditSummary: {
             managedIssueCount: 10,
             readyIssueCount: 0,
@@ -182,6 +199,7 @@ describe('buildBootstrapGateReportForRepo', () => {
     ])
     expect(report.blockingReasons).toContain('issue #37 is not done (state=ready, labels=agent:ready)')
     expect(report.blockingReasons).toContain('missing required evidence: bootstrap_scorecard_green')
+    expect(report.suppressedBlockers).toEqual([])
   })
 
   test('marks executable evidence missing when local suite evaluation throws', async () => {
@@ -222,6 +240,15 @@ describe('buildBootstrapGateReportForRepo', () => {
           release_process_failure: 0,
         },
         topBlockers: [],
+        suppressedCategoryCounts: {
+          contract_failure: 0,
+          runtime_failure: 0,
+          pr_lifecycle_failure: 0,
+          review_failure: 0,
+          github_transport_failure: 0,
+          release_process_failure: 0,
+        },
+        suppressedBlockers: [],
         auditSummary: {
           managedIssueCount: 0,
           readyIssueCount: 0,
@@ -251,6 +278,7 @@ describe('buildBootstrapGateReportForRepo', () => {
     expect(report.blockingReasons).toEqual([
       'missing required evidence: self_bootstrap_suite_green',
     ])
+    expect(report.suppressedBlockers).toEqual([])
   })
 
   test('marks remotely failed blockers as satisfied when the current branch already contains their implementation', async () => {
@@ -300,6 +328,15 @@ describe('buildBootstrapGateReportForRepo', () => {
           release_process_failure: 0,
         },
         topBlockers: [],
+        suppressedCategoryCounts: {
+          contract_failure: 0,
+          runtime_failure: 0,
+          pr_lifecycle_failure: 0,
+          review_failure: 0,
+          github_transport_failure: 0,
+          release_process_failure: 0,
+        },
+        suppressedBlockers: [],
         auditSummary: {
           managedIssueCount: 0,
           readyIssueCount: 0,
@@ -365,5 +402,6 @@ describe('buildBootstrapGateReportForRepo', () => {
     expect(report.ready).toBe(true)
     expect(report.blockingReasons).toEqual([])
     expect(report.blockers.every((blocker) => blocker.implementedLocally)).toBe(true)
+    expect(report.suppressedBlockers).toHaveLength(10)
   })
 })

--- a/apps/agent-daemon/src/bootstrap-gate.test.ts
+++ b/apps/agent-daemon/src/bootstrap-gate.test.ts
@@ -42,6 +42,28 @@ describe('buildBootstrapGateReport', () => {
     expect(resolveBootstrapGateExitCode(report)).toBe(0)
     expect(formatBootstrapGateReport(report)).toContain('ready=true')
   })
+
+  test('treats locally implemented blockers as satisfied for the current branch gate', () => {
+    const report = buildBootstrapGateReport({
+      version: 'v0.2',
+      blockers: [
+        {
+          issueNumber: 37,
+          state: 'failed',
+          labels: ['agent:failed'],
+          implementedLocally: true,
+          localImplementationHeadline: 'feat(#37): add repo authoring context',
+        },
+      ],
+      requiredEvidence: [
+        { code: 'self_bootstrap_suite_green', satisfied: true },
+      ],
+    })
+
+    expect(report.ready).toBe(true)
+    expect(report.blockingReasons).toEqual([])
+    expect(formatBootstrapGateReport(report)).toContain('locallyImplemented=true')
+  })
 })
 
 describe('buildBootstrapGateReportForRepo', () => {
@@ -50,6 +72,7 @@ describe('buildBootstrapGateReportForRepo', () => {
 
     const report = await buildBootstrapGateReportForRepo({
       version: 'v0.2',
+      fixturesDir: '/tmp/self-bootstrap-fixtures',
       config: {
         repo: 'JamesWuHK/agent-loop',
         pat: 'test-token',
@@ -58,7 +81,7 @@ describe('buildBootstrapGateReportForRepo', () => {
       getAgentIssueByNumber: async (issueNumber) => {
         seen.push(issueNumber)
 
-        if (issueNumber === 60 || issueNumber === 61 || issueNumber === 69) {
+        if (issueNumber === 60 || issueNumber === 61) {
           return {
             number: issueNumber,
             title: `Issue ${issueNumber}`,
@@ -94,25 +117,253 @@ describe('buildBootstrapGateReportForRepo', () => {
           contractValidationErrors: [],
         }
       },
+      evaluateBootstrapScenarioFixtureDirectory: (fixturesDir) => {
+        expect(fixturesDir).toBe('/tmp/self-bootstrap-fixtures')
+
+        return {
+          suite: 'self-bootstrap-v0.2',
+          ok: true,
+          cases: [],
+          failedCases: [],
+          summary: {
+            requiredCases: 4,
+            presentCases: 4,
+            passedCases: 4,
+            failedCases: 0,
+          },
+        }
+      },
+      buildBootstrapScorecardForRepo: async ({ config }) => {
+        expect(config.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          ready: false,
+          categoryCounts: {
+            contract_failure: 0,
+            runtime_failure: 0,
+            pr_lifecycle_failure: 0,
+            review_failure: 1,
+            github_transport_failure: 0,
+            release_process_failure: 0,
+          },
+          topBlockers: [{
+            category: 'review_failure',
+            issueNumber: 39,
+            prNumber: 81,
+            reason: 'auto-fix changed files outside AllowedFiles',
+          }],
+          auditSummary: {
+            managedIssueCount: 10,
+            readyIssueCount: 0,
+            invalidReadyIssueCount: 0,
+            lowScoreIssueCount: 0,
+            warningIssueCount: 0,
+          },
+        }
+      },
+      buildLocalImplementationIndex: () => new Map(),
     })
 
-    expect(seen).toEqual([37, 38, 39, 40, 50, 51, 53, 54, 60, 61, 69, 70])
+    expect(seen).toEqual([37, 38, 39, 40, 50, 51, 53, 54, 60, 61])
     expect(report.blockers.map((blocker) => blocker.issueNumber)).toEqual([37, 38, 39, 40, 50, 51, 53, 54, 60, 61])
     expect(report.requiredEvidence).toEqual([
       {
         code: 'self_bootstrap_suite_green',
         satisfied: true,
         sourceIssueNumber: 69,
-        summary: 'tracked by #69 and currently done',
+        summary: 'scenario suite self-bootstrap-v0.2 passed (4/4 required cases)',
       },
       {
         code: 'bootstrap_scorecard_green',
         satisfied: false,
         sourceIssueNumber: 70,
-        summary: 'awaiting the bootstrap scorecard taxonomy report tracked by #70',
+        summary: 'bootstrap scorecard still reports blockers: review_failure for #39 / PR #81: auto-fix changed files outside AllowedFiles',
       },
     ])
     expect(report.blockingReasons).toContain('issue #37 is not done (state=ready, labels=agent:ready)')
     expect(report.blockingReasons).toContain('missing required evidence: bootstrap_scorecard_green')
+  })
+
+  test('marks executable evidence missing when local suite evaluation throws', async () => {
+    const report = await buildBootstrapGateReportForRepo({
+      version: 'v0.2',
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      getAgentIssueByNumber: async (issueNumber) => ({
+        number: issueNumber,
+        title: `Issue ${issueNumber}`,
+        body: '',
+        state: 'done',
+        labels: ['agent:done'],
+        assignee: null,
+        isClaimable: false,
+        updatedAt: '2026-04-11T00:00:00.000Z',
+        dependencyIssueNumbers: [],
+        hasDependencyMetadata: false,
+        dependencyParseError: false,
+        claimBlockedBy: [],
+        hasExecutableContract: true,
+        contractValidationErrors: [],
+      }),
+      evaluateBootstrapScenarioFixtureDirectory: () => {
+        throw new Error('fixtures directory is missing')
+      },
+      buildBootstrapScorecardForRepo: async () => ({
+        ready: true,
+        categoryCounts: {
+          contract_failure: 0,
+          runtime_failure: 0,
+          pr_lifecycle_failure: 0,
+          review_failure: 0,
+          github_transport_failure: 0,
+          release_process_failure: 0,
+        },
+        topBlockers: [],
+        auditSummary: {
+          managedIssueCount: 0,
+          readyIssueCount: 0,
+          invalidReadyIssueCount: 0,
+          lowScoreIssueCount: 0,
+          warningIssueCount: 0,
+        },
+      }),
+      buildLocalImplementationIndex: () => new Map(),
+    })
+
+    expect(report.ready).toBe(false)
+    expect(report.requiredEvidence).toEqual([
+      {
+        code: 'self_bootstrap_suite_green',
+        satisfied: false,
+        sourceIssueNumber: 69,
+        summary: 'scenario suite evaluation failed: fixtures directory is missing',
+      },
+      {
+        code: 'bootstrap_scorecard_green',
+        satisfied: true,
+        sourceIssueNumber: 70,
+        summary: 'bootstrap scorecard reported ready with no blockers',
+      },
+    ])
+    expect(report.blockingReasons).toEqual([
+      'missing required evidence: self_bootstrap_suite_green',
+    ])
+  })
+
+  test('marks remotely failed blockers as satisfied when the current branch already contains their implementation', async () => {
+    const report = await buildBootstrapGateReportForRepo({
+      version: 'v0.2',
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      getAgentIssueByNumber: async (issueNumber) => ({
+        number: issueNumber,
+        title: `Issue ${issueNumber}`,
+        body: '',
+        state: 'failed',
+        labels: ['agent:failed'],
+        assignee: null,
+        isClaimable: false,
+        updatedAt: '2026-04-11T00:00:00.000Z',
+        dependencyIssueNumbers: [],
+        hasDependencyMetadata: false,
+        dependencyParseError: false,
+        claimBlockedBy: [],
+        hasExecutableContract: true,
+        contractValidationErrors: [],
+      }),
+      evaluateBootstrapScenarioFixtureDirectory: () => ({
+        suite: 'self-bootstrap-v0.2',
+        ok: true,
+        cases: [],
+        failedCases: [],
+        summary: {
+          requiredCases: 4,
+          presentCases: 4,
+          passedCases: 4,
+          failedCases: 0,
+        },
+      }),
+      buildBootstrapScorecardForRepo: async () => ({
+        ready: true,
+        categoryCounts: {
+          contract_failure: 0,
+          runtime_failure: 0,
+          pr_lifecycle_failure: 0,
+          review_failure: 0,
+          github_transport_failure: 0,
+          release_process_failure: 0,
+        },
+        topBlockers: [],
+        auditSummary: {
+          managedIssueCount: 0,
+          readyIssueCount: 0,
+          invalidReadyIssueCount: 0,
+          lowScoreIssueCount: 0,
+          warningIssueCount: 0,
+        },
+      }),
+      buildLocalImplementationIndex: () => new Map([
+        [37, {
+          issueNumber: 37,
+          latestCommitHeadline: 'feat(#37): add repo authoring context',
+          commitCount: 1,
+        }],
+        [38, {
+          issueNumber: 38,
+          latestCommitHeadline: 'feat(#38): add issue rewrite cli',
+          commitCount: 1,
+        }],
+        [39, {
+          issueNumber: 39,
+          latestCommitHeadline: 'feat(#39): add parent issue splitter',
+          commitCount: 1,
+        }],
+        [40, {
+          issueNumber: 40,
+          latestCommitHeadline: 'feat(#40): add issue simulate command',
+          commitCount: 1,
+        }],
+        [50, {
+          issueNumber: 50,
+          latestCommitHeadline: 'feat(#50): add repo issue audit command',
+          commitCount: 1,
+        }],
+        [51, {
+          issueNumber: 51,
+          latestCommitHeadline: 'feat(#51): inject project issue authoring rules',
+          commitCount: 1,
+        }],
+        [53, {
+          issueNumber: 53,
+          latestCommitHeadline: 'feat(#53): add issue repair cli',
+          commitCount: 1,
+        }],
+        [54, {
+          issueNumber: 54,
+          latestCommitHeadline: 'feat(#54): add issue apply cli',
+          commitCount: 1,
+        }],
+        [60, {
+          issueNumber: 60,
+          latestCommitHeadline: 'fix(#60): reopen replacement PR flow',
+          commitCount: 1,
+        }],
+        [61, {
+          issueNumber: 61,
+          latestCommitHeadline: 'fix(#61): gate approved PR merges on check status',
+          commitCount: 1,
+        }],
+      ]),
+    })
+
+    expect(report.ready).toBe(true)
+    expect(report.blockingReasons).toEqual([])
+    expect(report.blockers.every((blocker) => blocker.implementedLocally)).toBe(true)
   })
 })

--- a/apps/agent-daemon/src/bootstrap-gate.test.ts
+++ b/apps/agent-daemon/src/bootstrap-gate.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildBootstrapGateReport,
+  buildBootstrapGateReportForRepo,
+  formatBootstrapGateReport,
+  resolveBootstrapGateExitCode,
+} from './bootstrap-gate'
+
+describe('buildBootstrapGateReport', () => {
+  test('blocks v0.2 when blockers or release evidence are unresolved', () => {
+    const report = buildBootstrapGateReport({
+      version: 'v0.2',
+      blockers: [
+        { issueNumber: 37, state: 'open', labels: ['agent:failed'] },
+        { issueNumber: 60, state: 'closed', labels: ['agent:done'] },
+      ],
+      requiredEvidence: [
+        { code: 'self_bootstrap_suite_green', satisfied: false },
+      ],
+    })
+
+    expect(report.ready).toBe(false)
+    expect(report.blockingReasons).toContain('issue #37 is not done (state=open, labels=agent:failed)')
+    expect(report.blockingReasons).toContain('missing required evidence: self_bootstrap_suite_green')
+    expect(resolveBootstrapGateExitCode(report)).toBe(1)
+  })
+
+  test('passes when blockers are done and required evidence is satisfied', () => {
+    const report = buildBootstrapGateReport({
+      version: 'v0.2',
+      blockers: [
+        { issueNumber: 37, state: 'done', labels: ['agent:done'] },
+        { issueNumber: 60, state: 'closed', labels: ['agent:done'] },
+      ],
+      requiredEvidence: [
+        { code: 'self_bootstrap_suite_green', satisfied: true },
+      ],
+    })
+
+    expect(report.ready).toBe(true)
+    expect(report.blockingReasons).toEqual([])
+    expect(resolveBootstrapGateExitCode(report)).toBe(0)
+    expect(formatBootstrapGateReport(report)).toContain('ready=true')
+  })
+})
+
+describe('buildBootstrapGateReportForRepo', () => {
+  test('uses deterministic blocker and release evidence issue sets', async () => {
+    const seen: number[] = []
+
+    const report = await buildBootstrapGateReportForRepo({
+      version: 'v0.2',
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      getAgentIssueByNumber: async (issueNumber) => {
+        seen.push(issueNumber)
+
+        if (issueNumber === 60 || issueNumber === 61 || issueNumber === 69) {
+          return {
+            number: issueNumber,
+            title: `Issue ${issueNumber}`,
+            body: '',
+            state: 'done',
+            labels: ['agent:done'],
+            assignee: null,
+            isClaimable: false,
+            updatedAt: '2026-04-11T00:00:00.000Z',
+            dependencyIssueNumbers: [],
+            hasDependencyMetadata: false,
+            dependencyParseError: false,
+            claimBlockedBy: [],
+            hasExecutableContract: true,
+            contractValidationErrors: [],
+          }
+        }
+
+        return {
+          number: issueNumber,
+          title: `Issue ${issueNumber}`,
+          body: '',
+          state: 'ready',
+          labels: ['agent:ready'],
+          assignee: null,
+          isClaimable: true,
+          updatedAt: '2026-04-11T00:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        }
+      },
+    })
+
+    expect(seen).toEqual([37, 38, 39, 40, 50, 51, 53, 54, 60, 61, 69, 70])
+    expect(report.blockers.map((blocker) => blocker.issueNumber)).toEqual([37, 38, 39, 40, 50, 51, 53, 54, 60, 61])
+    expect(report.requiredEvidence).toEqual([
+      {
+        code: 'self_bootstrap_suite_green',
+        satisfied: true,
+        sourceIssueNumber: 69,
+        summary: 'tracked by #69 and currently done',
+      },
+      {
+        code: 'bootstrap_scorecard_green',
+        satisfied: false,
+        sourceIssueNumber: 70,
+        summary: 'awaiting the bootstrap scorecard taxonomy report tracked by #70',
+      },
+    ])
+    expect(report.blockingReasons).toContain('issue #37 is not done (state=ready, labels=agent:ready)')
+    expect(report.blockingReasons).toContain('missing required evidence: bootstrap_scorecard_green')
+  })
+})

--- a/apps/agent-daemon/src/bootstrap-gate.ts
+++ b/apps/agent-daemon/src/bootstrap-gate.ts
@@ -1,8 +1,22 @@
+import { join } from 'node:path'
 import {
   getAgentIssueByNumber,
   type AgentConfig,
   type AgentIssue,
 } from '@agent/shared'
+import {
+  buildBootstrapScorecardForRepo,
+  type BootstrapScorecard,
+  type BootstrapScorecardBlocker,
+} from './bootstrap-scorecard'
+import {
+  buildLocalImplementationIndex,
+  type LocalImplementationRecord,
+} from './local-implementation'
+import {
+  evaluateBootstrapScenarioFixtureDirectory,
+  type BootstrapScenarioSuiteReport,
+} from './replay-eval'
 
 export const DEFAULT_BOOTSTRAP_GATE_VERSION = 'v0.2'
 export const DEFAULT_BOOTSTRAP_BLOCKER_ISSUE_NUMBERS = [
@@ -12,21 +26,24 @@ export const DEFAULT_BOOTSTRAP_BLOCKER_ISSUE_NUMBERS = [
 const DEFAULT_REQUIRED_EVIDENCE_SPECS = [
   {
     code: 'self_bootstrap_suite_green',
-    issueNumber: 69,
+    sourceIssueNumber: 69,
     summary: 'awaiting the deterministic self-bootstrap scenario suite tracked by #69',
   },
   {
     code: 'bootstrap_scorecard_green',
-    issueNumber: 70,
+    sourceIssueNumber: 70,
     summary: 'awaiting the bootstrap scorecard taxonomy report tracked by #70',
   },
 ] as const
+const DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR = join(import.meta.dir, 'fixtures', 'replay')
 
 export interface BootstrapGateBlocker {
   issueNumber: number
   state: string
   labels: string[]
   title?: string | null
+  implementedLocally?: boolean
+  localImplementationHeadline?: string | null
 }
 
 export interface BootstrapGateEvidence {
@@ -53,14 +70,22 @@ interface BuildBootstrapGateReportInput {
 interface BuildBootstrapGateReportForRepoInput {
   config: AgentConfig
   version?: string
+  fixturesDir?: string
+  repoRoot?: string
 }
 
 interface BootstrapGateDependencies {
   getAgentIssueByNumber: typeof getAgentIssueByNumber
+  evaluateBootstrapScenarioFixtureDirectory: typeof evaluateBootstrapScenarioFixtureDirectory
+  buildBootstrapScorecardForRepo: typeof buildBootstrapScorecardForRepo
+  buildLocalImplementationIndex: typeof buildLocalImplementationIndex
 }
 
 const DEFAULT_BOOTSTRAP_GATE_DEPENDENCIES: BootstrapGateDependencies = {
   getAgentIssueByNumber,
+  evaluateBootstrapScenarioFixtureDirectory,
+  buildBootstrapScorecardForRepo,
+  buildLocalImplementationIndex,
 }
 
 export function buildBootstrapGateReport(
@@ -95,41 +120,35 @@ export async function buildBootstrapGateReportForRepo(
   input: BuildBootstrapGateReportForRepoInput,
   deps: BootstrapGateDependencies = DEFAULT_BOOTSTRAP_GATE_DEPENDENCIES,
 ): Promise<BootstrapGateReport> {
-  const issueNumbers = new Set<number>(DEFAULT_BOOTSTRAP_BLOCKER_ISSUE_NUMBERS)
-  for (const evidence of DEFAULT_REQUIRED_EVIDENCE_SPECS) {
-    issueNumbers.add(evidence.issueNumber)
-  }
-
-  const issues = await Promise.all(
-    [...issueNumbers].map(async (issueNumber) => [
-      issueNumber,
-      await deps.getAgentIssueByNumber(issueNumber, input.config),
-    ] as const),
-  )
-  const issueMap = new Map<number, AgentIssue | null>(issues)
+  const localImplementationIndex = deps.buildLocalImplementationIndex(input.repoRoot)
+  const [blockers, requiredEvidence] = await Promise.all([
+    Promise.all(
+      DEFAULT_BOOTSTRAP_BLOCKER_ISSUE_NUMBERS.map(async (issueNumber) => {
+        const issue = await deps.getAgentIssueByNumber(issueNumber, input.config)
+        return buildBootstrapGateBlocker(
+          issueNumber,
+          issue,
+          localImplementationIndex.get(issueNumber) ?? null,
+        )
+      }),
+    ),
+    Promise.all([
+      buildScenarioSuiteEvidence({
+        fixturesDir: input.fixturesDir ?? DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR,
+        deps,
+      }),
+      buildBootstrapScorecardEvidence({
+        config: input.config,
+        repoRoot: input.repoRoot,
+        deps,
+      }),
+    ]),
+  ])
 
   return buildBootstrapGateReport({
     version: input.version ?? DEFAULT_BOOTSTRAP_GATE_VERSION,
-    blockers: DEFAULT_BOOTSTRAP_BLOCKER_ISSUE_NUMBERS.map((issueNumber) => {
-      const issue = issueMap.get(issueNumber) ?? null
-      return {
-        issueNumber,
-        state: issue?.state ?? 'missing',
-        labels: issue?.labels ? [...issue.labels] : [],
-        title: issue?.title ?? null,
-      }
-    }),
-    requiredEvidence: DEFAULT_REQUIRED_EVIDENCE_SPECS.map((evidence) => {
-      const issue = issueMap.get(evidence.issueNumber) ?? null
-      return {
-        code: evidence.code,
-        satisfied: issue?.state === 'done',
-        sourceIssueNumber: evidence.issueNumber,
-        summary: issue?.state === 'done'
-          ? `tracked by #${evidence.issueNumber} and currently done`
-          : evidence.summary,
-      }
-    }),
+    blockers,
+    requiredEvidence,
   })
 }
 
@@ -141,7 +160,7 @@ export function formatBootstrapGateReport(
     `version=${report.version}`,
     `ready=${report.ready}`,
     'blockers:',
-    ...report.blockers.map((blocker) => `- #${blocker.issueNumber} state=${blocker.state} labels=${formatBootstrapLabels(blocker.labels)}${blocker.title ? ` title=${blocker.title}` : ''}`),
+    ...report.blockers.map((blocker) => `- #${blocker.issueNumber} state=${blocker.state} labels=${formatBootstrapLabels(blocker.labels)}${blocker.title ? ` title=${blocker.title}` : ''}${blocker.implementedLocally ? ` locallyImplemented=true${blocker.localImplementationHeadline ? ` localCommit=${blocker.localImplementationHeadline}` : ''}` : ''}`),
     'requiredEvidence:',
     ...report.requiredEvidence.map((evidence) => `- ${evidence.code}: ${evidence.satisfied ? 'satisfied' : 'missing'}${evidence.sourceIssueNumber ? ` sourceIssue=#${evidence.sourceIssueNumber}` : ''}${evidence.summary ? ` summary=${evidence.summary}` : ''}`),
     'blockingReasons:',
@@ -164,12 +183,124 @@ export function resolveBootstrapGateExitCode(
 }
 
 function isBootstrapBlockerDone(
-  blocker: Pick<BootstrapGateBlocker, 'state'>,
+  blocker: Pick<BootstrapGateBlocker, 'state' | 'implementedLocally'>,
 ): boolean {
   const normalized = blocker.state.trim().toLowerCase()
-  return normalized === 'done' || normalized === 'closed'
+  return normalized === 'done' || normalized === 'closed' || blocker.implementedLocally === true
 }
 
 function formatBootstrapLabels(labels: string[]): string {
   return labels.length > 0 ? labels.join(',') : '-'
+}
+
+function buildBootstrapGateBlocker(
+  issueNumber: number,
+  issue: AgentIssue | null,
+  localImplementation: LocalImplementationRecord | null,
+): BootstrapGateBlocker {
+  return {
+    issueNumber,
+    state: issue?.state ?? 'missing',
+    labels: issue?.labels ? [...issue.labels] : [],
+    title: issue?.title ?? null,
+    implementedLocally: localImplementation !== null,
+    localImplementationHeadline: localImplementation?.latestCommitHeadline ?? null,
+  }
+}
+
+async function buildScenarioSuiteEvidence(input: {
+  fixturesDir: string
+  deps: BootstrapGateDependencies
+}): Promise<BootstrapGateEvidence> {
+  const spec = DEFAULT_REQUIRED_EVIDENCE_SPECS[0]
+
+  try {
+    const report = await Promise.resolve(
+      input.deps.evaluateBootstrapScenarioFixtureDirectory(input.fixturesDir),
+    )
+    return {
+      code: spec.code,
+      satisfied: report.ok,
+      sourceIssueNumber: spec.sourceIssueNumber,
+      summary: report.ok
+        ? `scenario suite ${report.suite} passed (${report.summary.passedCases}/${report.summary.requiredCases} required cases)`
+        : summarizeScenarioSuiteFailure(report),
+    }
+  } catch (error) {
+    return {
+      code: spec.code,
+      satisfied: false,
+      sourceIssueNumber: spec.sourceIssueNumber,
+      summary: `scenario suite evaluation failed: ${formatBootstrapGateError(error)}`,
+    }
+  }
+}
+
+async function buildBootstrapScorecardEvidence(input: {
+  config: AgentConfig
+  repoRoot?: string
+  deps: BootstrapGateDependencies
+}): Promise<BootstrapGateEvidence> {
+  const spec = DEFAULT_REQUIRED_EVIDENCE_SPECS[1]
+
+  try {
+    const scorecard = await input.deps.buildBootstrapScorecardForRepo({
+      config: input.config,
+      repoRoot: input.repoRoot,
+    })
+    return {
+      code: spec.code,
+      satisfied: scorecard.ready,
+      sourceIssueNumber: spec.sourceIssueNumber,
+      summary: scorecard.ready
+        ? 'bootstrap scorecard reported ready with no blockers'
+        : summarizeBootstrapScorecardFailure(scorecard),
+    }
+  } catch (error) {
+    return {
+      code: spec.code,
+      satisfied: false,
+      sourceIssueNumber: spec.sourceIssueNumber,
+      summary: `bootstrap scorecard evaluation failed: ${formatBootstrapGateError(error)}`,
+    }
+  }
+}
+
+function summarizeScenarioSuiteFailure(
+  report: BootstrapScenarioSuiteReport,
+): string {
+  return `scenario suite ${report.suite} failed (${report.summary.failedCases}/${report.summary.requiredCases} required cases failed: ${report.failedCases.join(',') || 'unknown'})`
+}
+
+function summarizeBootstrapScorecardFailure(
+  scorecard: BootstrapScorecard,
+): string {
+  const topBlocker = scorecard.topBlockers[0]
+  if (!topBlocker) {
+    return 'bootstrap scorecard is not ready'
+  }
+
+  return `bootstrap scorecard still reports blockers: ${topBlocker.category}${formatBootstrapScorecardBlockerTarget(topBlocker)}: ${topBlocker.reason}`
+}
+
+function formatBootstrapScorecardBlockerTarget(
+  blocker: BootstrapScorecardBlocker,
+): string {
+  const refs: string[] = []
+  if (blocker.issueNumber !== null && blocker.issueNumber !== undefined) {
+    refs.push(`#${blocker.issueNumber}`)
+  }
+  if (blocker.prNumber !== null && blocker.prNumber !== undefined) {
+    refs.push(`PR #${blocker.prNumber}`)
+  }
+
+  return refs.length > 0 ? ` for ${refs.join(' / ')}` : ''
+}
+
+function formatBootstrapGateError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message
+  }
+
+  return String(error)
 }

--- a/apps/agent-daemon/src/bootstrap-gate.ts
+++ b/apps/agent-daemon/src/bootstrap-gate.ts
@@ -46,6 +46,10 @@ export interface BootstrapGateBlocker {
   localImplementationHeadline?: string | null
 }
 
+export interface SuppressedBootstrapGateBlocker extends BootstrapGateBlocker {
+  suppressionKind: 'local_implementation'
+}
+
 export interface BootstrapGateEvidence {
   code: string
   satisfied: boolean
@@ -57,6 +61,7 @@ export interface BootstrapGateReport {
   version: string
   ready: boolean
   blockers: BootstrapGateBlocker[]
+  suppressedBlockers: SuppressedBootstrapGateBlocker[]
   requiredEvidence: BootstrapGateEvidence[]
   blockingReasons: string[]
 }
@@ -98,6 +103,12 @@ export function buildBootstrapGateReport(
   const requiredEvidence = input.requiredEvidence.map((evidence) => ({
     ...evidence,
   }))
+  const suppressedBlockers = blockers
+    .filter((blocker) => blocker.implementedLocally === true && !isTerminalDoneState(blocker.state))
+    .map<SuppressedBootstrapGateBlocker>((blocker) => ({
+      ...blocker,
+      suppressionKind: 'local_implementation',
+    }))
   const blockingReasons = [
     ...blockers
       .filter((blocker) => !isBootstrapBlockerDone(blocker))
@@ -111,6 +122,7 @@ export function buildBootstrapGateReport(
     version: input.version,
     ready: blockingReasons.length === 0,
     blockers,
+    suppressedBlockers,
     requiredEvidence,
     blockingReasons,
   }
@@ -161,6 +173,10 @@ export function formatBootstrapGateReport(
     `ready=${report.ready}`,
     'blockers:',
     ...report.blockers.map((blocker) => `- #${blocker.issueNumber} state=${blocker.state} labels=${formatBootstrapLabels(blocker.labels)}${blocker.title ? ` title=${blocker.title}` : ''}${blocker.implementedLocally ? ` locallyImplemented=true${blocker.localImplementationHeadline ? ` localCommit=${blocker.localImplementationHeadline}` : ''}` : ''}`),
+    'suppressedBlockers:',
+    ...(report.suppressedBlockers.length > 0
+      ? report.suppressedBlockers.map((blocker) => `- ${blocker.suppressionKind}: #${blocker.issueNumber} state=${blocker.state}${blocker.title ? ` title=${blocker.title}` : ''}${blocker.localImplementationHeadline ? ` localCommit=${blocker.localImplementationHeadline}` : ''}`)
+      : ['- none']),
     'requiredEvidence:',
     ...report.requiredEvidence.map((evidence) => `- ${evidence.code}: ${evidence.satisfied ? 'satisfied' : 'missing'}${evidence.sourceIssueNumber ? ` sourceIssue=#${evidence.sourceIssueNumber}` : ''}${evidence.summary ? ` summary=${evidence.summary}` : ''}`),
     'blockingReasons:',
@@ -187,6 +203,11 @@ function isBootstrapBlockerDone(
 ): boolean {
   const normalized = blocker.state.trim().toLowerCase()
   return normalized === 'done' || normalized === 'closed' || blocker.implementedLocally === true
+}
+
+function isTerminalDoneState(state: string): boolean {
+  const normalized = state.trim().toLowerCase()
+  return normalized === 'done' || normalized === 'closed'
 }
 
 function formatBootstrapLabels(labels: string[]): string {

--- a/apps/agent-daemon/src/bootstrap-gate.ts
+++ b/apps/agent-daemon/src/bootstrap-gate.ts
@@ -1,0 +1,175 @@
+import {
+  getAgentIssueByNumber,
+  type AgentConfig,
+  type AgentIssue,
+} from '@agent/shared'
+
+export const DEFAULT_BOOTSTRAP_GATE_VERSION = 'v0.2'
+export const DEFAULT_BOOTSTRAP_BLOCKER_ISSUE_NUMBERS = [
+  37, 38, 39, 40, 50, 51, 53, 54, 60, 61,
+] as const
+
+const DEFAULT_REQUIRED_EVIDENCE_SPECS = [
+  {
+    code: 'self_bootstrap_suite_green',
+    issueNumber: 69,
+    summary: 'awaiting the deterministic self-bootstrap scenario suite tracked by #69',
+  },
+  {
+    code: 'bootstrap_scorecard_green',
+    issueNumber: 70,
+    summary: 'awaiting the bootstrap scorecard taxonomy report tracked by #70',
+  },
+] as const
+
+export interface BootstrapGateBlocker {
+  issueNumber: number
+  state: string
+  labels: string[]
+  title?: string | null
+}
+
+export interface BootstrapGateEvidence {
+  code: string
+  satisfied: boolean
+  sourceIssueNumber?: number | null
+  summary?: string | null
+}
+
+export interface BootstrapGateReport {
+  version: string
+  ready: boolean
+  blockers: BootstrapGateBlocker[]
+  requiredEvidence: BootstrapGateEvidence[]
+  blockingReasons: string[]
+}
+
+interface BuildBootstrapGateReportInput {
+  version: string
+  blockers: BootstrapGateBlocker[]
+  requiredEvidence: BootstrapGateEvidence[]
+}
+
+interface BuildBootstrapGateReportForRepoInput {
+  config: AgentConfig
+  version?: string
+}
+
+interface BootstrapGateDependencies {
+  getAgentIssueByNumber: typeof getAgentIssueByNumber
+}
+
+const DEFAULT_BOOTSTRAP_GATE_DEPENDENCIES: BootstrapGateDependencies = {
+  getAgentIssueByNumber,
+}
+
+export function buildBootstrapGateReport(
+  input: BuildBootstrapGateReportInput,
+): BootstrapGateReport {
+  const blockers = input.blockers.map((blocker) => ({
+    ...blocker,
+    labels: [...blocker.labels],
+  }))
+  const requiredEvidence = input.requiredEvidence.map((evidence) => ({
+    ...evidence,
+  }))
+  const blockingReasons = [
+    ...blockers
+      .filter((blocker) => !isBootstrapBlockerDone(blocker))
+      .map((blocker) => `issue #${blocker.issueNumber} is not done (state=${blocker.state}, labels=${formatBootstrapLabels(blocker.labels)})`),
+    ...requiredEvidence
+      .filter((evidence) => !evidence.satisfied)
+      .map((evidence) => `missing required evidence: ${evidence.code}`),
+  ]
+
+  return {
+    version: input.version,
+    ready: blockingReasons.length === 0,
+    blockers,
+    requiredEvidence,
+    blockingReasons,
+  }
+}
+
+export async function buildBootstrapGateReportForRepo(
+  input: BuildBootstrapGateReportForRepoInput,
+  deps: BootstrapGateDependencies = DEFAULT_BOOTSTRAP_GATE_DEPENDENCIES,
+): Promise<BootstrapGateReport> {
+  const issueNumbers = new Set<number>(DEFAULT_BOOTSTRAP_BLOCKER_ISSUE_NUMBERS)
+  for (const evidence of DEFAULT_REQUIRED_EVIDENCE_SPECS) {
+    issueNumbers.add(evidence.issueNumber)
+  }
+
+  const issues = await Promise.all(
+    [...issueNumbers].map(async (issueNumber) => [
+      issueNumber,
+      await deps.getAgentIssueByNumber(issueNumber, input.config),
+    ] as const),
+  )
+  const issueMap = new Map<number, AgentIssue | null>(issues)
+
+  return buildBootstrapGateReport({
+    version: input.version ?? DEFAULT_BOOTSTRAP_GATE_VERSION,
+    blockers: DEFAULT_BOOTSTRAP_BLOCKER_ISSUE_NUMBERS.map((issueNumber) => {
+      const issue = issueMap.get(issueNumber) ?? null
+      return {
+        issueNumber,
+        state: issue?.state ?? 'missing',
+        labels: issue?.labels ? [...issue.labels] : [],
+        title: issue?.title ?? null,
+      }
+    }),
+    requiredEvidence: DEFAULT_REQUIRED_EVIDENCE_SPECS.map((evidence) => {
+      const issue = issueMap.get(evidence.issueNumber) ?? null
+      return {
+        code: evidence.code,
+        satisfied: issue?.state === 'done',
+        sourceIssueNumber: evidence.issueNumber,
+        summary: issue?.state === 'done'
+          ? `tracked by #${evidence.issueNumber} and currently done`
+          : evidence.summary,
+      }
+    }),
+  })
+}
+
+export function formatBootstrapGateReport(
+  report: BootstrapGateReport,
+): string {
+  return [
+    'Bootstrap Gate',
+    `version=${report.version}`,
+    `ready=${report.ready}`,
+    'blockers:',
+    ...report.blockers.map((blocker) => `- #${blocker.issueNumber} state=${blocker.state} labels=${formatBootstrapLabels(blocker.labels)}${blocker.title ? ` title=${blocker.title}` : ''}`),
+    'requiredEvidence:',
+    ...report.requiredEvidence.map((evidence) => `- ${evidence.code}: ${evidence.satisfied ? 'satisfied' : 'missing'}${evidence.sourceIssueNumber ? ` sourceIssue=#${evidence.sourceIssueNumber}` : ''}${evidence.summary ? ` summary=${evidence.summary}` : ''}`),
+    'blockingReasons:',
+    ...(report.blockingReasons.length > 0
+      ? report.blockingReasons.map((reason) => `- ${reason}`)
+      : ['- none']),
+  ].join('\n')
+}
+
+export function formatBootstrapGateReportJson(
+  report: BootstrapGateReport,
+): string {
+  return JSON.stringify(report, null, 2)
+}
+
+export function resolveBootstrapGateExitCode(
+  report: Pick<BootstrapGateReport, 'ready'>,
+): number {
+  return report.ready ? 0 : 1
+}
+
+function isBootstrapBlockerDone(
+  blocker: Pick<BootstrapGateBlocker, 'state'>,
+): boolean {
+  const normalized = blocker.state.trim().toLowerCase()
+  return normalized === 'done' || normalized === 'closed'
+}
+
+function formatBootstrapLabels(labels: string[]): string {
+  return labels.length > 0 ? labels.join(',') : '-'
+}

--- a/apps/agent-daemon/src/bootstrap-scorecard.test.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.test.ts
@@ -1,0 +1,478 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildBootstrapScorecard,
+  buildBootstrapScorecardForRepo,
+  classifyBootstrapFailureKind,
+  formatBootstrapScorecard,
+  resolveBootstrapScorecardExitCode,
+} from './bootstrap-scorecard'
+
+function buildStructuredReviewBlockerComment(
+  prNumber: number,
+  reason: string,
+  options: {
+    attempt?: number
+    headRefOid?: string
+  } = {},
+): string {
+  const metadata = {
+    pr: prNumber,
+    attempt: options.attempt ?? 9,
+    approved: false,
+    canMerge: false,
+    ...(options.headRefOid ? { headRefOid: options.headRefOid } : {}),
+  }
+
+  return `<!-- agent-loop:pr-review ${JSON.stringify(metadata)} -->
+<!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":${JSON.stringify(reason)},"findings":[{"severity":"high","file":"apps/agent-daemon/src/bootstrap-scorecard.ts","summary":"scorecard signal mismatch","mustFix":["reuse authoritative blocker signals"],"mustNotDo":["do not infer blockers from labels alone"],"validation":["bun test apps/agent-daemon/src/bootstrap-scorecard.test.ts"],"scopeRationale":"issue #70 requires stable taxonomy output"}]} -->
+## Automated review still failing — human intervention required`
+}
+
+function buildExecutionFailureReviewComment(
+  prNumber: number,
+  headRefOid: string,
+): string {
+  return `<!-- agent-loop:pr-review {"pr":${prNumber},"attempt":2,"approved":false,"canMerge":false,"headRefOid":"${headRefOid}"} -->
+## Automated review still failing — human intervention required
+
+- Attempt: 2
+- Merge ready: no
+- Reason: Review failed: ReviewAgentExecutionError: Agent exited with code 1`
+}
+
+function buildBlockedResumeEscalationComment(
+  issueNumber: number,
+  reason: string,
+  options: {
+    prNumber?: number | null
+    escalatedAt?: string
+  } = {},
+): string {
+  return `<!-- agent-loop:issue-resume-blocked ${JSON.stringify({
+    issueNumber,
+    prNumber: options.prNumber ?? null,
+    blockedSince: '2026-04-11T09:00:00.000Z',
+    escalatedAt: options.escalatedAt ?? '2026-04-11T09:05:00.000Z',
+    thresholdSeconds: 300,
+    reason,
+    machineId: 'codex-dev',
+    daemonInstanceId: 'daemon-1',
+  })} -->
+## agent-loop blocked resume escalation`
+}
+
+describe('buildBootstrapScorecard', () => {
+  test('groups blockers into stable failure taxonomy buckets', () => {
+    expect(classifyBootstrapFailureKind('closed PR blocked fresh PR creation')).toBe('pr_lifecycle_failure')
+    expect(classifyBootstrapFailureKind('missing executable test/build/check command in ### Validation')).toBe('contract_failure')
+
+    const scorecard = buildBootstrapScorecard({
+      audit: { managedIssueCount: 8, readyIssueCount: 3, invalidReadyIssueCount: 2, lowScoreIssueCount: 3, warningIssueCount: 1 },
+      prBlockers: [{ issueNumber: 60, reason: 'closed PR blocked fresh PR creation' }],
+      reviewBlockers: [{ issueNumber: 61, reason: 'agent:human-needed review blocker remains open' }],
+      releaseEvidenceMissing: ['self_bootstrap_suite_green'],
+    })
+
+    expect(scorecard.ready).toBe(false)
+    expect(scorecard.categoryCounts.pr_lifecycle_failure).toBe(1)
+    expect(scorecard.categoryCounts.release_process_failure).toBe(1)
+    expect(scorecard.categoryCounts.contract_failure).toBe(2)
+    expect(resolveBootstrapScorecardExitCode(scorecard)).toBe(1)
+    expect(formatBootstrapScorecard(scorecard)).toContain('Bootstrap Scorecard')
+  })
+})
+
+describe('buildBootstrapScorecardForRepo', () => {
+  test('reuses repo-native issue and pull request signals without hardcoded bootstrap issue numbers', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 50,
+          title: '[AL-11] issue audit',
+          body: '## 用户故事\n\n作为维护者，我希望 scorecard 统计 invalid ready issue。\n\n## Context\n\n### Dependencies\n```json\n{"dependsOn":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/bootstrap-scorecard.ts\n\n### Validation\n- `bun test apps/agent-daemon/src/bootstrap-scorecard.test.ts`\n\n## RED 测试\n```ts\nthrow new Error("red")\n```\n\n## 实现步骤\n1. add scorecard\n\n## 验收\n- [ ] valid',
+          state: 'ready',
+          labels: ['agent:ready'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: false,
+          contractValidationErrors: ['missing ### RequiredSemantics section'],
+        },
+        {
+          number: 61,
+          title: 'issue recovery remains blocked',
+          body: '',
+          state: 'failed',
+          labels: ['agent:failed'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+        {
+          number: 69,
+          title: 'self_bootstrap_suite_green release evidence still missing',
+          body: '',
+          state: 'working',
+          labels: ['agent:working'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [
+        {
+          number: 91,
+          title: 'Fix lifecycle blocker',
+          url: 'https://example.test/pr/91',
+          headRefName: 'agent/61/codex-dev',
+          headRefOid: 'abc123',
+          isDraft: false,
+          labels: ['agent:human-needed'],
+        },
+      ],
+      listIssueComments: async (number) => {
+        if (number === 61) return []
+        if (number === 91) {
+          return [{
+            commentId: 9101,
+            body: buildStructuredReviewBlockerComment(91, 'Approval bar flow regressed', {
+              headRefOid: 'abc123',
+            }),
+            createdAt: '2026-04-11T09:00:00.000Z',
+            updatedAt: '2026-04-11T09:05:00.000Z',
+          }]
+        }
+        return []
+      },
+      getAgentIssueByNumber: async (issueNumber) => ({
+        number: issueNumber,
+        title: `Issue ${issueNumber}`,
+        body: '',
+        state: 'working',
+        labels: ['agent:working'],
+        assignee: null,
+        isClaimable: false,
+        updatedAt: '2026-04-11T10:00:00.000Z',
+        dependencyIssueNumbers: [],
+        hasDependencyMetadata: false,
+        dependencyParseError: false,
+        claimBlockedBy: [],
+        hasExecutableContract: true,
+        contractValidationErrors: [],
+      }),
+    })
+
+    expect(scorecard.categoryCounts).toMatchObject({
+      contract_failure: 1,
+      pr_lifecycle_failure: 1,
+      review_failure: 1,
+      release_process_failure: 0,
+      runtime_failure: 0,
+      github_transport_failure: 0,
+    })
+    expect(scorecard.topBlockers).toEqual([
+      expect.objectContaining({
+        category: 'contract_failure',
+        reason: '1 invalid ready issue(s) require executable contracts',
+      }),
+      expect.objectContaining({
+        category: 'pr_lifecycle_failure',
+        issueNumber: 61,
+        prNumber: 91,
+      }),
+      expect.objectContaining({
+        category: 'review_failure',
+        issueNumber: 61,
+        prNumber: 91,
+        reason: 'Approval bar flow regressed',
+      }),
+    ])
+  })
+
+  test('does not derive release blockers from issue titles alone', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 70,
+          title: 'add bootstrap scorecard taxonomy report',
+          body: '',
+          state: 'working',
+          labels: ['agent:working'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [],
+      listIssueComments: async () => [],
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.categoryCounts.release_process_failure).toBe(0)
+    expect(scorecard.categoryCounts.runtime_failure).toBe(0)
+  })
+
+  test('surfaces closed-pr lifecycle blockers from blocked-resume escalation comments without an open linked PR', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 60,
+          title: 'issue recovery remains blocked',
+          body: '',
+          state: 'failed',
+          labels: ['agent:failed'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [],
+      listIssueComments: async (number) => {
+        if (number !== 60) {
+          return []
+        }
+
+        return [{
+          commentId: 6001,
+          body: buildBlockedResumeEscalationComment(60, 'closed PR blocked fresh PR creation', {
+            prNumber: 88,
+          }),
+          createdAt: '2026-04-11T09:00:00.000Z',
+          updatedAt: '2026-04-11T09:05:00.000Z',
+        }]
+      },
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.categoryCounts.pr_lifecycle_failure).toBe(1)
+    expect(scorecard.topBlockers).toContainEqual(expect.objectContaining({
+      category: 'pr_lifecycle_failure',
+      issueNumber: 60,
+      prNumber: 88,
+      reason: 'closed PR blocked fresh PR creation',
+    }))
+  })
+
+  test('does not synthesize lifecycle or release blockers for another repo when unrelated issue numbers are missing', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'someone-else/example',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [],
+      listOpenAgentPullRequests: async () => [],
+      listIssueComments: async () => [],
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.ready).toBe(true)
+    expect(scorecard.categoryCounts).toEqual({
+      contract_failure: 0,
+      runtime_failure: 0,
+      pr_lifecycle_failure: 0,
+      review_failure: 0,
+      github_transport_failure: 0,
+      release_process_failure: 0,
+    })
+    expect(scorecard.topBlockers).toEqual([])
+  })
+
+  test('suppresses review blockers for resumable human-needed pull requests', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 61,
+          title: 'review follow-up',
+          body: '',
+          state: 'working',
+          labels: ['agent:working'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [
+        {
+          number: 91,
+          title: 'Fix lifecycle blocker',
+          url: 'https://example.test/pr/91',
+          headRefName: 'agent/61/codex-dev',
+          headRefOid: 'abc123',
+          isDraft: false,
+          labels: ['agent:human-needed'],
+        },
+      ],
+      listIssueComments: async (number) => {
+        if (number === 91) {
+          return [{
+            commentId: 9101,
+            body: buildExecutionFailureReviewComment(91, 'abc123'),
+            createdAt: '2026-04-11T09:00:00.000Z',
+            updatedAt: '2026-04-11T09:05:00.000Z',
+          }]
+        }
+        return []
+      },
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.categoryCounts.review_failure).toBe(0)
+    expect(scorecard.categoryCounts.github_transport_failure).toBe(0)
+  })
+
+  test('preserves successful signals when a linked GitHub lookup fails', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 50,
+          title: '[AL-11] issue audit',
+          body: '## 用户故事\n\n作为维护者，我希望 scorecard 统计 invalid ready issue。\n\n## Context\n\n### Dependencies\n```json\n{"dependsOn":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/bootstrap-scorecard.ts\n\n### Validation\n- `bun test apps/agent-daemon/src/bootstrap-scorecard.test.ts`\n\n## RED 测试\n```ts\nthrow new Error("red")\n```\n\n## 实现步骤\n1. add scorecard\n\n## 验收\n- [ ] valid',
+          state: 'ready',
+          labels: ['agent:ready'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: false,
+          contractValidationErrors: ['missing ### RequiredSemantics section'],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [
+        {
+          number: 91,
+          title: 'Fix lifecycle blocker',
+          url: 'https://example.test/pr/91',
+          headRefName: 'agent/61/codex-dev',
+          headRefOid: 'abc123',
+          isDraft: false,
+          labels: ['agent:human-needed'],
+        },
+      ],
+      listIssueComments: async (number) => {
+        if (number === 91) {
+          return [{
+            commentId: 9101,
+            body: buildStructuredReviewBlockerComment(91, 'Approval bar flow regressed', {
+              headRefOid: 'abc123',
+            }),
+            createdAt: '2026-04-11T09:00:00.000Z',
+            updatedAt: '2026-04-11T09:05:00.000Z',
+          }]
+        }
+        return []
+      },
+      getAgentIssueByNumber: async () => {
+        throw new Error('The socket connection was closed unexpectedly.')
+      },
+    })
+
+    expect(scorecard.ready).toBe(false)
+    expect(scorecard.categoryCounts).toMatchObject({
+      contract_failure: 1,
+      review_failure: 1,
+      github_transport_failure: 1,
+      runtime_failure: 0,
+      pr_lifecycle_failure: 0,
+      release_process_failure: 0,
+    })
+    expect(scorecard.topBlockers).toEqual([
+      expect.objectContaining({
+        category: 'contract_failure',
+      }),
+      expect.objectContaining({
+        category: 'review_failure',
+        prNumber: 91,
+      }),
+      expect.objectContaining({
+        category: 'github_transport_failure',
+      }),
+    ])
+  })
+
+  test('downgrades repo fetch failures into transport blockers instead of throwing', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => {
+        throw new Error('The socket connection was closed unexpectedly.')
+      },
+      listOpenAgentPullRequests: async () => [],
+      listIssueComments: async () => [],
+      getAgentIssueByNumber: async () => null,
+    })
+
+    expect(scorecard.ready).toBe(false)
+    expect(scorecard.categoryCounts.github_transport_failure).toBe(1)
+    expect(scorecard.topBlockers).toEqual([
+      expect.objectContaining({
+        category: 'github_transport_failure',
+      }),
+    ])
+  })
+})

--- a/apps/agent-daemon/src/bootstrap-scorecard.test.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.test.ts
@@ -71,13 +71,30 @@ describe('buildBootstrapScorecard', () => {
       prBlockers: [{ issueNumber: 60, reason: 'closed PR blocked fresh PR creation' }],
       reviewBlockers: [{ issueNumber: 61, reason: 'agent:human-needed review blocker remains open' }],
       releaseEvidenceMissing: ['self_bootstrap_suite_green'],
+      suppressedBlockers: [{
+        category: 'review_failure',
+        issueNumber: 39,
+        prNumber: 81,
+        reason: 'auto-fix changed files outside AllowedFiles',
+        suppressionKind: 'local_implementation',
+        localImplementationHeadline: 'feat(#39): add parent issue splitter',
+      }],
     })
 
     expect(scorecard.ready).toBe(false)
     expect(scorecard.categoryCounts.pr_lifecycle_failure).toBe(1)
     expect(scorecard.categoryCounts.release_process_failure).toBe(1)
     expect(scorecard.categoryCounts.contract_failure).toBe(2)
+    expect(scorecard.suppressedCategoryCounts.review_failure).toBe(1)
+    expect(scorecard.suppressedBlockers).toEqual([
+      expect.objectContaining({
+        category: 'review_failure',
+        suppressionKind: 'local_implementation',
+        issueNumber: 39,
+      }),
+    ])
     expect(resolveBootstrapScorecardExitCode(scorecard)).toBe(1)
+    expect(formatBootstrapScorecard(scorecard)).toContain('suppressedBlockers:')
     expect(formatBootstrapScorecard(scorecard)).toContain('Bootstrap Scorecard')
   })
 })
@@ -209,6 +226,15 @@ describe('buildBootstrapScorecardForRepo', () => {
         reason: 'Approval bar flow regressed',
       }),
     ])
+    expect(scorecard.suppressedCategoryCounts).toEqual({
+      contract_failure: 0,
+      runtime_failure: 0,
+      pr_lifecycle_failure: 0,
+      review_failure: 0,
+      github_transport_failure: 0,
+      release_process_failure: 0,
+    })
+    expect(scorecard.suppressedBlockers).toEqual([])
   })
 
   test('does not derive release blockers from issue titles alone', async () => {
@@ -550,5 +576,23 @@ describe('buildBootstrapScorecardForRepo', () => {
     expect(scorecard.ready).toBe(true)
     expect(scorecard.categoryCounts.pr_lifecycle_failure).toBe(0)
     expect(scorecard.categoryCounts.review_failure).toBe(0)
+    expect(scorecard.suppressedCategoryCounts.pr_lifecycle_failure).toBe(1)
+    expect(scorecard.suppressedCategoryCounts.review_failure).toBe(1)
+    expect(scorecard.suppressedBlockers).toEqual([
+      expect.objectContaining({
+        category: 'pr_lifecycle_failure',
+        issueNumber: 70,
+        prNumber: 77,
+        suppressionKind: 'local_implementation',
+        localImplementationHeadline: 'Fix #70 add bootstrap scorecard taxonomy report',
+      }),
+      expect.objectContaining({
+        category: 'review_failure',
+        issueNumber: 70,
+        prNumber: 77,
+        suppressionKind: 'local_implementation',
+        localImplementationHeadline: 'Fix #70 add bootstrap scorecard taxonomy report',
+      }),
+    ])
   })
 })

--- a/apps/agent-daemon/src/bootstrap-scorecard.test.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.test.ts
@@ -181,6 +181,7 @@ describe('buildBootstrapScorecardForRepo', () => {
         hasExecutableContract: true,
         contractValidationErrors: [],
       }),
+      buildLocalImplementationIndex: () => new Map(),
     })
 
     expect(scorecard.categoryCounts).toMatchObject({
@@ -238,6 +239,7 @@ describe('buildBootstrapScorecardForRepo', () => {
       listOpenAgentPullRequests: async () => [],
       listIssueComments: async () => [],
       getAgentIssueByNumber: async () => null,
+      buildLocalImplementationIndex: () => new Map(),
     })
 
     expect(scorecard.categoryCounts.release_process_failure).toBe(0)
@@ -285,6 +287,7 @@ describe('buildBootstrapScorecardForRepo', () => {
         }]
       },
       getAgentIssueByNumber: async () => null,
+      buildLocalImplementationIndex: () => new Map(),
     })
 
     expect(scorecard.categoryCounts.pr_lifecycle_failure).toBe(1)
@@ -307,6 +310,7 @@ describe('buildBootstrapScorecardForRepo', () => {
       listOpenAgentPullRequests: async () => [],
       listIssueComments: async () => [],
       getAgentIssueByNumber: async () => null,
+      buildLocalImplementationIndex: () => new Map(),
     })
 
     expect(scorecard.ready).toBe(true)
@@ -369,6 +373,7 @@ describe('buildBootstrapScorecardForRepo', () => {
         return []
       },
       getAgentIssueByNumber: async () => null,
+      buildLocalImplementationIndex: () => new Map(),
     })
 
     expect(scorecard.categoryCounts.review_failure).toBe(0)
@@ -427,6 +432,7 @@ describe('buildBootstrapScorecardForRepo', () => {
       getAgentIssueByNumber: async () => {
         throw new Error('The socket connection was closed unexpectedly.')
       },
+      buildLocalImplementationIndex: () => new Map(),
     })
 
     expect(scorecard.ready).toBe(false)
@@ -465,6 +471,7 @@ describe('buildBootstrapScorecardForRepo', () => {
       listOpenAgentPullRequests: async () => [],
       listIssueComments: async () => [],
       getAgentIssueByNumber: async () => null,
+      buildLocalImplementationIndex: () => new Map(),
     })
 
     expect(scorecard.ready).toBe(false)
@@ -474,5 +481,74 @@ describe('buildBootstrapScorecardForRepo', () => {
         category: 'github_transport_failure',
       }),
     ])
+  })
+
+  test('suppresses stale review and lifecycle blockers when the current branch already implements the linked issue', async () => {
+    const scorecard = await buildBootstrapScorecardForRepo({
+      config: {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+    }, {
+      listOpenAgentIssues: async () => [
+        {
+          number: 70,
+          title: 'bootstrap scorecard follow-up',
+          body: '',
+          state: 'failed',
+          labels: ['agent:failed'],
+          assignee: null,
+          isClaimable: false,
+          updatedAt: '2026-04-11T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: false,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+        },
+      ],
+      listOpenAgentPullRequests: async () => [
+        {
+          number: 77,
+          title: 'Fix #70 add bootstrap scorecard taxonomy report',
+          url: 'https://example.test/pr/77',
+          headRefName: 'agent/70-rebuild/codex-dev',
+          headRefOid: 'abc123',
+          isDraft: false,
+          labels: ['agent:human-needed'],
+        },
+      ],
+      listIssueComments: async (number) => {
+        if (number === 77) {
+          return [{
+            commentId: 7701,
+            body: buildStructuredReviewBlockerComment(
+              77,
+              'linked PR #77 is in terminal agent:human-needed; automated review has no remaining structured retry path',
+              {
+                headRefOid: 'abc123',
+              },
+            ),
+            createdAt: '2026-04-11T09:00:00.000Z',
+            updatedAt: '2026-04-11T09:05:00.000Z',
+          }]
+        }
+
+        return []
+      },
+      getAgentIssueByNumber: async () => null,
+      buildLocalImplementationIndex: () => new Map([
+        [70, {
+          issueNumber: 70,
+          latestCommitHeadline: 'Fix #70 add bootstrap scorecard taxonomy report',
+          commitCount: 1,
+        }],
+      ]),
+    })
+
+    expect(scorecard.ready).toBe(true)
+    expect(scorecard.categoryCounts.pr_lifecycle_failure).toBe(0)
+    expect(scorecard.categoryCounts.review_failure).toBe(0)
   })
 })

--- a/apps/agent-daemon/src/bootstrap-scorecard.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.ts
@@ -1,0 +1,642 @@
+import {
+  PR_REVIEW_LABELS,
+  getAgentIssueByNumber,
+  listIssueComments,
+  listOpenAgentIssues,
+  listOpenAgentPullRequests,
+  type AgentConfig,
+  type AgentIssue,
+  type IssueComment,
+  type ManagedPullRequest,
+} from '@agent/shared'
+import {
+  buildAuditedIssue,
+  buildAuditIssueSummary,
+  type AuditIssueSummary,
+} from './audit-issue-contracts'
+import {
+  canResumeHumanNeededPrReview,
+  extractLatestAutomatedPrReviewBlockerSummary,
+} from './pr-reviewer'
+import {
+  extractBlockedIssueResumeEscalationComment,
+  evaluateBlockedIssueResumeResolution,
+  getFailedIssueResumeBlock,
+} from './daemon'
+
+export type BootstrapFailureKind =
+  | 'contract_failure'
+  | 'runtime_failure'
+  | 'pr_lifecycle_failure'
+  | 'review_failure'
+  | 'github_transport_failure'
+  | 'release_process_failure'
+
+export interface BootstrapScorecardSignal {
+  issueNumber?: number | null
+  prNumber?: number | null
+  reason: string
+}
+
+export interface BootstrapScorecardBlocker extends BootstrapScorecardSignal {
+  category: BootstrapFailureKind
+}
+
+export interface BootstrapScorecard {
+  ready: boolean
+  categoryCounts: Record<BootstrapFailureKind, number>
+  topBlockers: BootstrapScorecardBlocker[]
+  auditSummary: AuditIssueSummary
+}
+
+interface BootstrapScorecardInput {
+  audit: AuditIssueSummary
+  prBlockers?: BootstrapScorecardSignal[]
+  reviewBlockers?: BootstrapScorecardSignal[]
+  runtimeBlockers?: BootstrapScorecardSignal[]
+  transportBlockers?: BootstrapScorecardSignal[]
+  releaseEvidenceMissing: string[]
+}
+
+interface BootstrapScorecardDependencies {
+  listOpenAgentIssues: typeof listOpenAgentIssues
+  listOpenAgentPullRequests: typeof listOpenAgentPullRequests
+  listIssueComments: typeof listIssueComments
+  getAgentIssueByNumber: typeof getAgentIssueByNumber
+}
+
+const DEFAULT_BOOTSTRAP_SCORECARD_DEPENDENCIES: BootstrapScorecardDependencies = {
+  listOpenAgentIssues,
+  listOpenAgentPullRequests,
+  listIssueComments,
+  getAgentIssueByNumber,
+}
+
+const BOOTSTRAP_FAILURE_KIND_ORDER: BootstrapFailureKind[] = [
+  'contract_failure',
+  'runtime_failure',
+  'pr_lifecycle_failure',
+  'review_failure',
+  'github_transport_failure',
+  'release_process_failure',
+]
+
+const DEFAULT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS = 3
+
+export function classifyBootstrapFailureKind(reason: string): BootstrapFailureKind {
+  const normalized = reason.toLowerCase()
+
+  if (
+    normalized.includes('rate limit')
+    || normalized.includes('github api')
+    || normalized.includes('socket')
+    || normalized.includes('econn')
+    || normalized.includes('timeout')
+    || normalized.includes('transport')
+    || normalized.includes('connection reset')
+  ) {
+    return 'github_transport_failure'
+  }
+
+  if (
+    normalized.includes('missing required evidence:')
+    || normalized.includes('release evidence missing')
+  ) {
+    return 'release_process_failure'
+  }
+
+  if (
+    normalized.includes('closed pr')
+    || normalized.includes('fresh pr')
+    || normalized.includes('merge checks gate')
+    || normalized.includes('merge gate')
+    || normalized.includes('pr lifecycle')
+  ) {
+    return 'pr_lifecycle_failure'
+  }
+
+  if (
+    normalized.includes('human-needed')
+    || normalized.includes('review blocker')
+    || normalized.includes('review failed')
+    || normalized.includes('auto-fix')
+    || normalized.includes('review ')
+  ) {
+    return 'review_failure'
+  }
+
+  if (
+    normalized.includes('runtime blocker:')
+    || normalized.includes('daemon runtime failure:')
+  ) {
+    return 'runtime_failure'
+  }
+
+  return 'contract_failure'
+}
+
+export function buildBootstrapScorecard(
+  input: BootstrapScorecardInput,
+): BootstrapScorecard {
+  const categoryCounts = createEmptyCategoryCounts()
+  const blockers: BootstrapScorecardBlocker[] = []
+
+  if (input.audit.invalidReadyIssueCount > 0) {
+    categoryCounts.contract_failure += input.audit.invalidReadyIssueCount
+    blockers.push({
+      category: 'contract_failure',
+      issueNumber: null,
+      prNumber: null,
+      reason: `${input.audit.invalidReadyIssueCount} invalid ready issue(s) require executable contracts`,
+    })
+  }
+
+  for (const blocker of input.runtimeBlockers ?? []) {
+    categoryCounts.runtime_failure += 1
+    blockers.push({
+      category: 'runtime_failure',
+      ...normalizeScorecardSignal(blocker),
+    })
+  }
+
+  for (const blocker of input.prBlockers ?? []) {
+    categoryCounts.pr_lifecycle_failure += 1
+    blockers.push({
+      category: 'pr_lifecycle_failure',
+      ...normalizeScorecardSignal(blocker),
+    })
+  }
+
+  for (const blocker of input.reviewBlockers ?? []) {
+    categoryCounts.review_failure += 1
+    blockers.push({
+      category: 'review_failure',
+      ...normalizeScorecardSignal(blocker),
+    })
+  }
+
+  for (const blocker of input.transportBlockers ?? []) {
+    categoryCounts.github_transport_failure += 1
+    blockers.push({
+      category: 'github_transport_failure',
+      ...normalizeScorecardSignal(blocker),
+    })
+  }
+
+  for (const code of input.releaseEvidenceMissing) {
+    categoryCounts.release_process_failure += 1
+    blockers.push({
+      category: 'release_process_failure',
+      issueNumber: null,
+      prNumber: null,
+      reason: `missing required evidence: ${code}`,
+    })
+  }
+
+  return {
+    ready: BOOTSTRAP_FAILURE_KIND_ORDER.every((category) => categoryCounts[category] === 0),
+    categoryCounts,
+    topBlockers: BOOTSTRAP_FAILURE_KIND_ORDER.flatMap((category) => {
+      const blocker = blockers.find((candidate) => candidate.category === category)
+      return blocker ? [blocker] : []
+    }),
+    auditSummary: input.audit,
+  }
+}
+
+export async function buildBootstrapScorecardForRepo(
+  input: {
+    config: AgentConfig
+  },
+  deps: BootstrapScorecardDependencies = DEFAULT_BOOTSTRAP_SCORECARD_DEPENDENCIES,
+): Promise<BootstrapScorecard> {
+  const transportBlockers: BootstrapScorecardSignal[] = []
+  const issuesResult = await collectScorecardSource(
+    () => deps.listOpenAgentIssues(input.config),
+    transportBlockers,
+    'open issues',
+  )
+  const pullRequestsResult = await collectScorecardSource(
+    () => deps.listOpenAgentPullRequests(input.config),
+    transportBlockers,
+    'open pull requests',
+  )
+
+  const managedIssues = (issuesResult ?? [])
+    .filter((issue) => issue.labels.some((label) => label.startsWith('agent:')))
+  const pullRequests = pullRequestsResult ?? []
+  const issueBodiesByNumber = new Map(managedIssues.map((issue) => [issue.number, issue.body]))
+  const issueCommentsByNumber = new Map<number, IssueComment[] | null>()
+  const prCommentsByNumber = new Map<number, IssueComment[] | null>()
+  const linkedIssuesByNumber = new Map<number, AgentIssue | null>()
+  const commentLoader = createScorecardCommentLoader(
+    input.config,
+    deps,
+    transportBlockers,
+    issueCommentsByNumber,
+    prCommentsByNumber,
+  )
+  const linkedIssueLoader = createLinkedIssueLoader(
+    input.config,
+    deps,
+    transportBlockers,
+    linkedIssuesByNumber,
+  )
+  const [prBlockers, reviewBlockers] = await Promise.all([
+    collectPrLifecycleBlockers(
+      managedIssues,
+      pullRequests,
+      commentLoader,
+    ),
+    collectReviewBlockers(
+      pullRequests,
+      issueBodiesByNumber,
+      commentLoader,
+      linkedIssueLoader,
+    ),
+  ])
+
+  return buildBootstrapScorecard({
+    audit: issuesResult
+      ? buildAuditIssueSummary(managedIssues.map(buildAuditedIssue))
+      : buildEmptyAuditIssueSummary(),
+    runtimeBlockers: [],
+    prBlockers,
+    reviewBlockers,
+    transportBlockers,
+    releaseEvidenceMissing: [],
+  })
+}
+
+export function formatBootstrapScorecard(
+  scorecard: BootstrapScorecard,
+): string {
+  return [
+    'Bootstrap Scorecard',
+    `ready=${scorecard.ready}`,
+    `auditSummary=managed:${scorecard.auditSummary.managedIssueCount} ready:${scorecard.auditSummary.readyIssueCount} invalidReady:${scorecard.auditSummary.invalidReadyIssueCount} lowScore:${scorecard.auditSummary.lowScoreIssueCount} warnings:${scorecard.auditSummary.warningIssueCount}`,
+    'categoryCounts:',
+    ...BOOTSTRAP_FAILURE_KIND_ORDER.map((category) => `- ${category}: ${scorecard.categoryCounts[category]}`),
+    'topBlockers:',
+    ...(scorecard.topBlockers.length > 0
+      ? scorecard.topBlockers.map((blocker) => `- ${blocker.category}: ${formatScorecardBlockerTarget(blocker)}${blocker.reason}`)
+      : ['- none']),
+  ].join('\n')
+}
+
+export function formatBootstrapScorecardJson(
+  scorecard: BootstrapScorecard,
+): string {
+  return JSON.stringify(scorecard, null, 2)
+}
+
+export function resolveBootstrapScorecardExitCode(
+  scorecard: Pick<BootstrapScorecard, 'ready'>,
+): number {
+  return scorecard.ready ? 0 : 1
+}
+
+function createEmptyCategoryCounts(): Record<BootstrapFailureKind, number> {
+  return {
+    contract_failure: 0,
+    runtime_failure: 0,
+    pr_lifecycle_failure: 0,
+    review_failure: 0,
+    github_transport_failure: 0,
+    release_process_failure: 0,
+  }
+}
+
+function normalizeScorecardSignal(signal: BootstrapScorecardSignal): BootstrapScorecardSignal {
+  return {
+    issueNumber: signal.issueNumber ?? null,
+    prNumber: signal.prNumber ?? null,
+    reason: signal.reason,
+  }
+}
+
+function buildEmptyAuditIssueSummary(): AuditIssueSummary {
+  return {
+    managedIssueCount: 0,
+    readyIssueCount: 0,
+    invalidReadyIssueCount: 0,
+    lowScoreIssueCount: 0,
+    warningIssueCount: 0,
+  }
+}
+
+async function collectScorecardSource<T>(
+  load: () => Promise<T>,
+  transportBlockers: BootstrapScorecardSignal[],
+  target: string,
+): Promise<T | null> {
+  try {
+    return await load()
+  } catch (error) {
+    transportBlockers.push({
+      reason: `${target}: ${formatBootstrapScorecardError(error)}`,
+    })
+    return null
+  }
+}
+
+async function collectReviewBlockers(
+  pullRequests: ManagedPullRequest[],
+  issueBodiesByNumber: Map<number, string>,
+  commentLoader: ReturnType<typeof createScorecardCommentLoader>,
+  linkedIssueLoader: ReturnType<typeof createLinkedIssueLoader>,
+): Promise<BootstrapScorecardSignal[]> {
+  const blockers: BootstrapScorecardSignal[] = []
+
+  for (const pullRequest of pullRequests) {
+    const labelSet = new Set(pullRequest.labels)
+    if (!labelSet.has(PR_REVIEW_LABELS.HUMAN_NEEDED) && !labelSet.has(PR_REVIEW_LABELS.FAILED)) {
+      continue
+    }
+
+    const prComments = await commentLoader.loadPrComments(pullRequest.number)
+    if (!prComments) {
+      continue
+    }
+
+    const latestReviewBlocker = extractLatestAutomatedPrReviewBlockerSummary(prComments)
+    if (!latestReviewBlocker) {
+      continue
+    }
+
+    const issueNumber = parseIssueNumberFromManagedBranch(pullRequest.headRefName)
+    const linkedIssueBody = await resolveLinkedIssueBody(issueNumber, issueBodiesByNumber, linkedIssueLoader)
+
+    if (
+      labelSet.has(PR_REVIEW_LABELS.HUMAN_NEEDED)
+      && canResumeHumanNeededPrReview(
+        prComments,
+        DEFAULT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS,
+        pullRequest.headRefOid,
+        linkedIssueBody,
+      )
+    ) {
+      continue
+    }
+
+    if (issueNumber !== null) {
+      const issueComments = await commentLoader.loadIssueComments(issueNumber)
+      if (issueComments && evaluateBlockedIssueResumeResolution(issueComments, issueNumber, pullRequest.number).canResume) {
+        continue
+      }
+    }
+
+    blockers.push({
+      issueNumber,
+      prNumber: pullRequest.number,
+      reason: latestReviewBlocker.reason,
+    })
+  }
+
+  return blockers
+}
+
+function parseIssueNumberFromManagedBranch(headRefName: string): number | null {
+  const match = headRefName.match(/^agent\/(\d+)(?:\/|$)/)
+  if (!match) return null
+
+  const parsed = Number.parseInt(match[1] ?? '', 10)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
+async function collectPrLifecycleBlockers(
+  issues: AgentIssue[],
+  pullRequests: ManagedPullRequest[],
+  commentLoader: ReturnType<typeof createScorecardCommentLoader>,
+): Promise<BootstrapScorecardSignal[]> {
+  const blockers: BootstrapScorecardSignal[] = []
+  const pullRequestsByIssueNumber = new Map<number, ManagedPullRequest[]>()
+
+  for (const pullRequest of pullRequests) {
+    const issueNumber = parseIssueNumberFromManagedBranch(pullRequest.headRefName)
+    if (issueNumber === null) continue
+    pullRequestsByIssueNumber.set(issueNumber, [...(pullRequestsByIssueNumber.get(issueNumber) ?? []), pullRequest])
+  }
+
+  for (const issue of issues) {
+    if (issue.state !== 'failed') {
+      continue
+    }
+
+    const issueComments = await commentLoader.loadIssueComments(issue.number)
+    if (!issueComments) {
+      continue
+    }
+
+    const linkedPullRequests = pullRequestsByIssueNumber.get(issue.number) ?? []
+    const fallbackBlockedEscalation = findLatestUnresolvedPrLifecycleEscalation(
+      issueComments,
+      issue.number,
+      new Set(linkedPullRequests.map((pullRequest) => pullRequest.number)),
+    )
+
+    let hasResumableLinkedPr = false
+    let firstBlocked: BootstrapScorecardSignal | null = null
+
+    for (const pullRequest of linkedPullRequests) {
+      const prComments = await commentLoader.loadPrComments(pullRequest.number)
+      if (!prComments) {
+        continue
+      }
+
+      const canResumeHumanNeededReview = new Set(pullRequest.labels).has(PR_REVIEW_LABELS.HUMAN_NEEDED)
+        ? canResumeHumanNeededPrReview(
+          prComments,
+          DEFAULT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS,
+          pullRequest.headRefOid,
+          issue.body,
+        )
+        : false
+      const blocked = getFailedIssueResumeBlock(pullRequest, canResumeHumanNeededReview)
+
+      if (blocked === null) {
+        hasResumableLinkedPr = true
+        break
+      }
+
+      if (evaluateBlockedIssueResumeResolution(issueComments, issue.number, pullRequest.number).canResume) {
+        continue
+      }
+
+      if (firstBlocked === null) {
+        firstBlocked = {
+          issueNumber: issue.number,
+          prNumber: pullRequest.number,
+          reason: blocked.reason,
+        }
+      }
+    }
+
+    if (!hasResumableLinkedPr && firstBlocked) {
+      blockers.push(firstBlocked)
+      continue
+    }
+
+    if (!hasResumableLinkedPr && fallbackBlockedEscalation) {
+      blockers.push(fallbackBlockedEscalation)
+    }
+  }
+
+  return blockers
+}
+
+function findLatestUnresolvedPrLifecycleEscalation(
+  issueComments: IssueComment[],
+  issueNumber: number,
+  openLinkedPrNumbers: Set<number>,
+): BootstrapScorecardSignal | null {
+  let latestBlocked: { signal: BootstrapScorecardSignal; timestamp: number } | null = null
+
+  for (const comment of issueComments) {
+    const escalation = extractBlockedIssueResumeEscalationComment(comment.body)
+    if (!escalation || escalation.issueNumber !== issueNumber) {
+      continue
+    }
+
+    if (classifyBootstrapFailureKind(escalation.reason) !== 'pr_lifecycle_failure') {
+      continue
+    }
+
+    if (escalation.prNumber !== null) {
+      if (openLinkedPrNumbers.has(escalation.prNumber)) {
+        continue
+      }
+
+      if (evaluateBlockedIssueResumeResolution(issueComments, issueNumber, escalation.prNumber).canResume) {
+        continue
+      }
+    }
+
+    const timestamp = readScorecardCommentTimestamp(comment, escalation.escalatedAt)
+    if (latestBlocked && latestBlocked.timestamp >= timestamp) {
+      continue
+    }
+
+    latestBlocked = {
+      signal: {
+        issueNumber,
+        prNumber: escalation.prNumber,
+        reason: escalation.reason,
+      },
+      timestamp,
+    }
+  }
+
+  return latestBlocked?.signal ?? null
+}
+
+function readScorecardCommentTimestamp(
+  comment: Pick<IssueComment, 'updatedAt' | 'createdAt'>,
+  fallbackIso: string | null = null,
+): number {
+  const candidates = [comment.updatedAt, comment.createdAt, fallbackIso]
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') {
+      continue
+    }
+
+    const parsed = Date.parse(candidate)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return 0
+}
+
+function createScorecardCommentLoader(
+  config: AgentConfig,
+  deps: BootstrapScorecardDependencies,
+  transportBlockers: BootstrapScorecardSignal[],
+  issueCommentsByNumber: Map<number, IssueComment[] | null>,
+  prCommentsByNumber: Map<number, IssueComment[] | null>,
+) {
+  return {
+    loadIssueComments: async (issueNumber: number): Promise<IssueComment[] | null> => {
+      if (issueCommentsByNumber.has(issueNumber)) {
+        return issueCommentsByNumber.get(issueNumber) ?? null
+      }
+
+      const comments = await collectScorecardSource(
+        () => deps.listIssueComments(issueNumber, config),
+        transportBlockers,
+        `issue#${issueNumber} comments`,
+      )
+      issueCommentsByNumber.set(issueNumber, comments)
+      return comments
+    },
+    loadPrComments: async (prNumber: number): Promise<IssueComment[] | null> => {
+      if (prCommentsByNumber.has(prNumber)) {
+        return prCommentsByNumber.get(prNumber) ?? null
+      }
+
+      const comments = await collectScorecardSource(
+        () => deps.listIssueComments(prNumber, config),
+        transportBlockers,
+        `pr#${prNumber} comments`,
+      )
+      prCommentsByNumber.set(prNumber, comments)
+      return comments
+    },
+  }
+}
+
+function createLinkedIssueLoader(
+  config: AgentConfig,
+  deps: BootstrapScorecardDependencies,
+  transportBlockers: BootstrapScorecardSignal[],
+  linkedIssuesByNumber: Map<number, AgentIssue | null>,
+) {
+  return {
+    loadLinkedIssue: async (issueNumber: number): Promise<AgentIssue | null> => {
+      if (linkedIssuesByNumber.has(issueNumber)) {
+        return linkedIssuesByNumber.get(issueNumber) ?? null
+      }
+
+      const linkedIssue = await collectScorecardSource(
+        () => deps.getAgentIssueByNumber(issueNumber, config),
+        transportBlockers,
+        `issue#${issueNumber} lookup`,
+      )
+      linkedIssuesByNumber.set(issueNumber, linkedIssue)
+      return linkedIssue
+    },
+  }
+}
+
+async function resolveLinkedIssueBody(
+  issueNumber: number | null,
+  issueBodiesByNumber: Map<number, string>,
+  linkedIssueLoader: ReturnType<typeof createLinkedIssueLoader>,
+): Promise<string | null> {
+  if (issueNumber === null) {
+    return null
+  }
+
+  if (issueBodiesByNumber.has(issueNumber)) {
+    return issueBodiesByNumber.get(issueNumber) ?? null
+  }
+
+  const linkedIssue = await linkedIssueLoader.loadLinkedIssue(issueNumber)
+  return linkedIssue?.body ?? null
+}
+
+function formatScorecardBlockerTarget(blocker: BootstrapScorecardBlocker): string {
+  if (blocker.issueNumber !== null && blocker.issueNumber !== undefined) {
+    return `issue#${blocker.issueNumber} `
+  }
+  if (blocker.prNumber !== null && blocker.prNumber !== undefined) {
+    return `pr#${blocker.prNumber} `
+  }
+  return ''
+}
+
+function formatBootstrapScorecardError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/apps/agent-daemon/src/bootstrap-scorecard.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.ts
@@ -46,10 +46,17 @@ export interface BootstrapScorecardBlocker extends BootstrapScorecardSignal {
   category: BootstrapFailureKind
 }
 
+export interface SuppressedBootstrapScorecardBlocker extends BootstrapScorecardBlocker {
+  suppressionKind: 'local_implementation'
+  localImplementationHeadline?: string | null
+}
+
 export interface BootstrapScorecard {
   ready: boolean
   categoryCounts: Record<BootstrapFailureKind, number>
   topBlockers: BootstrapScorecardBlocker[]
+  suppressedCategoryCounts: Record<BootstrapFailureKind, number>
+  suppressedBlockers: SuppressedBootstrapScorecardBlocker[]
   auditSummary: AuditIssueSummary
 }
 
@@ -60,6 +67,7 @@ interface BootstrapScorecardInput {
   runtimeBlockers?: BootstrapScorecardSignal[]
   transportBlockers?: BootstrapScorecardSignal[]
   releaseEvidenceMissing: string[]
+  suppressedBlockers?: SuppressedBootstrapScorecardBlocker[]
 }
 
 interface BootstrapScorecardDependencies {
@@ -146,6 +154,10 @@ export function buildBootstrapScorecard(
 ): BootstrapScorecard {
   const categoryCounts = createEmptyCategoryCounts()
   const blockers: BootstrapScorecardBlocker[] = []
+  const suppressedCategoryCounts = createEmptyCategoryCounts()
+  const suppressedBlockers = (input.suppressedBlockers ?? []).map((blocker) => ({
+    ...blocker,
+  }))
 
   if (input.audit.invalidReadyIssueCount > 0) {
     categoryCounts.contract_failure += input.audit.invalidReadyIssueCount
@@ -199,6 +211,10 @@ export function buildBootstrapScorecard(
     })
   }
 
+  for (const blocker of suppressedBlockers) {
+    suppressedCategoryCounts[blocker.category] += 1
+  }
+
   return {
     ready: BOOTSTRAP_FAILURE_KIND_ORDER.every((category) => categoryCounts[category] === 0),
     categoryCounts,
@@ -206,6 +222,8 @@ export function buildBootstrapScorecard(
       const blocker = blockers.find((candidate) => candidate.category === category)
       return blocker ? [blocker] : []
     }),
+    suppressedCategoryCounts,
+    suppressedBlockers,
     auditSummary: input.audit,
   }
 }
@@ -263,16 +281,30 @@ export async function buildBootstrapScorecardForRepo(
       linkedIssueLoader,
     ),
   ])
+  const prLifecycleSignals = partitionLocallyImplementedSignals(
+    prBlockers,
+    'pr_lifecycle_failure',
+    localImplementationIndex,
+  )
+  const reviewSignals = partitionLocallyImplementedSignals(
+    reviewBlockers,
+    'review_failure',
+    localImplementationIndex,
+  )
 
   return buildBootstrapScorecard({
     audit: issuesResult
       ? buildAuditIssueSummary(managedIssues.map(buildAuditedIssue))
       : buildEmptyAuditIssueSummary(),
     runtimeBlockers: [],
-    prBlockers: filterLocallyImplementedSignals(prBlockers, localImplementationIndex),
-    reviewBlockers: filterLocallyImplementedSignals(reviewBlockers, localImplementationIndex),
+    prBlockers: prLifecycleSignals.active,
+    reviewBlockers: reviewSignals.active,
     transportBlockers,
     releaseEvidenceMissing: [],
+    suppressedBlockers: [
+      ...prLifecycleSignals.suppressed,
+      ...reviewSignals.suppressed,
+    ],
   })
 }
 
@@ -288,6 +320,12 @@ export function formatBootstrapScorecard(
     'topBlockers:',
     ...(scorecard.topBlockers.length > 0
       ? scorecard.topBlockers.map((blocker) => `- ${blocker.category}: ${formatScorecardBlockerTarget(blocker)}${blocker.reason}`)
+      : ['- none']),
+    'suppressedCategoryCounts:',
+    ...BOOTSTRAP_FAILURE_KIND_ORDER.map((category) => `- ${category}: ${scorecard.suppressedCategoryCounts[category]}`),
+    'suppressedBlockers:',
+    ...(scorecard.suppressedBlockers.length > 0
+      ? scorecard.suppressedBlockers.map((blocker) => `- ${blocker.suppressionKind}: ${blocker.category}: ${formatScorecardBlockerTarget(blocker)}${blocker.reason}${blocker.localImplementationHeadline ? ` localCommit=${blocker.localImplementationHeadline}` : ''}`)
       : ['- none']),
   ].join('\n')
 }
@@ -323,15 +361,40 @@ function normalizeScorecardSignal(signal: BootstrapScorecardSignal): BootstrapSc
   }
 }
 
-function filterLocallyImplementedSignals(
+function partitionLocallyImplementedSignals(
   signals: BootstrapScorecardSignal[],
+  category: BootstrapFailureKind,
   localImplementationIndex: Map<number, LocalImplementationRecord>,
-): BootstrapScorecardSignal[] {
-  return signals.filter((signal) => (
-    signal.issueNumber === null
-    || signal.issueNumber === undefined
-    || !localImplementationIndex.has(signal.issueNumber)
-  ))
+): {
+  active: BootstrapScorecardSignal[]
+  suppressed: SuppressedBootstrapScorecardBlocker[]
+} {
+  const active: BootstrapScorecardSignal[] = []
+  const suppressed: SuppressedBootstrapScorecardBlocker[] = []
+
+  for (const signal of signals) {
+    const normalized = normalizeScorecardSignal(signal)
+    const localImplementation = typeof normalized.issueNumber === 'number'
+      ? localImplementationIndex.get(normalized.issueNumber)
+      : undefined
+
+    if (!localImplementation) {
+      active.push(normalized)
+      continue
+    }
+
+    suppressed.push({
+      category,
+      ...normalized,
+      suppressionKind: 'local_implementation',
+      localImplementationHeadline: localImplementation.latestCommitHeadline,
+    })
+  }
+
+  return {
+    active,
+    suppressed,
+  }
 }
 
 function buildEmptyAuditIssueSummary(): AuditIssueSummary {

--- a/apps/agent-daemon/src/bootstrap-scorecard.ts
+++ b/apps/agent-daemon/src/bootstrap-scorecard.ts
@@ -15,6 +15,10 @@ import {
   type AuditIssueSummary,
 } from './audit-issue-contracts'
 import {
+  buildLocalImplementationIndex,
+  type LocalImplementationRecord,
+} from './local-implementation'
+import {
   canResumeHumanNeededPrReview,
   extractLatestAutomatedPrReviewBlockerSummary,
 } from './pr-reviewer'
@@ -63,6 +67,7 @@ interface BootstrapScorecardDependencies {
   listOpenAgentPullRequests: typeof listOpenAgentPullRequests
   listIssueComments: typeof listIssueComments
   getAgentIssueByNumber: typeof getAgentIssueByNumber
+  buildLocalImplementationIndex: typeof buildLocalImplementationIndex
 }
 
 const DEFAULT_BOOTSTRAP_SCORECARD_DEPENDENCIES: BootstrapScorecardDependencies = {
@@ -70,6 +75,7 @@ const DEFAULT_BOOTSTRAP_SCORECARD_DEPENDENCIES: BootstrapScorecardDependencies =
   listOpenAgentPullRequests,
   listIssueComments,
   getAgentIssueByNumber,
+  buildLocalImplementationIndex,
 }
 
 const BOOTSTRAP_FAILURE_KIND_ORDER: BootstrapFailureKind[] = [
@@ -207,9 +213,11 @@ export function buildBootstrapScorecard(
 export async function buildBootstrapScorecardForRepo(
   input: {
     config: AgentConfig
+    repoRoot?: string
   },
   deps: BootstrapScorecardDependencies = DEFAULT_BOOTSTRAP_SCORECARD_DEPENDENCIES,
 ): Promise<BootstrapScorecard> {
+  const localImplementationIndex = deps.buildLocalImplementationIndex(input.repoRoot)
   const transportBlockers: BootstrapScorecardSignal[] = []
   const issuesResult = await collectScorecardSource(
     () => deps.listOpenAgentIssues(input.config),
@@ -261,8 +269,8 @@ export async function buildBootstrapScorecardForRepo(
       ? buildAuditIssueSummary(managedIssues.map(buildAuditedIssue))
       : buildEmptyAuditIssueSummary(),
     runtimeBlockers: [],
-    prBlockers,
-    reviewBlockers,
+    prBlockers: filterLocallyImplementedSignals(prBlockers, localImplementationIndex),
+    reviewBlockers: filterLocallyImplementedSignals(reviewBlockers, localImplementationIndex),
     transportBlockers,
     releaseEvidenceMissing: [],
   })
@@ -313,6 +321,17 @@ function normalizeScorecardSignal(signal: BootstrapScorecardSignal): BootstrapSc
     prNumber: signal.prNumber ?? null,
     reason: signal.reason,
   }
+}
+
+function filterLocallyImplementedSignals(
+  signals: BootstrapScorecardSignal[],
+  localImplementationIndex: Map<number, LocalImplementationRecord>,
+): BootstrapScorecardSignal[] {
+  return signals.filter((signal) => (
+    signal.issueNumber === null
+    || signal.issueNumber === undefined
+    || !localImplementationIndex.has(signal.issueNumber)
+  ))
 }
 
 function buildEmptyAuditIssueSummary(): AuditIssueSummary {
@@ -397,7 +416,7 @@ async function collectReviewBlockers(
 }
 
 function parseIssueNumberFromManagedBranch(headRefName: string): number | null {
-  const match = headRefName.match(/^agent\/(\d+)(?:\/|$)/)
+  const match = headRefName.match(/^agent\/(\d+)(?:-rebuild(?:-\d+)?)?(?:\/|$)/)
   if (!match) return null
 
   const parsed = Number.parseInt(match[1] ?? '', 10)

--- a/apps/agent-daemon/src/cli-agent.test.ts
+++ b/apps/agent-daemon/src/cli-agent.test.ts
@@ -46,6 +46,7 @@ const baseConfig: AgentConfig = {
     fallback: 'claude',
     claudePath: 'claude',
     codexPath: 'codex',
+    codexReasoningEffort: 'high',
     timeoutMs: 60_000,
   },
   git: {
@@ -70,8 +71,8 @@ describe('cli-agent', () => {
     ])
   })
 
-  test('builds Codex command with non-interactive exec flags', () => {
-    expect(buildAgentCommand('codex', 'codex', '/tmp/last-message.txt', true)).toEqual([
+  test('builds Codex command with configured reasoning effort', () => {
+    expect(buildAgentCommand('codex', 'codex', '/tmp/last-message.txt', true, 'high')).toEqual([
       'codex',
       'exec',
       '--color',
@@ -79,14 +80,14 @@ describe('cli-agent', () => {
       '--output-last-message',
       '/tmp/last-message.txt',
       '-c',
-      'model_reasoning_effort="medium"',
+      'model_reasoning_effort="high"',
       '--dangerously-bypass-approvals-and-sandbox',
       '-',
     ])
   })
 
-  test('builds read-only Codex command for review-style runs', () => {
-    expect(buildAgentCommand('codex', 'codex', '/tmp/review-message.txt', false)).toEqual([
+  test('builds read-only Codex command with configured reasoning effort', () => {
+    expect(buildAgentCommand('codex', 'codex', '/tmp/review-message.txt', false, 'high')).toEqual([
       'codex',
       'exec',
       '--color',
@@ -94,11 +95,17 @@ describe('cli-agent', () => {
       '--output-last-message',
       '/tmp/review-message.txt',
       '-c',
-      'model_reasoning_effort="medium"',
+      'model_reasoning_effort="high"',
       '--sandbox',
       'read-only',
       '-',
     ])
+  })
+
+  test('writes the same reasoning effort into isolated Codex config', () => {
+    expect(buildIsolatedCodexConfig('http://127.0.0.1:18777/v1', 'high')).toContain(
+      'model_reasoning_effort = "high"',
+    )
   })
 
   test('prefers environment auth for isolated Codex runtime', () => {
@@ -138,7 +145,7 @@ describe('cli-agent', () => {
       expect(existsSync(join(homeDir, '.zshenv'))).toBe(true)
       expect(existsSync(join(homeDir, '.bash_profile'))).toBe(true)
       expect(readFileSync(join(codexHomeDir, 'config.toml'), 'utf-8')).toBe(
-        buildIsolatedCodexConfig('http://127.0.0.1:18777/v1'),
+        buildIsolatedCodexConfig('http://127.0.0.1:18777/v1', 'high'),
       )
       expect(readFileSync(join(codexHomeDir, 'auth.json'), 'utf-8')).toBe(
         '{\n  "OPENAI_API_KEY": "sk-local-proxy"\n}\n',
@@ -223,24 +230,25 @@ printf 'fake codex ok\n' > "$response_file"
           prompt: 'noop',
           worktreePath,
           timeoutMs: 5_000,
-          config: {
-            ...baseConfig,
-            agent: {
-              ...baseConfig.agent,
-              primary: 'codex',
-              fallback: null,
-              codexPath: scriptPath,
-              codexBaseUrl: 'http://127.0.0.1:18777/v1',
-            },
+        config: {
+          ...baseConfig,
+          agent: {
+            ...baseConfig.agent,
+            primary: 'codex',
+            fallback: null,
+            codexPath: scriptPath,
+            codexBaseUrl: 'http://127.0.0.1:18777/v1',
+            codexReasoningEffort: 'high',
           },
-        })
+        },
+      })
 
         expect(result.ok).toBe(true)
         expect(result.exitCode).toBe(0)
         expect(result.responseText).toBe('fake codex ok')
 
         expect(readFileSync(configCapturePath, 'utf-8')).toBe(
-          buildIsolatedCodexConfig('http://127.0.0.1:18777/v1'),
+          buildIsolatedCodexConfig('http://127.0.0.1:18777/v1', 'high'),
         )
         const argv = readFileSync(argvCapturePath, 'utf-8').trim().split('\n')
         expect(argv[0]).toBe('exec')
@@ -249,7 +257,7 @@ printf 'fake codex ok\n' > "$response_file"
         expect(argv[3]).toBe('--output-last-message')
         expect(argv[4]).toEndWith('/last-message.txt')
         expect(argv[5]).toBe('-c')
-        expect(argv[6]).toBe('model_reasoning_effort="medium"')
+        expect(argv[6]).toBe('model_reasoning_effort="high"')
         expect(argv[7]).toBe('--dangerously-bypass-approvals-and-sandbox')
         expect(argv[8]).toBe('-')
         expect(readFileSync(envCapturePath, 'utf-8')).toContain('OPENAI_BASE_URL=__UNSET__')

--- a/apps/agent-daemon/src/cli-agent.ts
+++ b/apps/agent-daemon/src/cli-agent.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { homedir, tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import type { AgentConfig, AgentExitCode, CodexReasoningEffort } from '@agent/shared'
+import { DETACH_PROCESS_GROUP, killProcessTree } from './process-tree'
 
 export type AgentKind = AgentConfig['agent']['primary']
 
@@ -224,6 +225,7 @@ async function runSingleAgent(
     const env = buildRuntimeEnv(agent, options.config, tempDir)
     proc = Bun.spawn(command, {
       cwd: options.worktreePath,
+      detached: DETACH_PROCESS_GROUP,
       env,
       stdin: 'pipe',
       stdout: 'pipe',
@@ -260,20 +262,12 @@ async function runSingleAgent(
           () => lastActivityAt,
           () => {
             idleTimedOut = true
-            try {
-              proc?.kill('SIGKILL')
-            } catch {
-              // ignore kill errors
-            }
+            killProcessTree(proc)
           },
           (message) => {
             aborted = true
             abortMessage = message
-            try {
-              proc?.kill('SIGKILL')
-            } catch {
-              // ignore kill errors
-            }
+            killProcessTree(proc)
           },
         ).finally(() => {
           monitorInFlight = false
@@ -306,11 +300,7 @@ async function runSingleAgent(
       new Promise<never>((_, reject) => {
         processTimeoutId = setTimeout(() => {
           timedOut = true
-          try {
-            proc?.kill('SIGKILL')
-          } catch {
-            // ignore kill errors
-          }
+          killProcessTree(proc)
           reject(new Error(`Timeout after ${options.timeoutMs}ms`))
         }, options.timeoutMs)
       }),

--- a/apps/agent-daemon/src/cli-agent.ts
+++ b/apps/agent-daemon/src/cli-agent.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
-import type { AgentConfig, AgentExitCode } from '@agent/shared'
+import type { AgentConfig, AgentExitCode, CodexReasoningEffort } from '@agent/shared'
 
 export type AgentKind = AgentConfig['agent']['primary']
 
@@ -73,6 +73,7 @@ export function buildAgentCommand(
   binaryPath: string,
   responseFilePath: string,
   allowWrites: boolean,
+  codexReasoningEffort: CodexReasoningEffort = 'high',
 ): string[] {
   if (agent === 'claude') {
     return [binaryPath, '--print', '--permission-mode', 'bypassPermissions']
@@ -86,13 +87,16 @@ export function buildAgentCommand(
     '--output-last-message',
     responseFilePath,
     '-c',
-    'model_reasoning_effort="medium"',
+    `model_reasoning_effort="${codexReasoningEffort}"`,
     ...(allowWrites ? ['--dangerously-bypass-approvals-and-sandbox'] : ['--sandbox', 'read-only']),
     '-',
   ]
 }
 
-export function buildIsolatedCodexConfig(baseUrl?: string | null): string {
+export function buildIsolatedCodexConfig(
+  baseUrl?: string | null,
+  codexReasoningEffort: CodexReasoningEffort = 'high',
+): string {
   const providerLines = [
     '[model_providers.custom]',
     'name = "custom"',
@@ -103,7 +107,7 @@ export function buildIsolatedCodexConfig(baseUrl?: string | null): string {
 
   return `model_provider = "custom"
 model = "gpt-5.4"
-model_reasoning_effort = "medium"
+model_reasoning_effort = "${codexReasoningEffort}"
 network_access = "enabled"
 disable_response_storage = true
 
@@ -127,6 +131,7 @@ export function createIsolatedCodexHome(
   tempDir: string,
   env: Record<string, string>,
   fallbackAuthJson: string | null = readLocalCodexAuthJson(),
+  codexReasoningEffort: CodexReasoningEffort = 'high',
 ): { homeDir: string; codexHomeDir: string } {
   const homeDir = join(tempDir, 'home')
   const codexHomeDir = join(homeDir, '.codex')
@@ -134,7 +139,7 @@ export function createIsolatedCodexHome(
   mkdirSync(codexHomeDir, { recursive: true })
   writeFileSync(
     join(codexHomeDir, 'config.toml'),
-    buildIsolatedCodexConfig(env.OPENAI_BASE_URL ?? null),
+    buildIsolatedCodexConfig(env.OPENAI_BASE_URL ?? null, codexReasoningEffort),
     'utf-8',
   )
 
@@ -200,6 +205,7 @@ async function runSingleAgent(
     binaryPath,
     responseFilePath,
     options.allowWrites ?? true,
+    options.config.agent.codexReasoningEffort ?? 'high',
   )
 
   let proc: ReturnType<typeof Bun.spawn> | null = null
@@ -625,7 +631,12 @@ function buildRuntimeEnv(
     return cleanEnv
   }
 
-  const { homeDir, codexHomeDir } = createIsolatedCodexHome(tempDir, cleanEnv)
+  const { homeDir, codexHomeDir } = createIsolatedCodexHome(
+    tempDir,
+    cleanEnv,
+    readLocalCodexAuthJson(),
+    config.agent.codexReasoningEffort ?? 'high',
+  )
 
   delete cleanEnv.OPENAI_BASE_URL
   delete cleanEnv.OPENAI_API_BASE

--- a/apps/agent-daemon/src/config.test.ts
+++ b/apps/agent-daemon/src/config.test.ts
@@ -90,6 +90,7 @@ describe('buildConfig', () => {
     expect(config.agent.fallback).toBe('claude')
     expect(config.agent.claudePath).toBe('claude-home')
     expect(config.agent.codexPath).toBe('codex-home')
+    expect(config.agent.codexReasoningEffort).toBe('high')
     expect(config.git.defaultBranch).toBe('main')
     expect(config.requestedConcurrency).toBe(1)
     expect(config.concurrency).toBe(1)
@@ -128,6 +129,7 @@ describe('buildConfig', () => {
     ])
     expect(config.project.maxConcurrency).toBeUndefined()
     expect(config.agent.primary).toBe('claude')
+    expect(config.agent.codexReasoningEffort).toBe('high')
     expect(config.git.defaultBranch).toBe('master')
     expect(config.requestedConcurrency).toBe(1)
     expect(config.concurrency).toBe(1)
@@ -186,6 +188,46 @@ describe('buildConfig', () => {
 
     expect(config.agent.primary).toBe('codex')
     expect(config.agent.fallback).toBeNull()
+  })
+
+  test('defaults Codex reasoning effort to high and lets repo-local config override home config', () => {
+    const defaultConfig = buildConfig(
+      {},
+      {
+        fileConfig: baseFileConfig,
+        repoConfig: {},
+        env: {},
+        homeDir: '/tmp/agent-loop-home',
+      },
+    )
+
+    expect(defaultConfig.agent.codexReasoningEffort).toBe('high')
+
+    const configured = buildConfig(
+      {},
+      {
+        fileConfig: {
+          ...baseFileConfig,
+          agent: {
+            ...baseFileConfig.agent!,
+            primary: 'codex',
+            fallback: 'claude',
+            codexReasoningEffort: 'low',
+          },
+        },
+        repoConfig: {
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            codexReasoningEffort: 'high',
+          },
+        },
+        env: {},
+        homeDir: '/tmp/agent-loop-home',
+      },
+    )
+
+    expect(configured.agent.codexReasoningEffort).toBe('high')
   })
 
   test('lets CLI override the idle backstop poll interval but never below the active poll interval', () => {

--- a/apps/agent-daemon/src/config.ts
+++ b/apps/agent-daemon/src/config.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path'
 import { execFileSync } from 'node:child_process'
 import type {
   AgentConfig,
+  CodexReasoningEffort,
   ProjectProfileName,
   ProjectPromptContext,
   ProjectPromptGuidanceOverrides,
@@ -27,6 +28,7 @@ export interface RepoLocalConfig {
   agent?: {
     primary?: AgentConfig['agent']['primary']
     fallback?: AgentConfig['agent']['fallback']
+    codexReasoningEffort?: AgentConfig['agent']['codexReasoningEffort']
   }
   git?: {
     defaultBranch?: string
@@ -218,6 +220,10 @@ export function buildConfig(
         env.OPENAI_API_URL ??
         env.OPENAI_BASE ??
         fileConfig.agent?.codexBaseUrl,
+      codexReasoningEffort: resolveCodexReasoningEffort(
+        repoConfig.agent?.codexReasoningEffort
+          ?? fileConfig.agent?.codexReasoningEffort,
+      ),
       timeoutMs: fileConfig.agent?.timeoutMs ?? 30 * 60 * 1000, // 30 min default
     },
     git: {
@@ -333,6 +339,14 @@ function resolveGitHubToken(input: {
   }
 
   return ''
+}
+
+function resolveCodexReasoningEffort(value: unknown): CodexReasoningEffort {
+  if (value === 'low' || value === 'medium' || value === 'high') {
+    return value
+  }
+
+  return 'high'
 }
 
 function canUseGhCliSession(homeDir = homedir()): boolean {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -1633,6 +1633,28 @@ describe('daemon merge recovery helpers', () => {
     )).toBe(true)
   })
 
+  test('pauses working-issue resume while a lineage-block cooldown is active', () => {
+    const now = Date.now()
+
+    expect(shouldResumeManagedIssue(
+      { state: 'working' },
+      true,
+      1,
+      now + 60_000,
+      now,
+      2,
+    )).toBe(false)
+
+    expect(shouldResumeManagedIssue(
+      { state: 'working' },
+      true,
+      1,
+      now - 1,
+      now,
+      2,
+    )).toBe(true)
+  })
+
   test('resumes stale issues with a preserved local worktree after daemon restart', () => {
     expect(shouldResumeManagedIssue(
       { state: 'stale' },
@@ -1780,6 +1802,7 @@ describe('daemon merge recovery helpers', () => {
     expect(shouldClearFailedIssueResumeTrackingAfterFinalize('failed')).toBe(true)
     expect(shouldClearFailedIssueResumeTrackingAfterFinalize('completed')).toBe(false)
     expect(shouldClearFailedIssueResumeTrackingAfterFinalize('recoverable')).toBe(false)
+    expect(shouldClearFailedIssueResumeTrackingAfterFinalize('blocked')).toBe(false)
   })
 
   test('resets linked PR labels back to retry when issue recovery resumes', () => {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -44,6 +44,7 @@ import {
   shouldCompleteIssueRecoveryOnRemoteClose,
   shouldRequeueFailedIssue,
   shouldResumeManagedIssue,
+  runRemoteUpgradeAnnouncementSafely,
 } from './daemon'
 import { ISSUE_LABELS, PR_REVIEW_LABELS } from '@agent/shared'
 import {
@@ -552,6 +553,44 @@ describe('wake queue integration', () => {
 })
 
 describe('agent-loop upgrade coordination', () => {
+  test('downgrades startup remote upgrade announcement failures into warnings', async () => {
+    const warnings: string[] = []
+
+    await runRemoteUpgradeAnnouncementSafely(
+      async () => {
+        throw new Error('The socket connection was closed unexpectedly.')
+      },
+      {
+        warn(message: string) {
+          warnings.push(message)
+        },
+      },
+    )
+
+    expect(warnings).toEqual([
+      expect.stringContaining('failed to process remote upgrade announcement'),
+    ])
+  })
+
+  test('keeps successful remote upgrade announcement checks silent', async () => {
+    let called = false
+    const warnings: string[] = []
+
+    await runRemoteUpgradeAnnouncementSafely(
+      async () => {
+        called = true
+      },
+      {
+        warn(message: string) {
+          warnings.push(message)
+        },
+      },
+    )
+
+    expect(called).toBe(true)
+    expect(warnings).toEqual([])
+  })
+
   test('refreshes upgrade status and wakes the scheduler when a newer remote upgrade announcement appears', async () => {
     const daemon = createTestDaemon({
       upgrade: {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -184,6 +184,72 @@ function createHistoricalLeaseComment(issueNumber: number, branch: string, workt
   }
 }
 
+describe('issue ops observability', () => {
+  test('updates issue contract quality gauges from managed issue bodies', async () => {
+    registry.resetMetrics()
+
+    const daemon = createTestDaemon()
+
+    ;(daemon as any).updateIssueOpsMetricsFromIssues([
+      {
+        number: 50,
+        title: '[AL-11] audit',
+        body: '## 用户故事\n只有用户故事',
+        state: 'ready',
+      },
+      {
+        number: 53,
+        title: '[AL-13] repair',
+        body: [
+          '## 用户故事',
+          '作为维护者，我希望 repair flow 能保留具体边界。',
+          '',
+          '## Context',
+          '### Dependencies',
+          '```json',
+          '{"dependsOn":[50]}',
+          '```',
+          '### Constraints',
+          '- 只修 contract',
+          '### AllowedFiles',
+          '- frontend files',
+          '- backend code',
+          '### ForbiddenFiles',
+          '- apps/agent-daemon/src/dashboard.ts',
+          '### MustPreserve',
+          '- narrow scope',
+          '### OutOfScope',
+          '- 远端写回',
+          '### RequiredSemantics',
+          '- repair 输出 canonical markdown',
+          '### ReviewHints',
+          '- 检查 broad allowed files',
+          '### Validation',
+          '- `bun test apps/agent-daemon/src/issue-repair.test.ts`',
+          '- manual smoke test',
+          '',
+          '## RED 测试',
+          '```ts',
+          'expect(true).toBe(false)',
+          '```',
+          '',
+          '## 实现步骤',
+          '1. 先补 repair',
+          '',
+          '## 验收',
+          '- [ ] warnings 可见',
+        ].join('\n'),
+        state: 'ready',
+      },
+    ])
+
+    const metrics = await getMetrics()
+    expect(metrics).toContain('agent_loop_issue_contract_invalid_ready 1')
+    expect(metrics).toContain('agent_loop_issue_contract_warning_issues 1')
+    expect(metrics).toContain('agent_loop_issue_contract_low_score_issues 2')
+  })
+})
+
 describe('issue preflight comments', () => {
   test('extracts the latest automated preflight blocker from issue comments', () => {
     const older = buildIssuePreflightFailureComment(

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -32,6 +32,8 @@ import {
   shouldDeferResumableIssueForActiveLinkedPrTask,
   shouldDeferResumableIssueForActiveLinkedPrLease,
   shouldClearFailedIssueResumeTrackingAfterFinalize,
+  classifyApprovedPrMergeChecksGate,
+  classifyLinkedIssueApprovedMergeOutcome,
   shouldEscalateBlockedIssueResume,
   shouldRefreshBlockedHumanNeededPr,
   shouldResumeFailedIssueWithLinkedPr,
@@ -2236,6 +2238,94 @@ describe('daemon merge recovery helpers', () => {
     expect(isMergeabilityFailure('Pull Request is not mergeable')).toBe(true)
     expect(isMergeabilityFailure('Merge conflict between base and head')).toBe(true)
     expect(isMergeabilityFailure('Required status check "test" is failing')).toBe(false)
+  })
+
+  describe('approved PR merge checks gate', () => {
+    test('defers pending checks without forcing the linked issue into failed', () => {
+      expect(classifyApprovedPrMergeChecksGate({
+        state: 'pending',
+        summary: 'build-and-test is pending',
+      })).toEqual({
+        outcome: 'defer',
+        recoverable: true,
+        reason: 'PR checks not ready for merge: build-and-test is pending',
+      })
+    })
+
+    test('routes failing checks to human-needed', () => {
+      expect(classifyApprovedPrMergeChecksGate({
+        state: 'fail',
+        summary: 'build-and-test is fail',
+      })).toEqual({
+        outcome: 'human-needed',
+        recoverable: false,
+        reason: 'PR checks failed: build-and-test is fail',
+      })
+    })
+
+    test('skips merge calls when checks fail and keeps the linked issue recoverable', async () => {
+      const daemon = createTestDaemon()
+      const comments: string[] = []
+      const reviewStates: string[] = []
+      let mergeCalls = 0
+
+      ;(daemon as any).getPullRequestChecksStatus = async () => ({
+        state: 'fail',
+        summary: 'build-and-test is fail',
+      })
+      ;(daemon as any).commentOnManagedPr = async (_prNumber: number, body: string) => {
+        comments.push(body)
+      }
+      ;(daemon as any).setManagedPrReviewState = async (_prNumber: number, state: string) => {
+        reviewStates.push(state)
+      }
+      ;(daemon as any).mergeManagedPullRequest = async () => {
+        mergeCalls += 1
+        return { merged: true, message: 'unexpected merge' }
+      }
+
+      const mergeResult = await (daemon as any).attemptApprovedPrMergeWithRecovery(
+        110,
+        'https://github.com/JamesWuHK/agent-loop/pull/110',
+        'agent/61/codex-dev',
+        '/tmp/worktrees/issue-61-codex-dev',
+      )
+
+      expect(mergeCalls).toBe(0)
+      expect(reviewStates).toEqual(['human-needed'])
+      expect(comments).toHaveLength(1)
+      expect(comments[0]).toContain('PR checks failed: build-and-test is fail')
+      expect(mergeResult).toMatchObject({
+        merged: false,
+        message: 'PR checks failed: build-and-test is fail',
+        checksBlocked: true,
+      })
+      expect(classifyLinkedIssueApprovedMergeOutcome(mergeResult)).toEqual({
+        status: 'recoverable',
+        reason: 'PR checks failed: build-and-test is fail',
+      })
+    })
+
+    test('treats check lookup errors as recoverable deferrals', () => {
+      expect(classifyApprovedPrMergeChecksGate({
+        state: 'error',
+        summary: 'gh pr checks exited with code 4',
+      })).toEqual({
+        outcome: 'defer',
+        recoverable: true,
+        reason: 'Merge gate could not confirm PR checks: gh pr checks exited with code 4',
+      })
+    })
+
+    test('keeps true merge failures on the failed linked-issue path', () => {
+      expect(classifyLinkedIssueApprovedMergeOutcome({
+        merged: false,
+        message: 'Pull Request is not mergeable',
+      })).toEqual({
+        status: 'failed',
+        reason: 'Pull Request is not mergeable',
+      })
+    })
   })
 
   test('builds a merge retry comment with recovery details', () => {

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -250,6 +250,35 @@ describe('issue ops observability', () => {
   })
 })
 
+describe('terminal PR safeguards', () => {
+  test('skips standalone PR automation when the branch record is already closed or merged', async () => {
+    const daemon = createTestDaemon()
+    const pr = {
+      number: 386,
+      title: '[AL-24] stale closed PR',
+      url: 'https://github.com/JamesWuHK/agent-loop/pull/386',
+      headRefName: 'agent/83/codex-dev',
+      headRefOid: 'abc123',
+      isDraft: false,
+      labels: [PR_REVIEW_LABELS.RETRY],
+    }
+
+    for (const prState of ['closed', 'merged'] as const) {
+      ;(daemon as any).resolveBranchPullRequestRecord = async () => ({
+        number: 386,
+        prUrl: pr.url,
+        prState,
+        headRefName: pr.headRefName,
+        baseRefName: 'main',
+        body: null,
+      })
+
+      await expect((daemon as any).getAutomationEligibleStandalonePr(pr, 'review')).resolves.toBeNull()
+      await expect((daemon as any).getAutomationEligibleStandalonePr(pr, 'merge')).resolves.toBeNull()
+    }
+  })
+})
+
 describe('issue preflight comments', () => {
   test('extracts the latest automated preflight blocker from issue comments', () => {
     const older = buildIssuePreflightFailureComment(

--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -13,6 +13,7 @@ import {
   buildIssuePreflightFailureComment,
   buildPrReviewRefreshFailureComment,
   canResumeBlockedIssueFromResolution,
+  classifyStandalonePrReviewFollowup,
   canRetryPrReviewRefresh,
   canResumeIssueFromLease,
   getEffectiveActiveTaskCount,
@@ -2052,6 +2053,78 @@ describe('daemon merge recovery helpers', () => {
       true,
       true,
     )).toBe(false)
+  })
+
+  test('stops at human-needed when a blocked refresh rerun is still rejected', () => {
+    expect(classifyStandalonePrReviewFollowup(
+      {
+        approved: false,
+        canMerge: false,
+        reason: 'First blocker',
+        findings: [{
+          severity: 'high',
+          file: 'apps/agent-daemon/src/daemon.ts',
+          summary: 'still blocked after base refresh',
+          mustFix: ['stop after the rerun review and leave the PR in human-needed'],
+          mustNotDo: ['do not launch review auto-fix for the blocked refresh rerun'],
+          validation: ['bun test apps/agent-daemon/src/daemon.test.ts'],
+          scopeRationale: 'blocked refresh reruns should release the ready queue instead of consuming another auto-fix attempt',
+        }],
+      },
+      {
+        issueNumber: 40,
+        rerunAfterBlockedRefresh: true,
+      },
+    )).toEqual({
+      nextReviewLabel: 'human-needed',
+      shouldRunAutoFix: false,
+      shouldMarkIssueFailed: true,
+    })
+  })
+
+  test('still allows one auto-fix retry for a normal standalone rejection', () => {
+    expect(classifyStandalonePrReviewFollowup(
+      {
+        approved: false,
+        canMerge: false,
+        reason: 'First blocker',
+        findings: [{
+          severity: 'high',
+          file: 'apps/agent-daemon/src/daemon.ts',
+          summary: 'ordinary standalone rejection',
+          mustFix: ['keep the existing auto-fix retry path'],
+          mustNotDo: ['do not treat every rejection as terminal human-needed'],
+          validation: ['bun test apps/agent-daemon/src/daemon.test.ts'],
+          scopeRationale: 'only blocked refresh reruns should skip auto-fix',
+        }],
+      },
+      {
+        issueNumber: 40,
+        rerunAfterBlockedRefresh: false,
+      },
+    )).toEqual({
+      nextReviewLabel: 'retry',
+      shouldRunAutoFix: true,
+      shouldMarkIssueFailed: false,
+    })
+  })
+
+  test('keeps approved blocked refresh reruns on the approved path', () => {
+    expect(classifyStandalonePrReviewFollowup(
+      {
+        approved: true,
+        canMerge: true,
+        reason: 'Ready to merge',
+      },
+      {
+        issueNumber: 40,
+        rerunAfterBlockedRefresh: true,
+      },
+    )).toEqual({
+      nextReviewLabel: 'approved',
+      shouldRunAutoFix: false,
+      shouldMarkIssueFailed: false,
+    })
   })
 
   test('suppresses repeated PR refresh retries when head and base are unchanged since the last failure', () => {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -9,6 +9,7 @@ import type {
   AgentLoopBuildMetadata,
   AgentLoopUpgradeMetadata,
   AgentIssue,
+  BranchPullRequestRecord,
   BlockedIssueResumeRuntimeDetail,
   ClaimEvent,
   DaemonStatus,
@@ -21,7 +22,7 @@ import type {
   StalledWorkerRuntimeDetail,
   WorktreeInfo,
 } from '@agent/shared'
-import { ISSUE_LABELS, PR_REVIEW_LABELS, canDaemonAdoptManagedLease, getActiveManagedLease, getLatestManagedLease, listOpenAgentIssues, listOpenAgentPullRequests, transitionIssueState, commentOnIssue, commentOnPr, setManagedPrReviewLabels, mergePullRequest, checkPrExists, listIssueComments, resolveActiveClaimMachine, getAgentIssueByNumber, getManagedPullRequestByNumber, setGitHubApiRequestObserver } from '@agent/shared'
+import { ISSUE_LABELS, PR_REVIEW_LABELS, canDaemonAdoptManagedLease, getActiveManagedLease, getLatestManagedLease, listOpenAgentIssues, listOpenAgentPullRequests, transitionIssueState, commentOnIssue, commentOnPr, setManagedPrReviewLabels, mergePullRequest, checkPrExists, listIssueComments, resolveActiveClaimMachine, getAgentIssueByNumber, getManagedPullRequestByNumber, listBranchPullRequests, parseIssueContract, setGitHubApiRequestObserver } from '@agent/shared'
 import { claimSpecificIssue, pollAndClaim } from './claimer'
 import { createWorktree, removeWorktree, cleanupOrphanedWorktrees, hasWorktreeForIssue } from './worktree-manager'
 import { runIssueBranchPreflight, runSubtaskExecutor, runReviewAutoFix, runIssueRecovery } from './subtask-executor'
@@ -109,6 +110,13 @@ import {
   resolveAgentLoopBuildMetadata,
   resolveAgentLoopUpgradePolicy,
 } from './version'
+import { parsePrLineageMetadata } from './pr-lineage'
+import {
+  PrLineagePreflightError,
+  collectPrLineagePreflightActualState,
+  evaluatePrLineagePreflight,
+  isCommitAncestorInWorktree,
+} from './pr-lineage-preflight'
 
 export interface HealthServerConfig {
   host: string
@@ -619,6 +627,83 @@ export class AgentDaemon {
       buildIssueWorkingTransitionEvent('recoverable', this.config.machineId, reason),
       this.config,
     )
+  }
+
+  private async runPrLineagePreflightOrThrow(input: {
+    stage: string
+    worktreePath: string
+    branch: string
+    issueNumber: number | null
+    issueBody?: string | null
+    prNumber?: number | null
+    detachedHead?: boolean
+  }): Promise<void> {
+    const branchPullRequest = input.prNumber === undefined || input.prNumber === null
+      ? null
+      : await this.resolveBranchPullRequestRecord(input.branch, input.prNumber)
+    const expectedBaseBranch = branchPullRequest?.baseRefName ?? this.config.git.defaultBranch
+    const actual = await collectPrLineagePreflightActualState({
+      worktreePath: input.worktreePath,
+      expectedBaseBranch,
+      actualHeadBranch: input.detachedHead ? input.branch : undefined,
+      actualBaseBranch: branchPullRequest?.baseRefName ?? null,
+    })
+    const contract = parseIssueContract(input.issueBody ?? '')
+
+    let expected = {
+      issueNumber: input.issueNumber ?? 0,
+      headBranch: input.branch,
+      baseBranch: expectedBaseBranch,
+      baseSha: actual.baseSha,
+      allowedChangedFiles: contract.allowedFiles,
+    }
+
+    if (branchPullRequest?.body) {
+      try {
+        const metadata = parsePrLineageMetadata(branchPullRequest.body)
+        expected = {
+          issueNumber: metadata.issue,
+          headBranch: metadata.headBranch,
+          baseBranch: metadata.baseBranch,
+          baseSha: metadata.baseSha,
+          allowedChangedFiles: contract.allowedFiles,
+        }
+
+        if (metadata.baseSha !== actual.baseSha) {
+          const forwardCompatibleBaseSha = await isCommitAncestorInWorktree(
+            input.worktreePath,
+            metadata.baseSha,
+            actual.baseSha,
+          )
+          if (forwardCompatibleBaseSha) {
+            expected = {
+              ...expected,
+              baseSha: actual.baseSha,
+            }
+          }
+        }
+      } catch (error) {
+        this.logger.warn(
+          `[daemon] ignoring invalid PR lineage metadata for ${input.branch}: ${formatDaemonError(error)}`,
+        )
+      }
+    }
+
+    const result = evaluatePrLineagePreflight({
+      expected,
+      actual,
+    })
+    if (!result.ok) {
+      throw new PrLineagePreflightError(input.stage, result)
+    }
+  }
+
+  private async resolveBranchPullRequestRecord(
+    branch: string,
+    prNumber: number,
+  ): Promise<BranchPullRequestRecord | null> {
+    const pullRequests = await listBranchPullRequests(branch, this.config)
+    return pullRequests.find(pullRequest => pullRequest.number === prNumber) ?? null
   }
 
   private enqueueWakeRequests(requests: WakeRequest[]): void {
@@ -2090,19 +2175,6 @@ export class AgentDaemon {
     const reviewLabels = new Set(pr.labels)
     const issueNumber = extractIssueNumberFromPrTitle(pr.title)
     const linkedIssue = issueNumber === null ? null : await getAgentIssueByNumber(issueNumber, this.config)
-    if (
-      issueNumber !== null
-      && linkedIssue
-      && linkedIssue.state !== 'working'
-      && linkedIssue.state !== 'done'
-    ) {
-      await this.transitionStandaloneIssue(
-        issueNumber,
-        ISSUE_LABELS.WORKING,
-        `Standalone PR review running for PR #${pr.number}`,
-        pr.number,
-      )
-    }
     const resumableHumanNeededReview = reviewLabels.has(PR_REVIEW_LABELS.HUMAN_NEEDED)
       && canResumeHumanNeededPrReview(
         priorComments,
@@ -2126,6 +2198,40 @@ export class AgentDaemon {
     let leaseReason: string | undefined
     let leaseRecoveryKind: string | undefined
     try {
+      try {
+        await this.runPrLineagePreflightOrThrow({
+          stage: 'PR review',
+          worktreePath: detached.worktreePath,
+          branch: pr.headRefName,
+          issueNumber,
+          issueBody: linkedIssue?.body ?? null,
+          prNumber: pr.number,
+          detachedHead: true,
+        })
+      } catch (error) {
+        if (error instanceof PrLineagePreflightError) {
+          this.logger.warn(`[pr-review-subagent] blocked PR #${pr.number} by lineage preflight: ${error.message}`)
+          leaseReason = error.message
+          leaseRecoveryKind = 'pr-review-lineage-blocked'
+          return
+        }
+        throw error
+      }
+
+      if (
+        issueNumber !== null
+        && linkedIssue
+        && linkedIssue.state !== 'working'
+        && linkedIssue.state !== 'done'
+      ) {
+        await this.transitionStandaloneIssue(
+          issueNumber,
+          ISSUE_LABELS.WORKING,
+          `Standalone PR review running for PR #${pr.number}`,
+          pr.number,
+        )
+      }
+
       const monitor = this.buildManagedLeaseMonitor('pr-review', pr.number, lease.handle)
       let currentHeadRefOid = await readGitHeadRefOid(detached.worktreePath)
       const worktreeBaseSyncState = await readWorktreeBaseSyncState(
@@ -2436,6 +2542,8 @@ export class AgentDaemon {
 
   private async processStandaloneApprovedPrMerge(pr: ManagedPullRequest): Promise<void> {
     this.logger.log(`[pr-merge-subagent] attempting merge for approved PR #${pr.number}: "${pr.title}"`)
+    const issueNumber = extractIssueNumberFromPrTitle(pr.title)
+    const linkedIssue = issueNumber === null ? null : await getAgentIssueByNumber(issueNumber, this.config)
     const lease = await this.acquireLeaseForScope({
       targetNumber: pr.number,
       scope: 'pr-merge',
@@ -2443,7 +2551,7 @@ export class AgentDaemon {
       worktreeId: `pr-merge-${pr.number}`,
       phase: 'pr-merge',
       prNumber: pr.number,
-      issueNumber: extractIssueNumberFromPrTitle(pr.title) ?? undefined,
+      issueNumber: issueNumber ?? undefined,
     })
     if (!lease) return
 
@@ -2452,6 +2560,26 @@ export class AgentDaemon {
     let leaseReason: string | undefined
     let leaseRecoveryKind: string | undefined
     try {
+      try {
+        await this.runPrLineagePreflightOrThrow({
+          stage: 'PR merge',
+          worktreePath: detached.worktreePath,
+          branch: pr.headRefName,
+          issueNumber,
+          issueBody: linkedIssue?.body ?? null,
+          prNumber: pr.number,
+          detachedHead: true,
+        })
+      } catch (error) {
+        if (error instanceof PrLineagePreflightError) {
+          this.logger.warn(`[pr-merge-subagent] blocked PR #${pr.number} by lineage preflight: ${error.message}`)
+          leaseReason = error.message
+          leaseRecoveryKind = 'pr-merge-lineage-blocked'
+          return
+        }
+        throw error
+      }
+
       const mergeResult = await this.attemptApprovedPrMergeWithRecovery(
         pr.number,
         pr.url,
@@ -2487,7 +2615,6 @@ export class AgentDaemon {
         return
       }
 
-      const issueNumber = extractIssueNumberFromPrTitle(pr.title)
       if (issueNumber !== null) {
         await this.transitionStandaloneIssue(
           issueNumber,
@@ -2607,32 +2734,6 @@ export class AgentDaemon {
       worktreePath = ensured.worktreePath
       worktreeId = ensured.worktreeId
 
-      if (issue.state === 'failed') {
-        await transitionIssueState(
-          issueNumber,
-          ISSUE_LABELS.WORKING,
-          ISSUE_LABELS.FAILED,
-          buildIssueWorkingTransitionEvent(
-            'resume',
-            this.config.machineId,
-            candidate.requiresRemoteAdoption ? 'resume-expired-lease' : 'resume-existing-worktree',
-          ),
-          this.config,
-        )
-      } else {
-        await transitionIssueState(
-          issueNumber,
-          ISSUE_LABELS.WORKING,
-          ISSUE_LABELS.WORKING,
-          buildIssueWorkingTransitionEvent(
-            'resume',
-            this.config.machineId,
-            candidate.requiresRemoteAdoption ? 'resume-expired-lease' : 'resume-existing-worktree',
-          ),
-          this.config,
-        )
-      }
-
       const wt: WorktreeInfo = {
         path: worktreePath,
         issueNumber,
@@ -2666,6 +2767,61 @@ export class AgentDaemon {
       const linkedOpenPr = hasReusableOpenPr(prCheck)
         ? (await listOpenAgentPullRequests(this.config)).find((pr) => pr.number === prCheck.prNumber) ?? null
         : null
+      try {
+        await this.runPrLineagePreflightOrThrow({
+          stage: 'issue recovery',
+          worktreePath,
+          branch,
+          issueNumber,
+          issueBody: issue.body,
+          prNumber: linkedOpenPr?.number ?? null,
+        })
+      } catch (error) {
+        if (error instanceof PrLineagePreflightError) {
+          this.logger.warn(`[daemon] issue #${issueNumber} blocked by PR lineage preflight: ${error.message}`)
+          this.registerFailedIssueResume(issueNumber)
+          await this.completeManagedLease(
+            'issue-process',
+            issueNumber,
+            leaseHandle,
+            'completed',
+            error.message,
+            'issue-process-pr-lineage-blocked',
+          )
+          this.activeWorktrees.delete(issueNumber)
+          this.syncRuntimeMetrics()
+          recordIssueProcessingDuration(Date.now() - processingStartTime)
+          return
+        }
+        throw error
+      }
+
+      if (issue.state === 'failed') {
+        await transitionIssueState(
+          issueNumber,
+          ISSUE_LABELS.WORKING,
+          ISSUE_LABELS.FAILED,
+          buildIssueWorkingTransitionEvent(
+            'resume',
+            this.config.machineId,
+            candidate.requiresRemoteAdoption ? 'resume-expired-lease' : 'resume-existing-worktree',
+          ),
+          this.config,
+        )
+      } else {
+        await transitionIssueState(
+          issueNumber,
+          ISSUE_LABELS.WORKING,
+          ISSUE_LABELS.WORKING,
+          buildIssueWorkingTransitionEvent(
+            'resume',
+            this.config.machineId,
+            candidate.requiresRemoteAdoption ? 'resume-expired-lease' : 'resume-existing-worktree',
+          ),
+          this.config,
+        )
+      }
+
       if (prCheck.prNumber !== null && prCheck.prState !== 'open') {
         this.logger.warn(
           `[daemon] skipping terminal linked PR #${prCheck.prNumber} (${prCheck.prState}) during issue #${issueNumber} recovery`,
@@ -2766,6 +2922,18 @@ export class AgentDaemon {
         this.failedIssueResumeAttempts.delete(issueNumber)
         this.failedIssueResumeCooldownUntil.delete(issueNumber)
         await this.completeManagedLease('issue-process', issueNumber, leaseHandle, 'completed')
+        this.syncRuntimeMetrics()
+      } else if (finalized.status === 'blocked') {
+        this.registerFailedIssueResume(issueNumber)
+        await this.completeManagedLease(
+          'issue-process',
+          issueNumber,
+          leaseHandle,
+          'completed',
+          finalized.reason,
+          'issue-process-pr-lineage-blocked',
+        )
+        this.activeWorktrees.delete(issueNumber)
         this.syncRuntimeMetrics()
       } else if (finalized.status === 'recoverable') {
         await this.markIssueRecoverable(issueNumber, finalized.reason ?? 'recoverable resume handoff')
@@ -3101,7 +3269,7 @@ export class AgentDaemon {
     issue: AgentIssue,
     worktreePath: string,
     branch: string,
-  ): Promise<{ status: 'completed' | 'failed' | 'recoverable'; reason?: string }> {
+  ): Promise<{ status: 'completed' | 'failed' | 'recoverable' | 'blocked'; reason?: string }> {
     let activeBranch = branch
 
     const preflight = await runIssueBranchPreflight(worktreePath, issue.body, this.config, this.logger)
@@ -3135,7 +3303,28 @@ export class AgentDaemon {
       }
     }
 
-    const pr = await createOrFindPr(worktreePath, activeBranch, issue.number, issue.title, this.config, this.logger)
+    let pr: Awaited<ReturnType<typeof createOrFindPr>>
+    try {
+      pr = await createOrFindPr(
+        worktreePath,
+        activeBranch,
+        issue.number,
+        issue.title,
+        this.config,
+        this.logger,
+        {},
+        issue.body,
+      )
+    } catch (error) {
+      if (error instanceof PrLineagePreflightError) {
+        this.logger.warn(`[daemon] issue #${issue.number} blocked by PR lineage preflight: ${error.message}`)
+        return {
+          status: 'blocked',
+          reason: error.message,
+        }
+      }
+      throw error
+    }
     if (pr.branch !== activeBranch) {
       activeBranch = pr.branch
       const activeWorktree = this.activeWorktrees.get(issue.number)
@@ -3172,6 +3361,26 @@ export class AgentDaemon {
         status: 'failed',
         reason,
       }
+    }
+
+    try {
+      await this.runPrLineagePreflightOrThrow({
+        stage: 'PR review',
+        worktreePath,
+        branch: activeBranch,
+        issueNumber: issue.number,
+        issueBody: issue.body,
+        prNumber: pr.prNumber,
+      })
+    } catch (error) {
+      if (error instanceof PrLineagePreflightError) {
+        this.logger.warn(`[daemon] issue #${issue.number} blocked before PR review: ${error.message}`)
+        return {
+          status: 'blocked',
+          reason: error.message,
+        }
+      }
+      throw error
     }
 
     const reviewLease = await this.acquireLeaseForScope({
@@ -3218,6 +3427,26 @@ export class AgentDaemon {
     await this.completeManagedLease('pr-review', pr.prNumber, reviewLease.handle, 'completed')
 
     if (reviewOutcome.approved) {
+      try {
+        await this.runPrLineagePreflightOrThrow({
+          stage: 'PR merge',
+          worktreePath,
+          branch: activeBranch,
+          issueNumber: issue.number,
+          issueBody: issue.body,
+          prNumber: pr.prNumber,
+        })
+      } catch (error) {
+        if (error instanceof PrLineagePreflightError) {
+          this.logger.warn(`[daemon] issue #${issue.number} blocked before PR merge: ${error.message}`)
+          return {
+            status: 'blocked',
+            reason: error.message,
+          }
+        }
+        throw error
+      }
+
       const mergeLease = await this.acquireLeaseForScope({
         targetNumber: pr.prNumber,
         scope: 'pr-merge',
@@ -3418,7 +3647,19 @@ export class AgentDaemon {
 
       if (result.success) {
         const finalized = await this.finalizeIssueFromBranch(issue, worktreePath, branch)
-        if (finalized.status === 'recoverable') {
+        if (finalized.status === 'blocked') {
+          this.registerFailedIssueResume(issueNumber)
+          await this.completeManagedLease(
+            'issue-process',
+            issueNumber,
+            leaseHandle,
+            'completed',
+            finalized.reason,
+            'issue-process-pr-lineage-blocked',
+          )
+          this.activeWorktrees.delete(issueNumber)
+          this.syncRuntimeMetrics()
+        } else if (finalized.status === 'recoverable') {
           await this.markIssueRecoverable(issueNumber, finalized.reason ?? 'recoverable issue handoff')
           await this.completeManagedLease(
             'issue-process',
@@ -4456,7 +4697,7 @@ export function getFailedIssueResumeBlock(
 }
 
 export function shouldClearFailedIssueResumeTrackingAfterFinalize(
-  status: 'completed' | 'failed' | 'recoverable',
+  status: 'completed' | 'failed' | 'recoverable' | 'blocked',
 ): boolean {
   return status === 'failed'
 }
@@ -4883,6 +5124,9 @@ export function shouldResumeManagedIssue(
   if (!hasLocalWorktree) return false
 
   if (issue.state === 'working' || issue.state === 'stale') {
+    if (attempts > 0 && cooldownUntil > now) {
+      return false
+    }
     return true
   }
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -3232,7 +3232,7 @@ export class AgentDaemon {
         return
       }
 
-      const finalized = await this.finalizeIssueFromBranch(issue, worktreePath, branch)
+      const finalized = await this.finalizeIssueFromBranch(issue, worktreePath, branch, monitor)
       if (finalized.status === 'completed') {
         this.failedIssueResumeAttempts.delete(issueNumber)
         this.failedIssueResumeCooldownUntil.delete(issueNumber)
@@ -3650,10 +3650,11 @@ export class AgentDaemon {
     issue: AgentIssue,
     worktreePath: string,
     branch: string,
+    monitor?: TaskExecutionMonitor,
   ): Promise<{ status: 'completed' | 'failed' | 'recoverable' | 'blocked'; reason?: string }> {
     let activeBranch = branch
 
-    const preflight = await runIssueBranchPreflight(worktreePath, issue.body, this.config, this.logger)
+    const preflight = await runIssueBranchPreflight(worktreePath, issue.body, this.config, this.logger, monitor)
     if (!preflight.valid) {
       const reason = `Issue preflight failed before PR creation: ${preflight.violations.join('; ')}`
       await commentOnIssue(
@@ -4071,7 +4072,7 @@ export class AgentDaemon {
       )
 
       if (result.success) {
-        const finalized = await this.finalizeIssueFromBranch(issue, worktreePath, branch)
+        const finalized = await this.finalizeIssueFromBranch(issue, worktreePath, branch, monitor)
         if (finalized.status === 'blocked') {
           this.registerFailedIssueResume(issueNumber)
           await this.completeManagedLease(

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -1072,9 +1072,10 @@ export class AgentDaemon {
         return
       }
 
-      void this.maybeProcessRemoteUpgradeAnnouncement().catch((error) => {
-        this.logger.warn(`[daemon] failed to process remote upgrade announcement: ${formatDaemonError(error)}`)
-      })
+      void runRemoteUpgradeAnnouncementSafely(
+        () => this.maybeProcessRemoteUpgradeAnnouncement(),
+        this.logger,
+      )
     }, intervalMs)
   }
 
@@ -1170,7 +1171,10 @@ export class AgentDaemon {
     })
 
     void this.maybeRefreshAgentLoopUpgradeStatus(true)
-    void this.maybeProcessRemoteUpgradeAnnouncement()
+    void runRemoteUpgradeAnnouncementSafely(
+      () => this.maybeProcessRemoteUpgradeAnnouncement(),
+      this.logger,
+    )
 
     // Run first recovery + poll immediately; subsequent polls are self-scheduled
     await this.runPollCycleSafely()
@@ -4918,6 +4922,17 @@ export class AgentDaemon {
         `[daemon] failed to publish blocked resume escalation for issue #${issueNumber}: ${formatDaemonError(error)}`,
       )
     }
+  }
+}
+
+export async function runRemoteUpgradeAnnouncementSafely(
+  run: () => Promise<void>,
+  logger: Pick<Console, 'warn'>,
+): Promise<void> {
+  try {
+    await run()
+  } catch (error) {
+    logger.warn(`[daemon] failed to process remote upgrade announcement: ${formatDaemonError(error)}`)
   }
 }
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -2483,6 +2483,7 @@ export class AgentDaemon {
 
       const monitor = this.buildManagedLeaseMonitor('pr-review', pr.number, lease.handle)
       let currentHeadRefOid = await readGitHeadRefOid(detached.worktreePath)
+      let rerunAfterBlockedRefresh = false
       const worktreeBaseSyncState = await readWorktreeBaseSyncState(
         detached.worktreePath,
         this.config.git.defaultBranch,
@@ -2548,6 +2549,7 @@ export class AgentDaemon {
         }
 
         currentHeadRefOid = await readGitHeadRefOid(detached.worktreePath)
+        rerunAfterBlockedRefresh = true
       }
       const restartReviewOnUpdatedHead = reviewLabels.has(PR_REVIEW_LABELS.HUMAN_NEEDED)
         && shouldRestartAutomatedPrReviewOnNewHead(priorComments, currentHeadRefOid)
@@ -2632,7 +2634,12 @@ export class AgentDaemon {
           return
         }
 
-        if (firstReview.approved && firstReview.canMerge) {
+        const followup = classifyStandalonePrReviewFollowup(firstReview, {
+          issueNumber,
+          rerunAfterBlockedRefresh,
+        })
+
+        if (followup.nextReviewLabel === 'approved') {
           await commentOnPr(
             pr.number,
             buildPrReviewComment(pr.number, firstReview, nextAttempt, 'approved', currentHeadRefOid, linkedIssue?.body ?? null),
@@ -2643,17 +2650,23 @@ export class AgentDaemon {
           return
         }
 
-        if (firstReview.reviewFailed) {
+        if (followup.nextReviewLabel === 'human-needed') {
           await commentOnPr(
             pr.number,
             buildPrReviewComment(pr.number, firstReview, nextAttempt, 'human-needed', currentHeadRefOid, linkedIssue?.body ?? null),
             this.config,
           )
           await setManagedPrReviewLabels(pr.number, 'human-needed', this.config)
-          if (issueNumber !== null) {
+          if (followup.shouldMarkIssueFailed && issueNumber !== null) {
             await this.transitionStandaloneIssue(issueNumber, ISSUE_LABELS.FAILED, firstReview.reason)
           }
-          this.logger.warn(`[pr-review-subagent] PR #${pr.number} produced an invalid review payload; stopping before auto-fix`)
+          this.logger.warn(
+            firstReview.reviewFailed
+              ? `[pr-review-subagent] PR #${pr.number} produced an invalid review payload; stopping before auto-fix`
+              : rerunAfterBlockedRefresh
+                ? `[pr-review-subagent] PR #${pr.number} is still blocked after base refresh; stopping before auto-fix`
+                : `[pr-review-subagent] PR #${pr.number} rejected without auto-fix`,
+          )
           return
         }
 
@@ -2665,6 +2678,10 @@ export class AgentDaemon {
           )
           await setManagedPrReviewLabels(pr.number, 'human-needed', this.config)
           this.logger.warn(`[pr-review-subagent] PR #${pr.number} rejected without auto-fix: could not infer issue number`)
+          return
+        }
+
+        if (!followup.shouldRunAutoFix) {
           return
         }
 
@@ -4933,6 +4950,42 @@ export async function runRemoteUpgradeAnnouncementSafely(
     await run()
   } catch (error) {
     logger.warn(`[daemon] failed to process remote upgrade announcement: ${formatDaemonError(error)}`)
+  }
+}
+
+export interface StandalonePrReviewFollowup {
+  nextReviewLabel: 'approved' | 'retry' | 'human-needed'
+  shouldRunAutoFix: boolean
+  shouldMarkIssueFailed: boolean
+}
+
+export function classifyStandalonePrReviewFollowup(
+  review: Pick<PrReviewResult, 'approved' | 'canMerge' | 'reviewFailed' | 'reason' | 'findings'>,
+  context: {
+    issueNumber: number | null
+    rerunAfterBlockedRefresh: boolean
+  },
+): StandalonePrReviewFollowup {
+  if (review.approved && review.canMerge) {
+    return {
+      nextReviewLabel: 'approved',
+      shouldRunAutoFix: false,
+      shouldMarkIssueFailed: false,
+    }
+  }
+
+  if (review.reviewFailed || (context.rerunAfterBlockedRefresh && !review.approved && !review.canMerge)) {
+    return {
+      nextReviewLabel: 'human-needed',
+      shouldRunAutoFix: false,
+      shouldMarkIssueFailed: context.issueNumber !== null,
+    }
+  }
+
+  return {
+    nextReviewLabel: 'retry',
+    shouldRunAutoFix: true,
+    shouldMarkIssueFailed: false,
   }
 }
 

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -747,6 +747,23 @@ export class AgentDaemon {
     return pullRequests.find(pullRequest => pullRequest.number === prNumber) ?? null
   }
 
+  private async getAutomationEligibleStandalonePr(
+    pr: ManagedPullRequest | null,
+    stage: 'review' | 'merge',
+  ): Promise<ManagedPullRequest | null> {
+    if (!pr) return null
+
+    const branchPullRequest = await this.resolveBranchPullRequestRecord(pr.headRefName, pr.number)
+    if (branchPullRequest && branchPullRequest.prState !== 'open') {
+      this.logger.warn(
+        `[daemon] skipping terminal linked PR #${pr.number} (${branchPullRequest.prState}) during standalone PR ${stage}`,
+      )
+      return null
+    }
+
+    return pr
+  }
+
   private async observePrLineageForIssue(
     input: PrLineageObservationInput,
   ): Promise<void> {
@@ -2225,7 +2242,10 @@ export class AgentDaemon {
   private async findPendingStandaloneApprovedPrMergeByNumber(
     prNumber: number,
   ): Promise<ManagedPullRequest | null> {
-    const pr = await getManagedPullRequestByNumber(prNumber, this.config)
+    const pr = await this.getAutomationEligibleStandalonePr(
+      await getManagedPullRequestByNumber(prNumber, this.config),
+      'merge',
+    )
     if (!pr) return null
     if (pr.isDraft) return null
     if (this.activePrReviews.has(pr.number)) return null
@@ -2318,7 +2338,10 @@ export class AgentDaemon {
   private async findPendingStandalonePrReviewByNumber(
     prNumber: number,
   ): Promise<ManagedPullRequest | null> {
-    const pr = await getManagedPullRequestByNumber(prNumber, this.config)
+    const pr = await this.getAutomationEligibleStandalonePr(
+      await getManagedPullRequestByNumber(prNumber, this.config),
+      'review',
+    )
     if (!pr) return null
     if (pr.isDraft) return null
     if (this.activePrReviews.has(pr.number)) return null
@@ -2375,6 +2398,9 @@ export class AgentDaemon {
   }
 
   private async processStandalonePrReview(pr: ManagedPullRequest): Promise<void> {
+    if (!(await this.getAutomationEligibleStandalonePr(pr, 'review'))) {
+      return
+    }
     this.logger.log(`[pr-review-subagent] reviewing existing PR #${pr.number}: "${pr.title}"`)
     const priorComments = await listIssueComments(pr.number, this.config)
     const nextAttempt = getNextAutomatedPrReviewAttempt(priorComments)
@@ -2760,6 +2786,9 @@ export class AgentDaemon {
   }
 
   private async processStandaloneApprovedPrMerge(pr: ManagedPullRequest): Promise<void> {
+    if (!(await this.getAutomationEligibleStandalonePr(pr, 'merge'))) {
+      return
+    }
     this.logger.log(`[pr-merge-subagent] attempting merge for approved PR #${pr.number}: "${pr.title}"`)
     const issueNumber = extractIssueNumberFromPrTitle(pr.title)
     const linkedIssue = issueNumber === null ? null : await getAgentIssueByNumber(issueNumber, this.config)

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -3102,6 +3102,8 @@ export class AgentDaemon {
     worktreePath: string,
     branch: string,
   ): Promise<{ status: 'completed' | 'failed' | 'recoverable'; reason?: string }> {
+    let activeBranch = branch
+
     const preflight = await runIssueBranchPreflight(worktreePath, issue.body, this.config, this.logger)
     if (!preflight.valid) {
       const reason = `Issue preflight failed before PR creation: ${preflight.violations.join('; ')}`
@@ -3133,7 +3135,19 @@ export class AgentDaemon {
       }
     }
 
-    const pr = await createOrFindPr(worktreePath, branch, issue.number, issue.title, this.config, this.logger)
+    const pr = await createOrFindPr(worktreePath, activeBranch, issue.number, issue.title, this.config, this.logger)
+    if (pr.branch !== activeBranch) {
+      activeBranch = pr.branch
+      const activeWorktree = this.activeWorktrees.get(issue.number)
+      if (activeWorktree) {
+        this.activeWorktrees.set(issue.number, {
+          ...activeWorktree,
+          branch: activeBranch,
+        })
+        this.syncRuntimeMetrics()
+      }
+    }
+
     if (pr.kind === 'terminal') {
       const reason = `Linked PR #${pr.prNumber} is ${pr.prState}; replacement PR required before automation can continue`
       await transitionIssueState(
@@ -3163,7 +3177,7 @@ export class AgentDaemon {
     const reviewLease = await this.acquireLeaseForScope({
       targetNumber: pr.prNumber,
       scope: 'pr-review',
-      branch,
+      branch: activeBranch,
       worktreeId: this.buildLeaseKey('issue-process', issue.number),
       phase: 'reviewing-pr',
       issueNumber: issue.number,
@@ -3179,7 +3193,7 @@ export class AgentDaemon {
     const reviewOutcome = await this.reviewAndPossiblyAutoFix(
       issue,
       worktreePath,
-      branch,
+      activeBranch,
       pr.prNumber,
       pr.prUrl,
       this.buildManagedLeaseMonitor('pr-review', pr.prNumber, reviewLease.handle),
@@ -3207,7 +3221,7 @@ export class AgentDaemon {
       const mergeLease = await this.acquireLeaseForScope({
         targetNumber: pr.prNumber,
         scope: 'pr-merge',
-        branch,
+        branch: activeBranch,
         worktreeId: this.buildLeaseKey('issue-process', issue.number),
         phase: 'merging-pr',
         issueNumber: issue.number,
@@ -3223,7 +3237,7 @@ export class AgentDaemon {
       const mergeResult = await this.attemptApprovedPrMergeWithRecovery(
         pr.prNumber,
         pr.prUrl,
-        branch,
+        activeBranch,
         worktreePath,
         this.buildManagedLeaseMonitor('pr-merge', pr.prNumber, mergeLease.handle),
       )
@@ -3293,7 +3307,7 @@ export class AgentDaemon {
       recordIssueProcessed('done')
       recordPrCreated()
 
-      await removeWorktree(worktreePath, branch)
+      await removeWorktree(worktreePath, activeBranch)
       this.activeWorktrees.delete(issue.number)
       this.syncRuntimeMetrics()
       return { status: 'completed' }

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -25,7 +25,7 @@ import { ISSUE_LABELS, PR_REVIEW_LABELS, canDaemonAdoptManagedLease, getActiveMa
 import { claimSpecificIssue, pollAndClaim } from './claimer'
 import { createWorktree, removeWorktree, cleanupOrphanedWorktrees, hasWorktreeForIssue } from './worktree-manager'
 import { runIssueBranchPreflight, runSubtaskExecutor, runReviewAutoFix, runIssueRecovery } from './subtask-executor'
-import { createOrFindPr, pushBranch } from './pr-reporter'
+import { createOrFindPr, hasReusableOpenPr, pushBranch } from './pr-reporter'
 import { createDetachedPrWorktree, extractIssueNumberFromPrTitle, reviewPr, buildPrReviewComment, buildReviewFeedback, extractAutomatedReviewReasons, canResumeHumanNeededPrReview, getNextAutomatedPrReviewAttempt, getReusableAutomatedPrReviewFeedback, shouldRestartAutomatedPrReviewOnIssueUpdate, shouldRestartAutomatedPrReviewOnNewHead, classifyPrReviewOutcome, hydrateDetachedReviewWorktree, type PrReviewResult } from './pr-reviewer'
 import { acquireManagedLease, type ManagedLeaseHandle } from './lease'
 import type { TaskExecutionMonitor } from './cli-agent'
@@ -2663,9 +2663,14 @@ export class AgentDaemon {
       })
 
       const prCheck = await checkPrExists(branch, this.config)
-      const linkedOpenPr = prCheck.prNumber !== null && prCheck.prState === 'open'
+      const linkedOpenPr = hasReusableOpenPr(prCheck)
         ? (await listOpenAgentPullRequests(this.config)).find((pr) => pr.number === prCheck.prNumber) ?? null
         : null
+      if (prCheck.prNumber !== null && prCheck.prState !== 'open') {
+        this.logger.warn(
+          `[daemon] skipping terminal linked PR #${prCheck.prNumber} (${prCheck.prState}) during issue #${issueNumber} recovery`,
+        )
+      }
       if (linkedOpenPr && shouldResetLinkedPrToRetryOnIssueResume(linkedOpenPr.labels)) {
         await setManagedPrReviewLabels(linkedOpenPr.number, 'retry', this.config)
         this.logger.log(
@@ -2674,8 +2679,8 @@ export class AgentDaemon {
       }
       const recentBlockingReasons = [
         ...extractAutomatedIssuePreflightReasons(await listIssueComments(issueNumber, this.config)),
-        ...(prCheck.prNumber !== null
-          ? extractAutomatedReviewReasons(await listIssueComments(prCheck.prNumber, this.config))
+        ...(linkedOpenPr
+          ? extractAutomatedReviewReasons(await listIssueComments(linkedOpenPr.number, this.config))
           : []),
       ]
       const recoveryResult = await runIssueRecovery(
@@ -2685,8 +2690,8 @@ export class AgentDaemon {
         issue.body,
         this.config,
         this.logger,
-        prCheck.prNumber !== null && prCheck.prUrl
-          ? { number: prCheck.prNumber, url: prCheck.prUrl, branch }
+        linkedOpenPr
+          ? { number: linkedOpenPr.number, url: linkedOpenPr.url, branch }
           : null,
         recentBlockingReasons,
         monitor,
@@ -3129,6 +3134,32 @@ export class AgentDaemon {
     }
 
     const pr = await createOrFindPr(worktreePath, branch, issue.number, issue.title, this.config, this.logger)
+    if (pr.kind === 'terminal') {
+      const reason = `Linked PR #${pr.prNumber} is ${pr.prState}; replacement PR required before automation can continue`
+      await transitionIssueState(
+        issue.number,
+        ISSUE_LABELS.FAILED,
+        ISSUE_LABELS.WORKING,
+        {
+          event: 'failed',
+          machine: this.config.machineId,
+          ts: new Date().toISOString(),
+          prNumber: pr.prNumber,
+          reason,
+        },
+        this.config,
+      )
+
+      this.logger.warn(`[daemon] issue #${issue.number} stopped on terminal PR #${pr.prNumber} (${pr.prState})`)
+      recordIssueProcessed('failed')
+      this.activeWorktrees.delete(issue.number)
+      this.syncRuntimeMetrics()
+      return {
+        status: 'failed',
+        reason,
+      }
+    }
+
     const reviewLease = await this.acquireLeaseForScope({
       targetNumber: pr.prNumber,
       scope: 'pr-review',

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -65,6 +65,7 @@ import {
   setBlockedIssueResumeAgeSeconds,
   setBlockedIssueResumeEscalations,
   setBlockedIssueResumeEscalationAgeSeconds,
+  setIssueOpsSummaryMetrics,
   setLastTransientLoopErrorAgeSeconds,
   setPendingWakeRequests,
   setPrLineageWarningSnapshot,
@@ -76,6 +77,10 @@ import {
   type PrLineageEventKind,
   type MetricsServer,
 } from './metrics'
+import {
+  buildIssueLintReport,
+  buildIssueOpsSummary,
+} from './audit-issue-contracts'
 import {
   computeAutoUpgradePauseUntil,
   isAutoUpgradePauseActiveForTarget,
@@ -519,6 +524,29 @@ export class AgentDaemon {
     this.lastTransientLoopErrorMessage = formatDaemonError(error)
     recordTransientLoopError(kind)
     this.syncRuntimeMetrics()
+  }
+
+  private updateIssueOpsMetricsFromIssues(issues: AgentIssue[]): void {
+    try {
+      const summary = buildIssueOpsSummary(issues.map((issue) => {
+        const report = buildIssueLintReport(issue.body, {
+          kind: 'issue',
+          issueNumber: issue.number,
+          repo: this.config.repo,
+        }, issue.title)
+
+        return {
+          state: issue.state,
+          readyGateBlocked: report.readyGateBlocked,
+          qualityScore: report.score,
+          warningCount: report.warnings.length,
+        }
+      }))
+
+      setIssueOpsSummaryMetrics(summary)
+    } catch (error) {
+      this.logger.warn(`[daemon] failed to refresh issue ops summary metrics: ${formatDaemonError(error)}`)
+    }
   }
 
   private refreshObservability(): void {
@@ -1086,6 +1114,11 @@ export class AgentDaemon {
       defaultBranch: this.config.git.defaultBranch,
       machineId: this.config.machineId,
     })
+    setIssueOpsSummaryMetrics({
+      invalidReadyIssueCount: 0,
+      lowScoreIssueCount: 0,
+      warningIssueCount: 0,
+    })
     this.syncRuntimeMetrics()
 
     // Start metrics server
@@ -1133,6 +1166,7 @@ export class AgentDaemon {
    */
   private async reconcileIssueStates(): Promise<void> {
     const issues = await listOpenAgentIssues(this.config)
+    this.updateIssueOpsMetricsFromIssues(issues)
 
     for (const issue of issues) {
       // Only act on working/claimed issues from this machine
@@ -1166,6 +1200,7 @@ export class AgentDaemon {
       listOpenAgentIssues(this.config),
       listOpenAgentPullRequests(this.config),
     ])
+    this.updateIssueOpsMetricsFromIssues(issues)
     const issueMap = new Map(issues.map((issue) => [issue.number, issue]))
 
     for (const pr of prs) {
@@ -1824,6 +1859,7 @@ export class AgentDaemon {
       listOpenAgentIssues(this.config),
       listOpenAgentPullRequests(this.config),
     ])
+    this.updateIssueOpsMetricsFromIssues(issues)
     const now = Date.now()
     const openPrIssueNumbers = new Set(
       prs
@@ -1923,6 +1959,7 @@ export class AgentDaemon {
     skipIssueNumbers: ReadonlySet<number> = new Set<number>(),
   ): Promise<ResumableIssueCandidate | null> {
     const issues = await listOpenAgentIssues(this.config)
+    this.updateIssueOpsMetricsFromIssues(issues)
     const prs = await listOpenAgentPullRequests(this.config)
     const now = Date.now()
     const blockedIssueNumbers = new Set<number>()

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -18,6 +18,7 @@ import type {
   ManagedLeaseComment,
   ManagedLeaseScope,
   ManagedPullRequest,
+  PrLineageWarningRuntimeDetail,
   RecoveryActionRuntimeDetail,
   StalledWorkerRuntimeDetail,
   WorktreeInfo,
@@ -58,6 +59,7 @@ import {
   recordWorkerIdleTimeout,
   recordQueuedWakeRequest,
   recordHandledWakeRequest,
+  recordPrLineageEvent,
   setStalledWorkers,
   setBlockedIssueResumes,
   setBlockedIssueResumeAgeSeconds,
@@ -65,11 +67,13 @@ import {
   setBlockedIssueResumeEscalationAgeSeconds,
   setLastTransientLoopErrorAgeSeconds,
   setPendingWakeRequests,
+  setPrLineageWarningSnapshot,
   setStartupRecoveryPending,
   setAutoUpgradeSnapshot,
   startMetricsServer,
   METRICS_PORT_DEFAULT,
   METRICS_PATH,
+  type PrLineageEventKind,
   type MetricsServer,
 } from './metrics'
 import {
@@ -110,7 +114,7 @@ import {
   resolveAgentLoopBuildMetadata,
   resolveAgentLoopUpgradePolicy,
 } from './version'
-import { parsePrLineageMetadata } from './pr-lineage'
+import { inferPrAttemptFromBranch, parsePrLineageMetadata } from './pr-lineage'
 import {
   PrLineagePreflightError,
   collectPrLineagePreflightActualState,
@@ -159,6 +163,7 @@ const BLOCKED_ISSUE_RESUME_ESCALATION_COMMENT_PREFIX = '<!-- agent-loop:issue-re
 const ISSUE_RESUME_RESOLUTION_COMMENT_PREFIX = '<!-- agent-loop:issue-resume-resolved '
 export const BLOCKED_ISSUE_RESUME_WARNING_AGE_SECONDS = 5 * 60
 const MISSING_REMOTE_BRANCH_RECOVERY_REASON_PREFIX = 'missing-remote-branch:'
+const MAX_PR_LINEAGE_BRANCH_SCAN_ATTEMPTS = 4
 
 interface ResumableIssueCandidate {
   issue: AgentIssue
@@ -184,6 +189,13 @@ interface MissingRemoteBranchResumableIssueWorktree {
 type ResumableIssueWorktreeResult =
   | ReadyResumableIssueWorktree
   | MissingRemoteBranchResumableIssueWorktree
+
+interface PrLineageObservationInput {
+  issueNumber: number
+  branch: string
+  terminalReuseBlockedPrNumbers?: number[]
+  lineageMismatchBlockedPrNumbers?: number[]
+}
 
 interface ResumableIssuePrHandoff {
   kind: 'pr-review' | 'pr-merge'
@@ -268,6 +280,7 @@ export class AgentDaemon {
   private activeLeaseReaders = new Map<string, ActiveLeaseRuntimeReader>()
   private stalledWorkers = new Map<string, StalledWorkerState>()
   private blockedIssueResumes = new Map<number, BlockedIssueResumeState>()
+  private prLineageWarnings = new Map<number, PrLineageWarningRuntimeDetail>()
   private recoveryActionHistory: RecoveryActionRuntimeDetail[] = []
   private lastRecoveryActionAt: string | null = null
   private lastRecoveryActionKind: string | null = null
@@ -704,6 +717,161 @@ export class AgentDaemon {
   ): Promise<BranchPullRequestRecord | null> {
     const pullRequests = await listBranchPullRequests(branch, this.config)
     return pullRequests.find(pullRequest => pullRequest.number === prNumber) ?? null
+  }
+
+  private async observePrLineageForIssue(
+    input: PrLineageObservationInput,
+  ): Promise<void> {
+    const familyBranches = buildPrLineageFamilyBranches(input.branch)
+    const records = await Promise.all(
+      familyBranches.map(async (branch) => ({
+        branch,
+        pullRequests: await listBranchPullRequests(branch, this.config),
+      })),
+    )
+
+    const candidates = new Map<number, BranchPullRequestRecord>()
+    for (const entry of records) {
+      for (const pullRequest of entry.pullRequests) {
+        candidates.set(pullRequest.number, pullRequest)
+      }
+    }
+
+    const observed = [...candidates.values()]
+      .map((pullRequest) => {
+        let metadataIssue: number | null = null
+        let metadataAttempt = inferPrAttemptFromBranch(pullRequest.headRefName)
+        let hasValidMetadata = false
+
+        if (pullRequest.body) {
+          try {
+            const metadata = parsePrLineageMetadata(pullRequest.body)
+            metadataIssue = metadata.issue
+            metadataAttempt = metadata.attempt
+            hasValidMetadata = true
+          } catch {
+            hasValidMetadata = false
+          }
+        }
+
+        return {
+          ...pullRequest,
+          metadataIssue,
+          metadataAttempt,
+          hasValidMetadata,
+        }
+      })
+      .filter((pullRequest) => (
+        pullRequest.headRefName.startsWith(`agent/${input.issueNumber}/`)
+        || pullRequest.headRefName.startsWith(`agent/${input.issueNumber}-rebuild/`)
+        || pullRequest.headRefName.startsWith(`agent/${input.issueNumber}-rebuild-`)
+        || pullRequest.metadataIssue === input.issueNumber
+      ))
+
+    const openAttempts = observed
+      .filter(pullRequest => pullRequest.prState === 'open')
+      .map(pullRequest => pullRequest.metadataAttempt)
+    const highestOpenAttempt = openAttempts.length > 0
+      ? Math.max(...openAttempts)
+      : null
+
+    const activePrNumbers = observed
+      .filter(pullRequest => pullRequest.prState === 'open')
+      .map(pullRequest => pullRequest.number)
+      .sort((left, right) => left - right)
+
+    const supersededPrNumbers = highestOpenAttempt === null
+      ? []
+      : observed
+          .filter((pullRequest) => (
+            pullRequest.prState !== 'open'
+            && pullRequest.metadataAttempt < highestOpenAttempt
+          ))
+          .map(pullRequest => pullRequest.number)
+          .sort((left, right) => left - right)
+
+    const missingMetadataPrNumbers = observed
+      .filter(pullRequest => !pullRequest.hasValidMetadata)
+      .map(pullRequest => pullRequest.number)
+      .sort((left, right) => left - right)
+
+    const terminalReuseBlockedPrNumbers = uniqueSortedNumbers(
+      input.terminalReuseBlockedPrNumbers ?? [],
+    )
+
+    const lineageMismatchBlockedPrNumbers = uniqueSortedNumbers(
+      input.lineageMismatchBlockedPrNumbers ?? [],
+    )
+
+    this.setPrLineageWarningState({
+      issueNumber: input.issueNumber,
+      branch: input.branch,
+      activePrNumbers,
+      supersededPrNumbers,
+      terminalReuseBlockedPrNumbers,
+      missingMetadataPrNumbers,
+      lineageMismatchBlockedPrNumbers,
+      updatedAt: new Date().toISOString(),
+    })
+  }
+
+  private setPrLineageWarningState(next: PrLineageWarningRuntimeDetail): void {
+    if (!hasPrLineageWarnings(next)) {
+      const deleted = this.prLineageWarnings.delete(next.issueNumber)
+      if (deleted) {
+        this.syncRuntimeMetrics()
+      }
+      return
+    }
+
+    const previous = this.prLineageWarnings.get(next.issueNumber) ?? null
+
+    if (next.activePrNumbers.length > 1 && (previous?.activePrNumbers.length ?? 0) <= 1) {
+      recordPrLineageEvent('multi_active_lineage')
+    }
+    this.recordNewPrLineageNumbers(previous?.terminalReuseBlockedPrNumbers ?? [], next.terminalReuseBlockedPrNumbers, 'terminal_reuse_blocked')
+    this.recordNewPrLineageNumbers(previous?.supersededPrNumbers ?? [], next.supersededPrNumbers, 'superseded_lineage')
+    this.recordNewPrLineageNumbers(previous?.missingMetadataPrNumbers ?? [], next.missingMetadataPrNumbers, 'missing_metadata')
+    this.recordNewPrLineageNumbers(previous?.lineageMismatchBlockedPrNumbers ?? [], next.lineageMismatchBlockedPrNumbers, 'lineage_mismatch_blocked')
+
+    this.prLineageWarnings.set(next.issueNumber, next)
+    this.syncRuntimeMetrics()
+  }
+
+  private recordNewPrLineageNumbers(
+    previous: number[],
+    next: number[],
+    kind: PrLineageEventKind,
+  ): void {
+    const seen = new Set(previous)
+    for (const prNumber of next) {
+      if (seen.has(prNumber)) continue
+      recordPrLineageEvent(kind)
+    }
+  }
+
+  private clearPrLineageWarning(issueNumber: number): void {
+    if (this.prLineageWarnings.delete(issueNumber)) {
+      this.syncRuntimeMetrics()
+    }
+  }
+
+  private buildPrLineageStatus(): DaemonStatus['prLineage'] {
+    const warnings = [...this.prLineageWarnings.values()]
+      .sort((left, right) => left.issueNumber - right.issueNumber)
+    const warningCounts = {
+      multiActiveLineage: warnings.filter(warning => warning.activePrNumbers.length > 1).length,
+      terminalReuseBlocked: warnings.filter(warning => warning.terminalReuseBlockedPrNumbers.length > 0).length,
+      supersededLineage: warnings.filter(warning => warning.supersededPrNumbers.length > 0).length,
+      missingMetadata: warnings.filter(warning => warning.missingMetadataPrNumbers.length > 0).length,
+      lineageMismatchBlocked: warnings.filter(warning => warning.lineageMismatchBlockedPrNumbers.length > 0).length,
+    }
+
+    return {
+      warningCount: warnings.length,
+      warningCounts,
+      warnings,
+    }
   }
 
   private enqueueWakeRequests(requests: WakeRequest[]): void {
@@ -1156,6 +1324,7 @@ export class AgentDaemon {
         ...this.agentLoopBuild,
       },
       upgrade: this.buildUpgradeStatus(),
+      prLineage: this.buildPrLineageStatus(),
       endpoints: {
         health: {
           host: this.healthServerConfig.host,
@@ -2198,6 +2367,12 @@ export class AgentDaemon {
     let leaseReason: string | undefined
     let leaseRecoveryKind: string | undefined
     try {
+      if (issueNumber !== null) {
+        await this.observePrLineageForIssue({
+          issueNumber,
+          branch: pr.headRefName,
+        })
+      }
       try {
         await this.runPrLineagePreflightOrThrow({
           stage: 'PR review',
@@ -2210,6 +2385,13 @@ export class AgentDaemon {
         })
       } catch (error) {
         if (error instanceof PrLineagePreflightError) {
+          if (issueNumber !== null) {
+            await this.observePrLineageForIssue({
+              issueNumber,
+              branch: pr.headRefName,
+              lineageMismatchBlockedPrNumbers: [pr.number],
+            })
+          }
           this.logger.warn(`[pr-review-subagent] blocked PR #${pr.number} by lineage preflight: ${error.message}`)
           leaseReason = error.message
           leaseRecoveryKind = 'pr-review-lineage-blocked'
@@ -2560,6 +2742,12 @@ export class AgentDaemon {
     let leaseReason: string | undefined
     let leaseRecoveryKind: string | undefined
     try {
+      if (issueNumber !== null) {
+        await this.observePrLineageForIssue({
+          issueNumber,
+          branch: pr.headRefName,
+        })
+      }
       try {
         await this.runPrLineagePreflightOrThrow({
           stage: 'PR merge',
@@ -2572,6 +2760,13 @@ export class AgentDaemon {
         })
       } catch (error) {
         if (error instanceof PrLineagePreflightError) {
+          if (issueNumber !== null) {
+            await this.observePrLineageForIssue({
+              issueNumber,
+              branch: pr.headRefName,
+              lineageMismatchBlockedPrNumbers: [pr.number],
+            })
+          }
           this.logger.warn(`[pr-merge-subagent] blocked PR #${pr.number} by lineage preflight: ${error.message}`)
           leaseReason = error.message
           leaseRecoveryKind = 'pr-merge-lineage-blocked'
@@ -2610,6 +2805,7 @@ export class AgentDaemon {
               : mergeResult.message,
             pr.number,
           )
+          this.clearPrLineageWarning(issueNumber)
         }
         this.logger.log(`[pr-merge-subagent] merged approved PR #${pr.number}`)
         return
@@ -2767,6 +2963,13 @@ export class AgentDaemon {
       const linkedOpenPr = hasReusableOpenPr(prCheck)
         ? (await listOpenAgentPullRequests(this.config)).find((pr) => pr.number === prCheck.prNumber) ?? null
         : null
+      await this.observePrLineageForIssue({
+        issueNumber,
+        branch,
+        terminalReuseBlockedPrNumbers: prCheck.prNumber !== null && prCheck.prState !== 'open'
+          ? [prCheck.prNumber]
+          : [],
+      })
       try {
         await this.runPrLineagePreflightOrThrow({
           stage: 'issue recovery',
@@ -2778,6 +2981,14 @@ export class AgentDaemon {
         })
       } catch (error) {
         if (error instanceof PrLineagePreflightError) {
+          await this.observePrLineageForIssue({
+            issueNumber,
+            branch,
+            terminalReuseBlockedPrNumbers: prCheck.prNumber !== null && prCheck.prState !== 'open'
+              ? [prCheck.prNumber]
+              : [],
+            lineageMismatchBlockedPrNumbers: linkedOpenPr?.number !== undefined ? [linkedOpenPr.number] : [],
+          })
           this.logger.warn(`[daemon] issue #${issueNumber} blocked by PR lineage preflight: ${error.message}`)
           this.registerFailedIssueResume(issueNumber)
           await this.completeManagedLease(
@@ -3303,6 +3514,15 @@ export class AgentDaemon {
       }
     }
 
+    const linkedBranchPr = await checkPrExists(activeBranch, this.config)
+    await this.observePrLineageForIssue({
+      issueNumber: issue.number,
+      branch: activeBranch,
+      terminalReuseBlockedPrNumbers: linkedBranchPr.prNumber !== null && linkedBranchPr.prState !== 'open'
+        ? [linkedBranchPr.prNumber]
+        : [],
+    })
+
     let pr: Awaited<ReturnType<typeof createOrFindPr>>
     try {
       pr = await createOrFindPr(
@@ -3317,6 +3537,13 @@ export class AgentDaemon {
       )
     } catch (error) {
       if (error instanceof PrLineagePreflightError) {
+        await this.observePrLineageForIssue({
+          issueNumber: issue.number,
+          branch: activeBranch,
+          lineageMismatchBlockedPrNumbers: linkedBranchPr.prNumber !== null
+            ? [linkedBranchPr.prNumber]
+            : [],
+        })
         this.logger.warn(`[daemon] issue #${issue.number} blocked by PR lineage preflight: ${error.message}`)
         return {
           status: 'blocked',
@@ -3336,8 +3563,17 @@ export class AgentDaemon {
         this.syncRuntimeMetrics()
       }
     }
+    await this.observePrLineageForIssue({
+      issueNumber: issue.number,
+      branch: activeBranch,
+    })
 
     if (pr.kind === 'terminal') {
+      await this.observePrLineageForIssue({
+        issueNumber: issue.number,
+        branch: activeBranch,
+        terminalReuseBlockedPrNumbers: [pr.prNumber],
+      })
       const reason = `Linked PR #${pr.prNumber} is ${pr.prState}; replacement PR required before automation can continue`
       await transitionIssueState(
         issue.number,
@@ -3374,6 +3610,11 @@ export class AgentDaemon {
       })
     } catch (error) {
       if (error instanceof PrLineagePreflightError) {
+        await this.observePrLineageForIssue({
+          issueNumber: issue.number,
+          branch: activeBranch,
+          lineageMismatchBlockedPrNumbers: [pr.prNumber],
+        })
         this.logger.warn(`[daemon] issue #${issue.number} blocked before PR review: ${error.message}`)
         return {
           status: 'blocked',
@@ -3438,6 +3679,11 @@ export class AgentDaemon {
         })
       } catch (error) {
         if (error instanceof PrLineagePreflightError) {
+          await this.observePrLineageForIssue({
+            issueNumber: issue.number,
+            branch: activeBranch,
+            lineageMismatchBlockedPrNumbers: [pr.prNumber],
+          })
           this.logger.warn(`[daemon] issue #${issue.number} blocked before PR merge: ${error.message}`)
           return {
             status: 'blocked',
@@ -3537,6 +3783,7 @@ export class AgentDaemon {
       recordPrCreated()
 
       await removeWorktree(worktreePath, activeBranch)
+      this.clearPrLineageWarning(issue.number)
       this.activeWorktrees.delete(issue.number)
       this.syncRuntimeMetrics()
       return { status: 'completed' }
@@ -4359,6 +4606,7 @@ export class AgentDaemon {
 
   private syncRuntimeMetrics(): void {
     const runtime = this.buildRuntimeStatus()
+    const prLineage = this.buildPrLineageStatus()
     setActiveWorktrees(this.activeWorktrees.size)
     setActivePrReviews(runtime.activePrReviews)
     setInFlightIssueProcesses(runtime.inFlightIssueProcess)
@@ -4375,6 +4623,13 @@ export class AgentDaemon {
     setBlockedIssueResumeEscalations(runtime.blockedIssueResumeEscalationCount)
     setBlockedIssueResumeEscalationAgeSeconds(runtime.oldestBlockedIssueResumeEscalationAgeSeconds)
     setPendingWakeRequests(this.pendingWakeRequests.length)
+    setPrLineageWarningSnapshot({
+      multi_active_lineage: prLineage?.warningCounts.multiActiveLineage ?? 0,
+      terminal_reuse_blocked: prLineage?.warningCounts.terminalReuseBlocked ?? 0,
+      superseded_lineage: prLineage?.warningCounts.supersededLineage ?? 0,
+      missing_metadata: prLineage?.warningCounts.missingMetadata ?? 0,
+      lineage_mismatch_blocked: prLineage?.warningCounts.lineageMismatchBlocked ?? 0,
+    })
     setAutoUpgradeSnapshot(this.autoUpgradeState)
   }
 
@@ -5000,6 +5255,56 @@ export function buildDaemonRuntimeStatus(input: {
     oldestBlockedIssueResumeEscalationAgeSeconds: input.oldestBlockedIssueResumeEscalationAgeSeconds,
     autoUpgrade: input.autoUpgrade,
   }
+}
+
+function buildPrLineageFamilyBranches(branch: string): string[] {
+  const match = branch.match(/^agent\/(\d+)(?:-rebuild(?:-(\d+))?)?\/(.+)$/)
+  if (!match?.[1] || !match[3]) {
+    return [branch]
+  }
+
+  const issueNumber = match[1]
+  const suffix = match[3]
+  const currentAttempt = inferPrAttemptFromBranch(branch)
+  const maxAttempts = Math.max(MAX_PR_LINEAGE_BRANCH_SCAN_ATTEMPTS, currentAttempt + 1)
+  const branches: string[] = []
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    branches.push(attempt === 1
+      ? `agent/${issueNumber}/${suffix}`
+      : attempt === 2
+        ? `agent/${issueNumber}-rebuild/${suffix}`
+        : `agent/${issueNumber}-rebuild-${attempt - 1}/${suffix}`)
+  }
+
+  return uniqueSortedStrings(branches)
+}
+
+function hasPrLineageWarnings(
+  warning: Pick<
+    PrLineageWarningRuntimeDetail,
+    | 'activePrNumbers'
+    | 'supersededPrNumbers'
+    | 'terminalReuseBlockedPrNumbers'
+    | 'missingMetadataPrNumbers'
+    | 'lineageMismatchBlockedPrNumbers'
+  >,
+): boolean {
+  return (
+    warning.activePrNumbers.length > 1
+    || warning.supersededPrNumbers.length > 0
+    || warning.terminalReuseBlockedPrNumbers.length > 0
+    || warning.missingMetadataPrNumbers.length > 0
+    || warning.lineageMismatchBlockedPrNumbers.length > 0
+  )
+}
+
+function uniqueSortedNumbers(values: number[]): number[] {
+  return [...new Set(values)].sort((left, right) => left - right)
+}
+
+function uniqueSortedStrings(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right))
 }
 
 function getIsoAgeSeconds(iso: string, now = Date.now()): number {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -19,11 +19,13 @@ import type {
   ManagedLeaseScope,
   ManagedPullRequest,
   PrLineageWarningRuntimeDetail,
+  PrCheckResult,
+  PullRequestChecksStatus,
   RecoveryActionRuntimeDetail,
   StalledWorkerRuntimeDetail,
   WorktreeInfo,
 } from '@agent/shared'
-import { ISSUE_LABELS, PR_REVIEW_LABELS, canDaemonAdoptManagedLease, getActiveManagedLease, getLatestManagedLease, listOpenAgentIssues, listOpenAgentPullRequests, transitionIssueState, commentOnIssue, commentOnPr, setManagedPrReviewLabels, mergePullRequest, checkPrExists, listIssueComments, resolveActiveClaimMachine, getAgentIssueByNumber, getManagedPullRequestByNumber, listBranchPullRequests, parseIssueContract, setGitHubApiRequestObserver } from '@agent/shared'
+import { ISSUE_LABELS, PR_REVIEW_LABELS, canDaemonAdoptManagedLease, getActiveManagedLease, getLatestManagedLease, listOpenAgentIssues, listOpenAgentPullRequests, transitionIssueState, commentOnIssue, commentOnPr, setManagedPrReviewLabels, mergePullRequest, checkPrExists, listIssueComments, resolveActiveClaimMachine, getAgentIssueByNumber, getManagedPullRequestByNumber, listBranchPullRequests, parseIssueContract, setGitHubApiRequestObserver, getPullRequestChecksStatus } from '@agent/shared'
 import { claimSpecificIssue, pollAndClaim } from './claimer'
 import { createWorktree, removeWorktree, cleanupOrphanedWorktrees, hasWorktreeForIssue } from './worktree-manager'
 import { runIssueBranchPreflight, runSubtaskExecutor, runReviewAutoFix, runIssueRecovery } from './subtask-executor'
@@ -272,6 +274,21 @@ export interface IssueResumeResolutionComment {
 
 export interface IssueResumeResolutionRecord extends IssueComment {
   resolutionComment: IssueResumeResolutionComment
+}
+
+export interface ApprovedPrMergeChecksGateResult {
+  outcome: 'allow' | 'defer' | 'human-needed'
+  recoverable: boolean
+  reason: string | null
+}
+
+interface ApprovedPrMergeAttemptResult {
+  merged: boolean
+  message: string
+  sha?: string
+  review?: PrReviewResult
+  recoverable?: boolean
+  checksBlocked?: boolean
 }
 
 export class AgentDaemon {
@@ -3291,8 +3308,24 @@ export class AgentDaemon {
     branch: string,
     worktreePath: string,
     monitor?: TaskExecutionMonitor,
-  ): Promise<{ merged: boolean; message: string; sha?: string; review?: PrReviewResult; recoverable?: boolean }> {
-    const mergeResult = await mergePullRequest(prNumber, this.config)
+  ): Promise<ApprovedPrMergeAttemptResult> {
+    const initialChecksGate = await this.runApprovedPrMergeChecksGate(prNumber)
+    if (initialChecksGate.outcome === 'defer') {
+      return {
+        merged: false,
+        message: initialChecksGate.reason ?? 'PR checks not ready for merge',
+        recoverable: true,
+      }
+    }
+    if (initialChecksGate.outcome === 'human-needed') {
+      return {
+        merged: false,
+        message: initialChecksGate.reason ?? 'PR checks failed',
+        checksBlocked: true,
+      }
+    }
+
+    const mergeResult = await this.mergeManagedPullRequest(prNumber)
     if (mergeResult.merged) {
       recordPrMergeRecoveryOutcome('merged_initial')
       return mergeResult
@@ -3300,15 +3333,14 @@ export class AgentDaemon {
 
     if (!isMergeabilityFailure(mergeResult.message)) {
       recordPrMergeRecoveryOutcome('blocked_non_mergeable')
-      await commentOnPr(prNumber, buildPrMergeBlockedComment(prNumber, mergeResult.message), this.config)
-      await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+      await this.commentOnManagedPr(prNumber, buildPrMergeBlockedComment(prNumber, mergeResult.message))
+      await this.setManagedPrReviewState(prNumber, 'human-needed')
       return mergeResult
     }
 
-    await commentOnPr(
+    await this.commentOnManagedPr(
       prNumber,
       buildPrMergeRetryComment(prNumber, branch, this.config.git.defaultBranch, mergeResult.message),
-      this.config,
     )
 
     const refreshResult = await rebaseManagedBranchOntoDefault(
@@ -3323,8 +3355,8 @@ export class AgentDaemon {
         merged: false,
         message: `Branch refresh failed: ${refreshResult.message}`,
       }
-      await commentOnPr(prNumber, buildPrMergeBlockedComment(prNumber, blockedResult.message), this.config)
-      await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+      await this.commentOnManagedPr(prNumber, buildPrMergeBlockedComment(prNumber, blockedResult.message))
+      await this.setManagedPrReviewState(prNumber, 'human-needed')
       return blockedResult
     }
 
@@ -3336,8 +3368,8 @@ export class AgentDaemon {
         merged: false,
         message: `Branch refresh push failed: ${formatDaemonError(err)}`,
       }
-      await commentOnPr(prNumber, buildPrMergeBlockedComment(prNumber, blockedResult.message), this.config)
-      await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+      await this.commentOnManagedPr(prNumber, buildPrMergeBlockedComment(prNumber, blockedResult.message))
+      await this.setManagedPrReviewState(prNumber, 'human-needed')
       return blockedResult
     }
 
@@ -3355,8 +3387,8 @@ export class AgentDaemon {
 
     if (!(review.approved && review.canMerge)) {
       recordPrMergeRecoveryOutcome('refresh_review_blocked')
-      await commentOnPr(prNumber, buildPrReviewComment(prNumber, review, 2, 'human-needed'), this.config)
-      await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+      await this.commentOnManagedPr(prNumber, buildPrReviewComment(prNumber, review, 2, 'human-needed'))
+      await this.setManagedPrReviewState(prNumber, 'human-needed')
       return {
         merged: false,
         message: review.reason,
@@ -3364,10 +3396,28 @@ export class AgentDaemon {
       }
     }
 
-    await commentOnPr(prNumber, buildPrReviewComment(prNumber, review, 2, 'approved'), this.config)
-    await setManagedPrReviewLabels(prNumber, 'approved', this.config)
+    await this.commentOnManagedPr(prNumber, buildPrReviewComment(prNumber, review, 2, 'approved'))
+    await this.setManagedPrReviewState(prNumber, 'approved')
 
-    const retriedMergeResult = await mergePullRequest(prNumber, this.config)
+    const retriedChecksGate = await this.runApprovedPrMergeChecksGate(prNumber)
+    if (retriedChecksGate.outcome === 'defer') {
+      return {
+        merged: false,
+        message: retriedChecksGate.reason ?? 'PR checks not ready for merge',
+        review,
+        recoverable: true,
+      }
+    }
+    if (retriedChecksGate.outcome === 'human-needed') {
+      return {
+        merged: false,
+        message: retriedChecksGate.reason ?? 'PR checks failed',
+        review,
+        checksBlocked: true,
+      }
+    }
+
+    const retriedMergeResult = await this.mergeManagedPullRequest(prNumber)
     if (retriedMergeResult.merged) {
       recordPrMergeRecoveryOutcome('merged_after_refresh')
       return {
@@ -3377,12 +3427,45 @@ export class AgentDaemon {
     }
 
     recordPrMergeRecoveryOutcome('retry_merge_failed')
-    await commentOnPr(prNumber, buildPrMergeBlockedComment(prNumber, retriedMergeResult.message), this.config)
-    await setManagedPrReviewLabels(prNumber, 'human-needed', this.config)
+    await this.commentOnManagedPr(prNumber, buildPrMergeBlockedComment(prNumber, retriedMergeResult.message))
+    await this.setManagedPrReviewState(prNumber, 'human-needed')
     return {
       ...retriedMergeResult,
       review,
     }
+  }
+
+  private async runApprovedPrMergeChecksGate(
+    prNumber: number,
+  ): Promise<ApprovedPrMergeChecksGateResult> {
+    const checksStatus = await this.getPullRequestChecksStatus(prNumber)
+    const gate = classifyApprovedPrMergeChecksGate(checksStatus)
+
+    if (gate.outcome === 'human-needed' && gate.reason) {
+      await this.commentOnManagedPr(prNumber, buildPrMergeBlockedComment(prNumber, gate.reason))
+      await this.setManagedPrReviewState(prNumber, 'human-needed')
+    }
+
+    return gate
+  }
+
+  private async getPullRequestChecksStatus(prNumber: number): Promise<PullRequestChecksStatus> {
+    return getPullRequestChecksStatus(prNumber, this.config)
+  }
+
+  private async mergeManagedPullRequest(prNumber: number) {
+    return mergePullRequest(prNumber, this.config)
+  }
+
+  private async commentOnManagedPr(prNumber: number, body: string): Promise<void> {
+    await commentOnPr(prNumber, body, this.config)
+  }
+
+  private async setManagedPrReviewState(
+    prNumber: number,
+    state: 'approved' | 'failed' | 'retry' | 'human-needed',
+  ): Promise<void> {
+    await setManagedPrReviewLabels(prNumber, state, this.config)
   }
 
   private registerFailedIssueResume(issueNumber: number): void {
@@ -3823,6 +3906,14 @@ export class AgentDaemon {
       await this.completeManagedLease('pr-merge', pr.prNumber, mergeLease.handle, 'completed')
 
       if (!mergeResult.merged) {
+        const linkedIssueOutcome = classifyLinkedIssueApprovedMergeOutcome(mergeResult)
+        if (linkedIssueOutcome.status === 'recoverable') {
+          this.logger.warn(`[daemon] issue #${issue.number} approved PR #${pr.prNumber} is blocked pending human follow-up: ${mergeResult.message}`)
+          this.activeWorktrees.delete(issue.number)
+          this.syncRuntimeMetrics()
+          return linkedIssueOutcome
+        }
+
         await transitionIssueState(
           issue.number,
           ISSUE_LABELS.FAILED,
@@ -5692,6 +5783,57 @@ function buildAutoFixPushFailedReview(error: unknown): PrReviewResult {
 export function isMergeabilityFailure(message: string): boolean {
   const normalized = message.toLowerCase()
   return normalized.includes('not mergeable') || normalized.includes('merge conflict')
+}
+
+export function classifyApprovedPrMergeChecksGate(
+  status: PullRequestChecksStatus,
+): ApprovedPrMergeChecksGateResult {
+  switch (status.state) {
+    case 'pass':
+      return {
+        outcome: 'allow',
+        recoverable: false,
+        reason: null,
+      }
+    case 'pending':
+      return {
+        outcome: 'defer',
+        recoverable: true,
+        reason: `PR checks not ready for merge: ${status.summary}`,
+      }
+    case 'fail':
+      return {
+        outcome: 'human-needed',
+        recoverable: false,
+        reason: `PR checks failed: ${status.summary}`,
+      }
+    case 'error':
+      return {
+        outcome: 'defer',
+        recoverable: true,
+        reason: `Merge gate could not confirm PR checks: ${status.summary}`,
+      }
+    default: {
+      const exhaustiveStatus: never = status.state
+      throw new Error(`Unhandled PR checks gate state: ${exhaustiveStatus}`)
+    }
+  }
+}
+
+export function classifyLinkedIssueApprovedMergeOutcome(
+  mergeResult: ApprovedPrMergeAttemptResult,
+): { status: 'failed' | 'recoverable'; reason: string } {
+  if (mergeResult.checksBlocked) {
+    return {
+      status: 'recoverable',
+      reason: mergeResult.message,
+    }
+  }
+
+  return {
+    status: 'failed',
+    reason: mergeResult.message,
+  }
 }
 
 export function isMissingRemoteBranchGitOutput(

--- a/apps/agent-daemon/src/dashboard.test.ts
+++ b/apps/agent-daemon/src/dashboard.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  buildDashboardIssueOpsSummary,
   buildDashboardMachineCards,
   buildDashboardUpgradeEvents,
   buildDashboardUpgradeRollout,
@@ -130,6 +131,29 @@ function buildPresence(overrides: Partial<DashboardPresenceView> = {}): Dashboar
 }
 
 describe('dashboard machine aggregation', () => {
+  test('derives dashboard issue ops summary counts from issue quality data', () => {
+    const summary = buildDashboardIssueOpsSummary([
+      {
+        state: 'ready',
+        readyGateBlocked: true,
+        qualityScore: 40,
+        warningCount: 0,
+      },
+      {
+        state: 'ready',
+        readyGateBlocked: false,
+        qualityScore: 75,
+        warningCount: 1,
+      },
+    ])
+
+    expect(summary).toEqual({
+      invalidReadyIssueCount: 1,
+      lowScoreIssueCount: 2,
+      warningIssueCount: 1,
+    })
+  })
+
   test('merges local and GitHub machine state and prefers local lease detail', () => {
     const localSnapshots = [buildLocalSnapshot()]
     const remoteLeases = [
@@ -209,6 +233,9 @@ describe('dashboard machine aggregation', () => {
         claimBlockedBy: [],
         hasExecutableContract: true,
         contractValidationErrors: [],
+        readyGateBlocked: false,
+        qualityScore: 100,
+        warningCount: 0,
         linkedPrNumbers: [226],
         activeLease: buildLease(),
       },
@@ -225,6 +252,9 @@ describe('dashboard machine aggregation', () => {
         claimBlockedBy: [],
         hasExecutableContract: true,
         contractValidationErrors: [],
+        readyGateBlocked: false,
+        qualityScore: 90,
+        warningCount: 0,
         linkedPrNumbers: [],
         activeLease: null,
       },
@@ -241,6 +271,9 @@ describe('dashboard machine aggregation', () => {
         claimBlockedBy: [92],
         hasExecutableContract: false,
         contractValidationErrors: ['missing RED test'],
+        readyGateBlocked: true,
+        qualityScore: 40,
+        warningCount: 1,
         linkedPrNumbers: [227],
         activeLease: null,
       },
@@ -279,6 +312,9 @@ describe('dashboard machine aggregation', () => {
       readyIssueCount: 1,
       workingIssueCount: 1,
       failedIssueCount: 1,
+      invalidReadyIssueCount: 0,
+      lowScoreIssueCount: 1,
+      warningIssueCount: 1,
       openPrCount: 1,
       upgradePendingMachineCount: 0,
       upgradeCurrentMachineCount: 0,
@@ -375,6 +411,9 @@ describe('dashboard machine aggregation', () => {
       readyIssueCount: 0,
       workingIssueCount: 0,
       failedIssueCount: 0,
+      invalidReadyIssueCount: 0,
+      lowScoreIssueCount: 0,
+      warningIssueCount: 0,
       openPrCount: 0,
       upgradePendingMachineCount: 3,
       upgradeCurrentMachineCount: 0,
@@ -433,6 +472,9 @@ describe('dashboard machine aggregation', () => {
       readyIssueCount: 0,
       workingIssueCount: 0,
       failedIssueCount: 0,
+      invalidReadyIssueCount: 0,
+      lowScoreIssueCount: 0,
+      warningIssueCount: 0,
       openPrCount: 0,
       upgradePendingMachineCount: 0,
       upgradeCurrentMachineCount: 1,

--- a/apps/agent-daemon/src/dashboard.ts
+++ b/apps/agent-daemon/src/dashboard.ts
@@ -18,6 +18,12 @@ import {
   type DaemonObservabilitySnapshot,
 } from './status'
 import {
+  buildIssueLintReport,
+  buildIssueOpsSummary,
+  LOW_ISSUE_QUALITY_SCORE_THRESHOLD,
+  type IssueOpsSummary,
+} from './audit-issue-contracts'
+import {
   canResumeHumanNeededPrReview,
   extractLatestAutomatedPrReviewBlockerSummary,
 } from './pr-reviewer'
@@ -53,6 +59,9 @@ export interface DashboardSummary {
   readyIssueCount: number
   workingIssueCount: number
   failedIssueCount: number
+  invalidReadyIssueCount: number
+  lowScoreIssueCount: number
+  warningIssueCount: number
   openPrCount: number
   upgradePendingMachineCount: number
   upgradeCurrentMachineCount: number
@@ -170,6 +179,9 @@ export interface DashboardIssueView {
   claimBlockedBy: number[]
   hasExecutableContract: boolean
   contractValidationErrors: string[]
+  readyGateBlocked: boolean
+  qualityScore: number
+  warningCount: number
   linkedPrNumbers: number[]
   activeLease: DashboardLeaseView | null
 }
@@ -273,6 +285,7 @@ interface DashboardGitHubCollection {
   issues: DashboardIssueView[]
   prs: DashboardPullRequestView[]
   remoteLeases: DashboardLeaseView[]
+  issueOpsErrors: string[]
 }
 
 export async function collectDashboardSnapshot(
@@ -316,6 +329,7 @@ export async function collectDashboardSnapshot(
     issues = githubCollection.issues
     prs = githubCollection.prs
     remoteLeases = githubCollection.remoteLeases
+    errors.push(...githubCollection.issueOpsErrors)
   } catch (error) {
     errors.push(`GitHub 快照不可用：${formatError(error)}`)
   }
@@ -478,6 +492,7 @@ export function buildDashboardSummary(
   issues: DashboardIssueView[],
   prs: DashboardPullRequestView[],
 ): DashboardSummary {
+  const issueOpsSummary = buildDashboardIssueOpsSummary(issues)
   const activeLeaseKeys = new Set<string>()
   let localRuntimeCount = 0
   let managedPresenceCount = 0
@@ -531,6 +546,9 @@ export function buildDashboardSummary(
     readyIssueCount: issues.filter((issue) => issue.state === 'ready').length,
     workingIssueCount: issues.filter((issue) => issue.state === 'working').length,
     failedIssueCount: issues.filter((issue) => issue.state === 'failed').length,
+    invalidReadyIssueCount: issueOpsSummary.invalidReadyIssueCount,
+    lowScoreIssueCount: issueOpsSummary.lowScoreIssueCount,
+    warningIssueCount: issueOpsSummary.warningIssueCount,
     openPrCount: prs.length,
     upgradePendingMachineCount,
     upgradeCurrentMachineCount,
@@ -541,6 +559,17 @@ export function buildDashboardSummary(
     upgradeErrorMachineCount,
     upgradeFailedMachineCount,
   }
+}
+
+export function buildDashboardIssueOpsSummary(
+  issues: Array<Pick<DashboardIssueView, 'state' | 'readyGateBlocked' | 'qualityScore' | 'warningCount'>>,
+): IssueOpsSummary {
+  return buildIssueOpsSummary(issues.map((issue) => ({
+    state: issue.state,
+    readyGateBlocked: issue.readyGateBlocked,
+    qualityScore: issue.qualityScore,
+    warningCount: issue.warningCount,
+  })))
 }
 
 export function buildDashboardUpgradeFailureAlertMessages(
@@ -1034,26 +1063,65 @@ async function collectGitHubDashboardData(input: {
     }
   }
 
+  const issueOpsErrors: string[] = []
+  const issueQualityByNumber = new Map<number, {
+    readyGateBlocked: boolean
+    qualityScore: number
+    warningCount: number
+  }>()
+  for (const issue of issues) {
+    try {
+      const report = buildIssueLintReport(issue.body, {
+        kind: 'issue',
+        issueNumber: issue.number,
+        repo: input.config.repo,
+      }, issue.title)
+      issueQualityByNumber.set(issue.number, {
+        readyGateBlocked: report.readyGateBlocked,
+        qualityScore: report.score,
+        warningCount: report.warnings.length,
+      })
+    } catch (error) {
+      issueOpsErrors.push(`Issue ops 质量快照不可用：#${issue.number} ${formatError(error)}`)
+      issueQualityByNumber.set(issue.number, {
+        readyGateBlocked: !issue.hasExecutableContract,
+        qualityScore: 0,
+        warningCount: 0,
+      })
+    }
+  }
+
   const issueViews = issues
-    .map((issue) => ({
-      number: issue.number,
-      title: issue.title,
-      url: buildGitHubIssueUrl(input.config.repo, issue.number),
-      state: issue.state,
-      labels: issue.labels,
-      assignee: issue.assignee,
-      isClaimable: issue.isClaimable,
-      updatedAt: issue.updatedAt,
-      dependencyIssueNumbers: issue.dependencyIssueNumbers,
-      claimBlockedBy: issue.claimBlockedBy,
-      hasExecutableContract: issue.hasExecutableContract,
-      contractValidationErrors: issue.contractValidationErrors,
-      linkedPrNumbers: (linkedPrsByIssue.get(issue.number) ?? []).map((pr) => pr.number).sort((left, right) => left - right),
-      activeLease: preferLocalLease(
-        input.localLeaseIndex,
-        issueLeaseMap.get(issue.number) ?? null,
-      ),
-    }) satisfies DashboardIssueView)
+    .map((issue) => {
+      const quality = issueQualityByNumber.get(issue.number) ?? {
+        readyGateBlocked: !issue.hasExecutableContract,
+        qualityScore: 0,
+        warningCount: 0,
+      }
+
+      return {
+        number: issue.number,
+        title: issue.title,
+        url: buildGitHubIssueUrl(input.config.repo, issue.number),
+        state: issue.state,
+        labels: issue.labels,
+        assignee: issue.assignee,
+        isClaimable: issue.isClaimable,
+        updatedAt: issue.updatedAt,
+        dependencyIssueNumbers: issue.dependencyIssueNumbers,
+        claimBlockedBy: issue.claimBlockedBy,
+        hasExecutableContract: issue.hasExecutableContract,
+        contractValidationErrors: issue.contractValidationErrors,
+        readyGateBlocked: quality.readyGateBlocked,
+        qualityScore: quality.qualityScore,
+        warningCount: quality.warningCount,
+        linkedPrNumbers: (linkedPrsByIssue.get(issue.number) ?? []).map((pr) => pr.number).sort((left, right) => left - right),
+        activeLease: preferLocalLease(
+          input.localLeaseIndex,
+          issueLeaseMap.get(issue.number) ?? null,
+        ),
+      } satisfies DashboardIssueView
+    })
     .sort(compareIssues)
 
   const prViews = prs
@@ -1095,6 +1163,7 @@ async function collectGitHubDashboardData(input: {
     issues: issueViews,
     prs: prViews,
     remoteLeases,
+    issueOpsErrors,
   }
 }
 
@@ -1506,6 +1575,7 @@ export function renderDashboardHtml(): string {
                   <th>Issue</th>
                   <th>状态</th>
                   <th>可认领</th>
+                  <th>质量</th>
                   <th>租约</th>
                   <th>更新时间</th>
                 </tr>
@@ -2188,6 +2258,9 @@ function renderSummary(snapshot) {
     { label: '就绪 Issue', value: snapshot.summary.readyIssueCount, tone: '' },
     { label: '处理中 Issue', value: snapshot.summary.workingIssueCount, tone: 'accent' },
     { label: '失败 Issue', value: snapshot.summary.failedIssueCount, tone: snapshot.summary.failedIssueCount > 0 ? 'gold' : '' },
+    { label: 'Invalid Ready', value: snapshot.summary.invalidReadyIssueCount, tone: snapshot.summary.invalidReadyIssueCount > 0 ? 'error' : '' },
+    { label: 'Low Score', value: snapshot.summary.lowScoreIssueCount, tone: snapshot.summary.lowScoreIssueCount > 0 ? 'gold' : '' },
+    { label: 'Warnings', value: snapshot.summary.warningIssueCount, tone: snapshot.summary.warningIssueCount > 0 ? 'gold' : '' },
     { label: '开放 PR', value: snapshot.summary.openPrCount, tone: '' },
   ];
 
@@ -2305,7 +2378,7 @@ function renderMachines(machines) {
 
 function renderIssues(issues) {
   if (!Array.isArray(issues) || issues.length === 0) {
-    issuesBodyEl.innerHTML = '<tr><td colspan="5"><div class="empty-state">当前仓库没有返回开放的 Agent Issue。</div></td></tr>';
+    issuesBodyEl.innerHTML = '<tr><td colspan="6"><div class="empty-state">当前仓库没有返回开放的 Agent Issue。</div></td></tr>';
     return;
   }
 
@@ -2321,6 +2394,11 @@ function renderIssues(issues) {
     const contract = issue.hasExecutableContract
       ? '合约通过'
       : '合约无效：' + issue.contractValidationErrors.join('; ');
+    const issueQuality = [
+      renderChip('Score ' + issue.qualityScore, issue.qualityScore < LOW_ISSUE_QUALITY_SCORE_THRESHOLD ? 'gold' : 'accent'),
+      issue.readyGateBlocked ? renderChip('Ready Gate 阻塞', 'error') : renderChip('Ready Gate 通过', 'accent'),
+      issue.warningCount > 0 ? renderChip('Warnings ' + issue.warningCount, 'gold') : renderChip('Warnings 0', ''),
+    ].join('');
     const lease = issue.activeLease ? renderInlineLease(issue.activeLease) : '<span class="muted">无</span>';
     const linkedPrs = issue.linkedPrNumbers.length > 0
       ? '<div class="chip-row">' + issue.linkedPrNumbers.map((number) => renderChip('PR #' + number, '')).join('') + '</div>'
@@ -2335,6 +2413,7 @@ function renderIssues(issues) {
       '</td>',
       '<td>' + renderChip(localizeIssueState(issue.state), issue.state === 'working' ? 'accent' : issue.state === 'failed' ? 'error' : issue.state === 'ready' ? 'gold' : '') + '</td>',
       '<td>' + claimability + '<div class="muted" style="margin-top:8px">' + escapeHtml(deps) + '</div><div class="muted" style="margin-top:6px">' + escapeHtml(contract) + '</div></td>',
+      '<td><div class="chip-row">' + issueQuality + '</div><div class="muted" style="margin-top:8px">warning count: ' + escapeHtml(String(issue.warningCount)) + '</div></td>',
       '<td>' + lease + '</td>',
       '<td><div>' + escapeHtml(formatTimestamp(issue.updatedAt)) + '</div><div class="muted" style="margin-top:6px">' + escapeHtml(formatRelative(issue.updatedAt)) + '</div></td>',
       '</tr>',

--- a/apps/agent-daemon/src/fixtures/replay/self-bootstrap-checks-fail.json
+++ b/apps/agent-daemon/src/fixtures/replay/self-bootstrap-checks-fail.json
@@ -1,0 +1,42 @@
+{
+  "name": "self-bootstrap-checks-fail",
+  "openIssues": [
+    {
+      "number": 361,
+      "title": "failed issue after merge checks red path",
+      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 merge checks fail 的场景在 replay 中稳定呈现为 blocked human-needed path。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- replay remains local and deterministic\n\n### OutOfScope\n- live review or merge retries\n\n### RequiredSemantics\n- terminal linked PR blocks automated resume\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap checks fail fixture')\n```\n\n## 实现步骤\n1. add replay fixture\n\n## 验收\n- [ ] blocked failure stays reproducible",
+      "labels": [
+        "agent:failed"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T10:20:00.000Z"
+    }
+  ],
+  "issueComments": [
+    {
+      "issueNumber": 361,
+      "commentId": 1,
+      "body": "<!-- agent-loop:issue-resume-blocked {\"issueNumber\":361,\"prNumber\":461,\"blockedSince\":\"2026-04-11T10:18:00.000Z\",\"escalatedAt\":\"2026-04-11T10:20:00.000Z\",\"thresholdSeconds\":300,\"reason\":\"linked PR #461 is in terminal agent:human-needed after failing merge checks\",\"machineId\":\"codex-dev\",\"daemonInstanceId\":\"daemon-merge-checks\"} -->\n## agent-loop blocked resume escalation",
+      "createdAt": "2026-04-11T10:20:00.000Z",
+      "updatedAt": "2026-04-11T10:20:00.000Z"
+    }
+  ],
+  "openPullRequests": [
+    {
+      "number": 461,
+      "title": "Fix #361: failed issue after merge checks red path",
+      "labels": [
+        "agent:human-needed"
+      ],
+      "isDraft": false,
+      "headRefName": "agent/361/codex-dev",
+      "headRefOid": "def461"
+    }
+  ],
+  "expected": {
+    "claimable": 0,
+    "blocked": 1,
+    "invalid": 0
+  }
+}

--- a/apps/agent-daemon/src/fixtures/replay/self-bootstrap-checks-pending.json
+++ b/apps/agent-daemon/src/fixtures/replay/self-bootstrap-checks-pending.json
@@ -1,0 +1,42 @@
+{
+  "name": "self-bootstrap-checks-pending",
+  "openIssues": [
+    {
+      "number": 352,
+      "title": "failed issue waiting on linked PR checks to finish",
+      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 self-bootstrap replay 能稳定覆盖 linked PR checks 仍在 pending 的恢复场景。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- scenario stays local and deterministic\n\n### OutOfScope\n- live GitHub checks API or daemon polling\n\n### RequiredSemantics\n- failed issue remains blocked while the linked PR is still waiting on checks\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap checks pending fixture')\n```\n\n## 实现步骤\n1. add replay fixture for pending linked PR checks\n\n## 验收\n- [ ] linked PR checks pending path stays reproducible",
+      "labels": [
+        "agent:failed"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T10:11:00.000Z"
+    }
+  ],
+  "issueComments": [
+    {
+      "issueNumber": 352,
+      "commentId": 1,
+      "body": "<!-- agent-loop:issue-resume-blocked {\"issueNumber\":352,\"prNumber\":452,\"blockedSince\":\"2026-04-11T10:08:00.000Z\",\"escalatedAt\":\"2026-04-11T10:11:00.000Z\",\"thresholdSeconds\":300,\"reason\":\"linked PR #452 is still waiting for required self-bootstrap checks to finish before merge can resume\",\"machineId\":\"codex-dev\",\"daemonInstanceId\":\"daemon-self-bootstrap\"} -->\n## agent-loop blocked resume escalation",
+      "createdAt": "2026-04-11T10:11:00.000Z",
+      "updatedAt": "2026-04-11T10:11:00.000Z"
+    }
+  ],
+  "openPullRequests": [
+    {
+      "number": 452,
+      "title": "Fix #352: failed issue waiting on linked PR checks to finish",
+      "labels": [
+        "agent:review-approved"
+      ],
+      "isDraft": false,
+      "headRefName": "agent/352/codex-dev",
+      "headRefOid": "abc452"
+    }
+  ],
+  "expected": {
+    "claimable": 0,
+    "blocked": 1,
+    "invalid": 0
+  }
+}

--- a/apps/agent-daemon/src/fixtures/replay/self-bootstrap-closed-pr-recreate.json
+++ b/apps/agent-daemon/src/fixtures/replay/self-bootstrap-closed-pr-recreate.json
@@ -1,0 +1,31 @@
+{
+  "name": "self-bootstrap-closed-pr-recreate",
+  "openIssues": [
+    {
+      "number": 321,
+      "title": "ready issue after closed PR recreate path",
+      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 closed PR 历史不会继续阻塞 fresh PR recreate path。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/pr-reporter.ts\n\n### MustPreserve\n- replay remains local and deterministic\n\n### OutOfScope\n- touching live GitHub PR state\n\n### RequiredSemantics\n- issue is still claimable when no open linked PR remains\n\n### ReviewHints\n- verify the case stays green without network access\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap closed pr recreate fixture')\n```\n\n## 实现步骤\n1. add replay fixture\n\n## 验收\n- [ ] ready issue remains claimable",
+      "labels": [
+        "agent:ready"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T10:05:00.000Z"
+    }
+  ],
+  "issueComments": [
+    {
+      "issueNumber": 321,
+      "commentId": 1,
+      "body": "Historical note: a previous linked PR was closed and should not appear in the open PR replay state.",
+      "createdAt": "2026-04-11T10:04:00.000Z",
+      "updatedAt": "2026-04-11T10:04:00.000Z"
+    }
+  ],
+  "openPullRequests": [],
+  "expected": {
+    "claimable": 1,
+    "blocked": 0,
+    "invalid": 0
+  }
+}

--- a/apps/agent-daemon/src/fixtures/replay/self-bootstrap-happy-path.json
+++ b/apps/agent-daemon/src/fixtures/replay/self-bootstrap-happy-path.json
@@ -1,0 +1,23 @@
+{
+  "name": "self-bootstrap-happy-path",
+  "openIssues": [
+    {
+      "number": 301,
+      "title": "self-bootstrap happy path child issue",
+      "body": "## 用户故事\n\n作为 agent-loop 维护者，我希望 happy path child issue 可以直接进入 claimable 队列。\n\n## Context\n\n### Dependencies\n```json\n{\"dependsOn\":[]}\n```\n\n### AllowedFiles\n- apps/agent-daemon/src/replay-eval.ts\n\n### ForbiddenFiles\n- apps/agent-daemon/src/daemon.ts\n\n### MustPreserve\n- scenario stays deterministic\n\n### OutOfScope\n- real GitHub calls\n\n### RequiredSemantics\n- issue remains claimable in replay\n\n### ReviewHints\n- check contract validity\n\n### Validation\n- `bun test apps/agent-daemon/src/replay-eval.test.ts`\n\n## RED 测试\n\n```ts\nthrow new Error('self-bootstrap happy path fixture')\n```\n\n## 实现步骤\n1. add replay fixture\n\n## 验收\n- [ ] replay case stays claimable",
+      "labels": [
+        "agent:ready"
+      ],
+      "assignees": [],
+      "state": "open",
+      "updatedAt": "2026-04-11T10:00:00.000Z"
+    }
+  ],
+  "issueComments": [],
+  "openPullRequests": [],
+  "expected": {
+    "claimable": 1,
+    "blocked": 0,
+    "invalid": 0
+  }
+}

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -9,6 +9,7 @@ import {
   cleanupManagedRuntimeRecord,
   executeIssueLintCommand,
   executeIssueRewriteCommand,
+  executeIssueSplitCommand,
   executeWakeCommand,
   executeWakeRequest,
   formatIssueLintOutput,
@@ -16,6 +17,7 @@ import {
   readManagedRuntimeLog,
   resolveIssueLintTarget,
   resolveIssueRewritePath,
+  resolveIssueSplitInput,
   resolveWakeCommand,
   startManagedRuntime,
   reconcileManagedRuntime,
@@ -332,6 +334,153 @@ describe('index helpers', () => {
 
     expect(result.markdown).toBe('## 用户故事\n\nrewritten markdown')
     expect(result.validation.valid).toBe(true)
+  })
+
+  test('resolves split inputs and requires a starting issue number', () => {
+    expect(resolveIssueSplitInput({
+      'split-file': 'docs/issues/epic.md',
+      'split-start-number': '41',
+    })).toEqual({
+      path: 'docs/issues/epic.md',
+      startingIssueNumber: 41,
+    })
+
+    expect(resolveIssueSplitInput({})).toBeNull()
+
+    expect(() => resolveIssueSplitInput({
+      'split-file': 'docs/issues/epic.md',
+    })).toThrow('--split-file requires --split-start-number')
+
+    expect(() => resolveIssueSplitInput({
+      'split-start-number': '41',
+    })).toThrow('--split-start-number requires --split-file')
+  })
+
+  test('executes local issue split through the read-only agent runner', async () => {
+    const result = await executeIssueSplitCommand({
+      path: 'docs/issues/epic.md',
+      startingIssueNumber: 41,
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/repo-root',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      readIssueDraftFile: (path) => {
+        expect(path).toBe('docs/issues/epic.md')
+        return `# [AL-EPIC] 改进 issue authoring
+
+需要补 lint、rewrite、split 三块能力`
+      },
+      splitTrackingIssue: async ({ title, body, repoRoot, issueNumberAllocator }, { runAgent }) => {
+        expect(title).toBe('[AL-EPIC] 改进 issue authoring')
+        expect(body).toContain('需要补 lint')
+        expect(repoRoot).toBe('/tmp/repo-root')
+        expect(issueNumberAllocator()).toBe(41)
+        expect(issueNumberAllocator()).toBe(42)
+
+        const response = await runAgent({
+          prompt: 'split prompt',
+          repoRoot,
+        })
+
+        expect(response.responseText).toBe('1. [AL-X] 引入 lint\n2. [AL-Y] 增加 rewrite CLI')
+
+        return {
+          parentSummary: 'summary',
+          children: [
+            {
+              issueNumber: 41,
+              title: '[AL-X] 引入 lint',
+              body: 'child body 41',
+              validation: {
+                source: { kind: 'file', path: 'child-41.md' },
+                valid: true,
+                readyGateBlocked: false,
+                readyGateStatus: 'pass',
+                readyGateSummary: 'ready gate would pass hard validation checks',
+                score: 100,
+                errors: [],
+                warnings: [],
+                contract: { allowedFiles: ['apps/agent-daemon/src/audit-issue-contracts.ts'] },
+              },
+              authoringContext: {
+                candidateValidationCommands: ['bun run typecheck'],
+                candidateAllowedFiles: ['apps/agent-daemon/src/audit-issue-contracts.ts'],
+                candidateForbiddenFiles: ['package.json'],
+              },
+            },
+          ],
+        }
+      },
+      runConfiguredAgent: async (options) => {
+        expect(options.prompt).toBe('split prompt')
+        expect(options.worktreePath).toBe('/tmp/repo-root')
+        expect(options.allowWrites).toBe(false)
+        expect(options.config.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          ok: true,
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+          responseText: '1. [AL-X] 引入 lint\n2. [AL-Y] 增加 rewrite CLI',
+          usedAgent: 'codex',
+          usedFallback: false,
+        }
+      },
+    })
+
+    expect(result.parentSummary).toBe('summary')
+    expect(result.children).toHaveLength(1)
   })
 
   test('resolves wake commands and validates targeted wake numbers', () => {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -7,16 +7,19 @@ import {
   buildManagedRestartArgs,
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
+  executeAuditIssuesCommand,
   executeIssueLintCommand,
   executeIssueSimulationCommand,
   executeIssueRewriteCommand,
   executeIssueSplitCommand,
   executeWakeCommand,
   executeWakeRequest,
+  formatAuditIssuesOutput,
   formatIssueLintOutput,
   formatIssueSimulationOutput,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
+  resolveAuditIssuesInput,
   resolveIssueLintTarget,
   resolveIssueRewritePath,
   resolveIssueSimulationTarget,
@@ -27,6 +30,7 @@ import {
   formatLaunchdStatus,
   formatRuntimeListing,
   restartManagedRuntime,
+  shouldFailAuditIssuesCommand,
   shouldRemoveManagedRuntimeRecord,
   stopManagedRuntime,
 } from './index'
@@ -67,6 +71,324 @@ describe('index helpers', () => {
       'lint-issue': '36',
       'lint-file': 'docs/issues/ready.md',
     })).toThrow('Only one of --lint-issue or --lint-file can be used at a time')
+  })
+
+  test('resolves audit-issues selections and validates dependent flags', () => {
+    expect(resolveAuditIssuesInput({
+      'audit-issues': true,
+    })).toEqual({
+      issueNumbers: [],
+      includeSimulation: false,
+    })
+
+    expect(resolveAuditIssuesInput({
+      'audit-issues': true,
+      issue: ['50', '51', '50'],
+      simulate: true,
+    })).toEqual({
+      issueNumbers: [50, 51],
+      includeSimulation: true,
+    })
+
+    expect(() => resolveAuditIssuesInput({
+      issue: ['50'],
+    })).toThrow('--issue requires --audit-issues')
+
+    expect(() => resolveAuditIssuesInput({
+      simulate: true,
+    })).toThrow('--simulate requires --audit-issues')
+  })
+
+  test('executes audit-issues against default open managed issues without simulation', async () => {
+    const result = await executeAuditIssuesCommand({
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/repo-root',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      loadIssuesForAudit: async ({ config, issueNumbers }) => {
+        expect(config.repo).toBe('JamesWuHK/agent-loop')
+        expect(issueNumbers).toEqual([])
+
+        return [{
+          number: 50,
+          title: '[AL-11] 增加 repo issue audit report CLI 与 JSON 输出',
+          body: 'body',
+          state: 'ready',
+          labels: ['agent:ready'],
+          isClaimable: true,
+          updatedAt: '2026-04-12T10:00:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: true,
+          dependencyParseError: false,
+          claimBlockedBy: [],
+          hasExecutableContract: true,
+          contractValidationErrors: [],
+          assignee: null,
+        }]
+      },
+      auditIssues: async ({ issues, repo, includeSimulation, repoRoot, runPlanner }) => {
+        expect(repo).toBe('JamesWuHK/agent-loop')
+        expect(includeSimulation).toBeUndefined()
+        expect(repoRoot).toBe('/tmp/repo-root')
+        expect(runPlanner).toBeUndefined()
+        expect(issues).toHaveLength(1)
+
+        return {
+          summary: {
+            auditedIssueCount: 1,
+            invalidIssueCount: 0,
+            invalidReadyIssueCount: 0,
+            lowScoreIssueCount: 0,
+            warningIssueCount: 0,
+          },
+          issues: [],
+        }
+      },
+      runConfiguredAgent: async () => {
+        throw new Error('audit without --simulate should not invoke the agent')
+      },
+    })
+
+    expect(result).toEqual({
+      report: {
+        summary: {
+          auditedIssueCount: 1,
+          invalidIssueCount: 0,
+          invalidReadyIssueCount: 0,
+          lowScoreIssueCount: 0,
+          warningIssueCount: 0,
+        },
+        issues: [],
+      },
+      explicitIssueNumbers: [],
+    })
+    expect(shouldFailAuditIssuesCommand(result)).toBe(false)
+  })
+
+  test('executes audit-issues for an explicit issue set with simulation and exposes failure exit semantics', async () => {
+    const result = await executeAuditIssuesCommand({
+      issueNumbers: [50, 53],
+      includeSimulation: true,
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/repo-root',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      loadIssuesForAudit: async ({ config, issueNumbers }) => {
+        expect(config.repo).toBe('JamesWuHK/agent-loop')
+        expect(issueNumbers).toEqual([50, 53])
+
+        return [{
+          number: 53,
+          title: '[AL-13] 增加 issue repair CLI 并消费 lint / simulate findings',
+          body: 'body',
+          state: 'ready',
+          labels: ['agent:ready'],
+          isClaimable: false,
+          updatedAt: '2026-04-12T10:01:00.000Z',
+          dependencyIssueNumbers: [],
+          hasDependencyMetadata: true,
+          dependencyParseError: false,
+          claimBlockedBy: [50],
+          hasExecutableContract: false,
+          contractValidationErrors: ['missing ## RED 测试 / RED Tests'],
+          assignee: null,
+        }]
+      },
+      auditIssues: async ({ issues, repo, includeSimulation, repoRoot, runPlanner }) => {
+        expect(repo).toBe('JamesWuHK/agent-loop')
+        expect(includeSimulation).toBe(true)
+        expect(repoRoot).toBe('/tmp/repo-root')
+        expect(issues).toHaveLength(1)
+
+        const response = await runPlanner!({
+          prompt: 'audit simulate prompt',
+          repoRoot: '/tmp/repo-root',
+        })
+
+        expect(response.responseText).toBe('1. Simulate the issue audit plan')
+
+        return {
+          summary: {
+            auditedIssueCount: 1,
+            invalidIssueCount: 1,
+            invalidReadyIssueCount: 1,
+            lowScoreIssueCount: 1,
+            warningIssueCount: 1,
+          },
+          issues: [
+            {
+              number: 53,
+              title: '[AL-13] 增加 issue repair CLI 并消费 lint / simulate findings',
+              state: 'ready',
+              labels: ['agent:ready'],
+              isClaimable: false,
+              hasExecutableContract: false,
+              claimBlockedBy: [50],
+              contractValidationErrors: ['missing ## RED 测试 / RED Tests'],
+              qualityScore: 70,
+              contractWarnings: ['AllowedFiles should use exact paths or tightly scoped directories: frontend files'],
+              contract: {
+                source: {
+                  kind: 'issue',
+                  issueNumber: 53,
+                  repo: 'JamesWuHK/agent-loop',
+                },
+                valid: false,
+                readyGateBlocked: true,
+                readyGateStatus: 'blocked',
+                readyGateSummary: 'ready gate would still block on hard validation errors',
+                score: 70,
+                errors: ['missing ## RED 测试 / RED Tests'],
+                warnings: ['AllowedFiles should use exact paths or tightly scoped directories: frontend files'],
+                contract: {
+                  allowedFiles: ['frontend files'],
+                },
+              } as any,
+              simulation: {
+                valid: false,
+                failures: ['planning output does not contain commit-shaped subtasks'],
+                plannerOutput: response.responseText,
+                checks: {
+                  commitShapedPlan: false,
+                  scopedAllowedFiles: true,
+                  specificValidation: true,
+                },
+              },
+            },
+          ],
+        }
+      },
+      runConfiguredAgent: async (options) => {
+        expect(options.prompt).toBe('audit simulate prompt')
+        expect(options.worktreePath).toBe('/tmp/repo-root')
+        expect(options.allowWrites).toBe(false)
+        expect(options.config.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          ok: true,
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+          responseText: '1. Simulate the issue audit plan',
+          usedAgent: 'codex',
+          usedFallback: false,
+        }
+      },
+    })
+
+    expect(result.explicitIssueNumbers).toEqual([50, 53])
+    expect(shouldFailAuditIssuesCommand(result)).toBe(true)
+    expect(JSON.parse(formatAuditIssuesOutput(result.report, true))).toMatchObject({
+      summary: {
+        invalidIssueCount: 1,
+      },
+      issues: [
+        {
+          number: 53,
+          state: 'ready',
+        },
+      ],
+    })
   })
 
   test('executes local issue lint without loading remote config', async () => {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
   executeAuditIssuesCommand,
+  executeIssueApplyCommand,
   executeIssueLintCommand,
   executeIssueRepairCommand,
   executeIssueSimulationCommand,
@@ -16,12 +17,14 @@ import {
   executeWakeCommand,
   executeWakeRequest,
   formatAuditIssuesOutput,
+  formatIssueApplyOutput,
   formatIssueLintOutput,
   formatIssueRepairOutput,
   formatIssueSimulationOutput,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
   resolveAuditIssuesInput,
+  resolveIssueApplyInput,
   resolveIssueLintTarget,
   resolveIssueRepairInput,
   resolveIssueRewritePath,
@@ -34,6 +37,7 @@ import {
   formatRuntimeListing,
   restartManagedRuntime,
   shouldFailAuditIssuesCommand,
+  shouldFailIssueApplyCommand,
   shouldFailIssueRepairCommand,
   shouldRemoveManagedRuntimeRecord,
   stopManagedRuntime,
@@ -93,6 +97,11 @@ describe('index helpers', () => {
       issueNumbers: [50, 51],
       includeSimulation: true,
     })
+
+    expect(resolveAuditIssuesInput({
+      'apply-file': 'docs/issues/ready.md',
+      issue: ['54'],
+    })).toBeNull()
 
     expect(resolveAuditIssuesInput({
       'repair-file': 'docs/issues/broken.md',
@@ -561,6 +570,56 @@ describe('index helpers', () => {
     })).toThrow('--rewrite-file must be a non-empty path')
   })
 
+  test('resolves apply file inputs and enforces stale-write guards', () => {
+    expect(resolveIssueApplyInput({
+      'apply-file': 'docs/issues/ready.md',
+      issue: ['54'],
+      'expected-updated-at': '2026-04-12T08:00:00.000Z',
+    })).toEqual({
+      path: 'docs/issues/ready.md',
+      issueNumber: 54,
+      expectedUpdatedAt: '2026-04-12T08:00:00.000Z',
+      force: false,
+    })
+
+    expect(resolveIssueApplyInput({
+      'apply-file': 'docs/issues/ready.md',
+      issue: ['54'],
+      force: true,
+    })).toEqual({
+      path: 'docs/issues/ready.md',
+      issueNumber: 54,
+      force: true,
+    })
+
+    expect(resolveIssueApplyInput({})).toBeNull()
+
+    expect(() => resolveIssueApplyInput({
+      'expected-updated-at': '2026-04-12T08:00:00.000Z',
+    })).toThrow('--expected-updated-at requires --apply-file')
+
+    expect(() => resolveIssueApplyInput({
+      'apply-file': 'docs/issues/ready.md',
+    })).toThrow('--apply-file requires --issue')
+
+    expect(() => resolveIssueApplyInput({
+      'apply-file': 'docs/issues/ready.md',
+      issue: ['54', '55'],
+      force: true,
+    })).toThrow('--apply-file requires exactly one --issue')
+
+    expect(() => resolveIssueApplyInput({
+      'apply-file': 'docs/issues/ready.md',
+      issue: ['54'],
+    })).toThrow('--apply-file requires --expected-updated-at unless --force is provided')
+
+    expect(() => resolveIssueApplyInput({
+      'apply-file': 'docs/issues/ready.md',
+      issue: ['54'],
+      'expected-updated-at': 'not-an-iso',
+    })).toThrow('--expected-updated-at must be a valid ISO-8601 timestamp')
+  })
+
   test('resolves repair file paths and shared simulate flag', () => {
     expect(resolveIssueRepairInput({
       'repair-file': 'docs/issues/broken.md',
@@ -902,6 +961,136 @@ describe('index helpers', () => {
       },
     })
     expect(formatIssueSimulationOutput(result)).toContain('source=issue:JamesWuHK/agent-loop#40')
+  })
+
+  test('executes local issue apply through the shared GitHub apply flow', async () => {
+    const result = await executeIssueApplyCommand({
+      path: 'docs/issues/ready.md',
+      issueNumber: 54,
+      expectedUpdatedAt: '2026-04-12T08:00:00.000Z',
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      readIssueDraftFile: (path) => {
+        expect(path).toBe('docs/issues/ready.md')
+        return '## 用户故事\n\ncanonical markdown'
+      },
+      applyIssueBodyUpdate: async (input) => {
+        expect(input.issueNumber).toBe(54)
+        expect(input.markdown).toBe('## 用户故事\n\ncanonical markdown')
+        expect(input.expectedUpdatedAt).toBe('2026-04-12T08:00:00.000Z')
+        expect(input.force).toBeUndefined()
+        expect(input.config.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          status: 'updated',
+          updated: true,
+          issueNumber: 54,
+          issueUrl: 'https://github.com/JamesWuHK/agent-loop/issues/54',
+          oldUpdatedAt: '2026-04-12T08:00:00.000Z',
+          newUpdatedAt: '2026-04-12T08:06:00.000Z',
+          expectedUpdatedAt: '2026-04-12T08:00:00.000Z',
+          validation: {
+            source: { kind: 'file', path: 'stdin' },
+            valid: true,
+            readyGateBlocked: false,
+            readyGateStatus: 'pass',
+            readyGateSummary: 'ready gate would pass hard validation checks',
+            score: 100,
+            errors: [],
+            warnings: [],
+            contract: {} as any,
+          },
+          message: 'Remote issue body updated',
+        }
+      },
+    })
+
+    expect(result.status).toBe('updated')
+    expect(result.updated).toBe(true)
+    expect(formatIssueApplyOutput(result)).toContain('status=updated')
+    expect(shouldFailIssueApplyCommand(result)).toBe(false)
+  })
+
+  test('formats apply json output and conflict failure semantics', () => {
+    const result = {
+      status: 'conflict',
+      updated: false,
+      issueNumber: 54,
+      issueUrl: 'https://github.com/JamesWuHK/agent-loop/issues/54',
+      oldUpdatedAt: '2026-04-12T08:05:00.000Z',
+      newUpdatedAt: null,
+      expectedUpdatedAt: '2026-04-12T08:00:00.000Z',
+      validation: {
+        source: { kind: 'file', path: 'stdin' },
+        valid: true,
+        readyGateBlocked: false,
+        readyGateStatus: 'pass',
+        readyGateSummary: 'ready gate would pass hard validation checks',
+        score: 100,
+        errors: [],
+        warnings: [],
+        contract: {} as any,
+      },
+      message: 'Remote issue updatedAt changed',
+    }
+
+    expect(shouldFailIssueApplyCommand(result as any)).toBe(true)
+    expect(JSON.parse(formatIssueApplyOutput(result as any, true))).toMatchObject({
+      status: 'conflict',
+      updated: false,
+      issueNumber: 54,
+    })
   })
 
   test('executes local issue repair through the read-only agent runner', async () => {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
   executeBootstrapGateCommand,
+  executeBootstrapScorecardCommand,
   executeBootstrapScenarioCommand,
   executeAuditIssuesCommand,
   executeIssueApplyCommand,
@@ -20,6 +21,7 @@ import {
   executeWakeRequest,
   formatAuditIssuesOutput,
   formatBootstrapGateOutput,
+  formatBootstrapScorecardOutput,
   formatBootstrapScenarioOutput,
   formatIssueApplyOutput,
   formatIssueLintOutput,
@@ -739,6 +741,107 @@ describe('index helpers', () => {
     })
 
     expect(report.ok).toBe(true)
+  })
+
+  test('executes bootstrap scorecard with repo-aware config and supports json output', async () => {
+    const scorecard = await executeBootstrapScorecardCommand({
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      buildBootstrapScorecardForRepo: async ({ config }) => {
+        expect(config.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          ready: false,
+          categoryCounts: {
+            contract_failure: 2,
+            runtime_failure: 0,
+            pr_lifecycle_failure: 1,
+            review_failure: 1,
+            github_transport_failure: 0,
+            release_process_failure: 1,
+          },
+          topBlockers: [
+            {
+              category: 'contract_failure',
+              issueNumber: null,
+              prNumber: null,
+              reason: '2 invalid ready issue(s) require executable contracts',
+            },
+          ],
+          auditSummary: {
+            managedIssueCount: 8,
+            readyIssueCount: 3,
+            invalidReadyIssueCount: 2,
+            lowScoreIssueCount: 3,
+            warningIssueCount: 1,
+          },
+        }
+      },
+    })
+
+    expect(scorecard.ready).toBe(false)
+    expect(JSON.parse(formatBootstrapScorecardOutput(scorecard, true))).toMatchObject({
+      ready: false,
+      categoryCounts: {
+        contract_failure: 2,
+        release_process_failure: 1,
+      },
+      auditSummary: {
+        invalidReadyIssueCount: 2,
+      },
+    })
+    expect(formatBootstrapScorecardOutput(scorecard)).toContain('Bootstrap Scorecard')
   })
 
   test('resolves rewrite file paths and rejects empty values', () => {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -8,15 +8,18 @@ import {
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
   executeIssueLintCommand,
+  executeIssueSimulationCommand,
   executeIssueRewriteCommand,
   executeIssueSplitCommand,
   executeWakeCommand,
   executeWakeRequest,
   formatIssueLintOutput,
+  formatIssueSimulationOutput,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
   resolveIssueLintTarget,
   resolveIssueRewritePath,
+  resolveIssueSimulationTarget,
   resolveIssueSplitInput,
   resolveWakeCommand,
   startManagedRuntime,
@@ -215,6 +218,304 @@ describe('index helpers', () => {
     expect(() => resolveIssueRewritePath({
       'rewrite-file': '   ',
     })).toThrow('--rewrite-file must be a non-empty path')
+  })
+
+  test('resolves simulate targets and rejects conflicting selectors', () => {
+    expect(resolveIssueSimulationTarget({
+      'simulate-file': 'docs/issues/simulate.md',
+    })).toEqual({
+      kind: 'file',
+      path: 'docs/issues/simulate.md',
+    })
+
+    expect(resolveIssueSimulationTarget({
+      'simulate-issue': '40',
+    })).toEqual({
+      kind: 'issue',
+      issueNumber: 40,
+    })
+
+    expect(() => resolveIssueSimulationTarget({
+      'simulate-issue': '40',
+      'simulate-file': 'docs/issues/simulate.md',
+    })).toThrow('Only one of --simulate-issue or --simulate-file can be used at a time')
+  })
+
+  test('executes local issue simulation through the read-only agent runner', async () => {
+    const result = await executeIssueSimulationCommand({
+      target: {
+        kind: 'file',
+        path: 'docs/issues/simulate.md',
+      },
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/repo-root',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      readIssueDraftFile: (path) => {
+        expect(path).toBe('docs/issues/simulate.md')
+        return [
+          '# [AL-10] Simulate local draft',
+          '',
+          '## 用户故事',
+          '作为维护者，我希望本地 draft 也能直接 simulate。',
+        ].join('\n')
+      },
+      fetchRemoteIssueDocument: async () => {
+        throw new Error('should not fetch a remote issue for local simulation')
+      },
+      simulateIssueExecutability: async ({ issueTitle, issueBody, repoRoot, runPlanner }) => {
+        expect(issueTitle).toBe('[AL-10] Simulate local draft')
+        expect(issueBody).toBe('## 用户故事\n作为维护者，我希望本地 draft 也能直接 simulate。')
+        expect(repoRoot).toBe('/tmp/repo-root')
+
+        const response = await runPlanner({
+          prompt: 'simulate prompt',
+          repoRoot: '/tmp/repo-root',
+        })
+
+        expect(response.responseText).toBe('1. Add local simulate coverage')
+
+        return {
+          valid: true,
+          failures: [],
+          plannerOutput: response.responseText,
+          checks: {
+            commitShapedPlan: true,
+            scopedAllowedFiles: true,
+            specificValidation: true,
+          },
+        }
+      },
+      runConfiguredAgent: async (options) => {
+        expect(options.prompt).toBe('simulate prompt')
+        expect(options.worktreePath).toBe('/tmp/repo-root')
+        expect(options.allowWrites).toBe(false)
+        expect(options.config.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          ok: true,
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+          responseText: '1. Add local simulate coverage',
+          usedAgent: 'codex',
+          usedFallback: false,
+        }
+      },
+    })
+
+    expect(result).toEqual({
+      source: {
+        kind: 'file',
+        path: 'docs/issues/simulate.md',
+        title: '[AL-10] Simulate local draft',
+      },
+      result: {
+        valid: true,
+        failures: [],
+        plannerOutput: '1. Add local simulate coverage',
+        checks: {
+          commitShapedPlan: true,
+          scopedAllowedFiles: true,
+          specificValidation: true,
+        },
+      },
+    })
+    expect(JSON.parse(formatIssueSimulationOutput(result, true))).toMatchObject({
+      source: {
+        kind: 'file',
+        path: 'docs/issues/simulate.md',
+      },
+      result: {
+        valid: true,
+      },
+    })
+  })
+
+  test('executes remote issue simulation with repo-aware config', async () => {
+    const result = await executeIssueSimulationCommand({
+      target: {
+        kind: 'issue',
+        issueNumber: 40,
+      },
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/repo-root',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      readIssueDraftFile: () => {
+        throw new Error('should not read a local file for remote simulation')
+      },
+      fetchRemoteIssueDocument: async ({ issueNumber, config }) => {
+        expect(issueNumber).toBe(40)
+        expect(config.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          number: 40,
+          title: '[AL-10] Simulate remote issue',
+          body: '## 用户故事\n作为维护者，我希望远端 issue 也能 simulate。',
+          url: 'https://github.com/JamesWuHK/agent-loop/issues/40',
+        }
+      },
+      simulateIssueExecutability: async ({ issueTitle, issueBody, repoRoot, runPlanner }) => {
+        expect(issueTitle).toBe('[AL-10] Simulate remote issue')
+        expect(issueBody).toBe('## 用户故事\n作为维护者，我希望远端 issue 也能 simulate。')
+        expect(repoRoot).toBe('/tmp/repo-root')
+
+        const response = await runPlanner({
+          prompt: 'remote simulate prompt',
+          repoRoot: '/tmp/repo-root',
+        })
+
+        expect(response.responseText).toBe('1. Implement remote simulate path')
+
+        return {
+          valid: false,
+          failures: ['planning output does not contain commit-shaped subtasks'],
+          plannerOutput: response.responseText,
+          checks: {
+            commitShapedPlan: false,
+            scopedAllowedFiles: true,
+            specificValidation: true,
+          },
+        }
+      },
+      runConfiguredAgent: async (options) => {
+        expect(options.prompt).toBe('remote simulate prompt')
+        expect(options.worktreePath).toBe('/tmp/repo-root')
+        expect(options.allowWrites).toBe(false)
+        expect(options.config.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          ok: true,
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+          responseText: '1. Implement remote simulate path',
+          usedAgent: 'codex',
+          usedFallback: false,
+        }
+      },
+    })
+
+    expect(result).toEqual({
+      source: {
+        kind: 'issue',
+        issueNumber: 40,
+        repo: 'JamesWuHK/agent-loop',
+        title: '[AL-10] Simulate remote issue',
+      },
+      result: {
+        valid: false,
+        failures: ['planning output does not contain commit-shaped subtasks'],
+        plannerOutput: '1. Implement remote simulate path',
+        checks: {
+          commitShapedPlan: false,
+          scopedAllowedFiles: true,
+          specificValidation: true,
+        },
+      },
+    })
+    expect(formatIssueSimulationOutput(result)).toContain('source=issue:JamesWuHK/agent-loop#40')
   })
 
   test('executes local issue rewrite through the read-only agent runner', async () => {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -9,6 +9,7 @@ import {
   cleanupManagedRuntimeRecord,
   executeAuditIssuesCommand,
   executeIssueLintCommand,
+  executeIssueRepairCommand,
   executeIssueSimulationCommand,
   executeIssueRewriteCommand,
   executeIssueSplitCommand,
@@ -16,11 +17,13 @@ import {
   executeWakeRequest,
   formatAuditIssuesOutput,
   formatIssueLintOutput,
+  formatIssueRepairOutput,
   formatIssueSimulationOutput,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
   resolveAuditIssuesInput,
   resolveIssueLintTarget,
+  resolveIssueRepairInput,
   resolveIssueRewritePath,
   resolveIssueSimulationTarget,
   resolveIssueSplitInput,
@@ -31,6 +34,7 @@ import {
   formatRuntimeListing,
   restartManagedRuntime,
   shouldFailAuditIssuesCommand,
+  shouldFailIssueRepairCommand,
   shouldRemoveManagedRuntimeRecord,
   stopManagedRuntime,
 } from './index'
@@ -89,6 +93,11 @@ describe('index helpers', () => {
       issueNumbers: [50, 51],
       includeSimulation: true,
     })
+
+    expect(resolveAuditIssuesInput({
+      'repair-file': 'docs/issues/broken.md',
+      simulate: true,
+    })).toBeNull()
 
     expect(() => resolveAuditIssuesInput({
       issue: ['50'],
@@ -346,8 +355,18 @@ describe('index helpers', () => {
               } as any,
               simulation: {
                 valid: false,
+                summary: 'simulation failed',
                 failures: ['planning output does not contain commit-shaped subtasks'],
+                findings: [
+                  {
+                    code: 'planning_not_commit_shaped',
+                    stage: 'planner',
+                    message: 'planning output does not contain commit-shaped subtasks',
+                  },
+                ],
+                plannerPrompt: 'audit simulate prompt',
                 plannerOutput: response.responseText,
+                plannedSubtasks: ['Simulate the issue audit plan'],
                 checks: {
                   commitShapedPlan: false,
                   scopedAllowedFiles: true,
@@ -542,6 +561,22 @@ describe('index helpers', () => {
     })).toThrow('--rewrite-file must be a non-empty path')
   })
 
+  test('resolves repair file paths and shared simulate flag', () => {
+    expect(resolveIssueRepairInput({
+      'repair-file': 'docs/issues/broken.md',
+      simulate: true,
+    })).toEqual({
+      path: 'docs/issues/broken.md',
+      includeSimulation: true,
+    })
+
+    expect(resolveIssueRepairInput({})).toBeNull()
+
+    expect(() => resolveIssueRepairInput({
+      'repair-file': '   ',
+    })).toThrow('--repair-file must be a non-empty path')
+  })
+
   test('resolves simulate targets and rejects conflicting selectors', () => {
     expect(resolveIssueSimulationTarget({
       'simulate-file': 'docs/issues/simulate.md',
@@ -649,8 +684,12 @@ describe('index helpers', () => {
 
         return {
           valid: true,
+          summary: 'simulation passed',
           failures: [],
+          findings: [],
+          plannerPrompt: 'simulate prompt',
           plannerOutput: response.responseText,
+          plannedSubtasks: ['Add local simulate coverage'],
           checks: {
             commitShapedPlan: true,
             scopedAllowedFiles: true,
@@ -684,8 +723,12 @@ describe('index helpers', () => {
       },
       result: {
         valid: true,
+        summary: 'simulation passed',
         failures: [],
+        findings: [],
+        plannerPrompt: 'simulate prompt',
         plannerOutput: '1. Add local simulate coverage',
+        plannedSubtasks: ['Add local simulate coverage'],
         checks: {
           commitShapedPlan: true,
           scopedAllowedFiles: true,
@@ -700,6 +743,7 @@ describe('index helpers', () => {
       },
       result: {
         valid: true,
+        summary: 'simulation passed',
       },
     })
   })
@@ -792,8 +836,18 @@ describe('index helpers', () => {
 
         return {
           valid: false,
+          summary: 'simulation failed',
           failures: ['planning output does not contain commit-shaped subtasks'],
+          findings: [
+            {
+              code: 'planning_not_commit_shaped',
+              stage: 'planner',
+              message: 'planning output does not contain commit-shaped subtasks',
+            },
+          ],
+          plannerPrompt: 'remote simulate prompt',
           plannerOutput: response.responseText,
+          plannedSubtasks: ['Implement remote simulate path'],
           checks: {
             commitShapedPlan: false,
             scopedAllowedFiles: true,
@@ -828,8 +882,18 @@ describe('index helpers', () => {
       },
       result: {
         valid: false,
+        summary: 'simulation failed',
         failures: ['planning output does not contain commit-shaped subtasks'],
+        findings: [
+          {
+            code: 'planning_not_commit_shaped',
+            stage: 'planner',
+            message: 'planning output does not contain commit-shaped subtasks',
+          },
+        ],
+        plannerPrompt: 'remote simulate prompt',
         plannerOutput: '1. Implement remote simulate path',
+        plannedSubtasks: ['Implement remote simulate path'],
         checks: {
           commitShapedPlan: false,
           scopedAllowedFiles: true,
@@ -838,6 +902,274 @@ describe('index helpers', () => {
       },
     })
     expect(formatIssueSimulationOutput(result)).toContain('source=issue:JamesWuHK/agent-loop#40')
+  })
+
+  test('executes local issue repair through the read-only agent runner', async () => {
+    let plannerInvocation = 0
+
+    const result = await executeIssueRepairCommand({
+      path: 'docs/issues/broken.md',
+      includeSimulation: true,
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/repo-root',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      readIssueDraftFile: (path) => {
+        expect(path).toBe('docs/issues/broken.md')
+        return 'broken issue markdown'
+      },
+      repairIssueDraft: async ({ issueText, repoRoot, includeSimulation }, { runAgent, runPlanner }) => {
+        expect(issueText).toBe('broken issue markdown')
+        expect(repoRoot).toBe('/tmp/repo-root')
+        expect(includeSimulation).toBe(true)
+
+        const repairResponse = await runAgent({
+          prompt: 'repair prompt',
+          repoRoot,
+        })
+
+        expect(repairResponse.responseText).toBe('## 用户故事\n\nrepaired markdown')
+
+        const beforeSimulation = await runPlanner!({
+          prompt: 'repair simulate before prompt',
+          repoRoot,
+        })
+        const afterSimulation = await runPlanner!({
+          prompt: 'repair simulate after prompt',
+          repoRoot,
+        })
+
+        expect(beforeSimulation.responseText).toBe('1. Simulate repair before state')
+        expect(afterSimulation.responseText).toBe('1. Simulate repair after state')
+
+        return {
+          success: true,
+          repairedMarkdown: repairResponse.responseText,
+          appliedFindingCodes: ['allowed_files_too_broad'],
+          blockingFindings: [],
+          before: {
+            validation: {
+              source: { kind: 'file', path: 'stdin' },
+              valid: false,
+              readyGateBlocked: true,
+              readyGateStatus: 'blocked',
+              readyGateSummary: 'ready gate would still block on hard validation errors',
+              score: 72,
+              errors: ['missing ### Constraints / Constraints'],
+              warnings: [],
+              contract: {} as any,
+            },
+            simulation: {
+              valid: false,
+              summary: 'simulation failed',
+              failures: ['planning output does not contain commit-shaped subtasks'],
+              findings: [
+                {
+                  code: 'planning_not_commit_shaped',
+                  stage: 'planner',
+                  message: 'planning output does not contain commit-shaped subtasks',
+                },
+              ],
+              plannerPrompt: 'repair simulate before prompt',
+              plannerOutput: beforeSimulation.responseText,
+              plannedSubtasks: ['Simulate repair before state'],
+              checks: {
+                commitShapedPlan: false,
+                scopedAllowedFiles: true,
+                specificValidation: true,
+              },
+            },
+          },
+          after: {
+            validation: {
+              source: { kind: 'file', path: 'stdout' },
+              valid: true,
+              readyGateBlocked: false,
+              readyGateStatus: 'pass',
+              readyGateSummary: 'ready gate would pass hard validation checks',
+              score: 100,
+              errors: [],
+              warnings: [],
+              contract: {} as any,
+            },
+            simulation: {
+              valid: true,
+              summary: 'simulation passed',
+              failures: [],
+              findings: [],
+              plannerPrompt: 'repair simulate after prompt',
+              plannerOutput: afterSimulation.responseText,
+              plannedSubtasks: ['Simulate repair after state'],
+              checks: {
+                commitShapedPlan: true,
+                scopedAllowedFiles: true,
+                specificValidation: true,
+              },
+            },
+          },
+          authoringContext: {
+            candidateValidationCommands: [
+              'bun test apps/agent-daemon/src/issue-repair.test.ts',
+            ],
+            candidateAllowedFiles: [
+              'apps/agent-daemon/src/issue-repair.ts',
+            ],
+            candidateForbiddenFiles: [
+              'apps/agent-daemon/src/dashboard.ts',
+            ],
+            candidateReviewHints: [
+              '检查 repair 是否保留 Dependencies JSON',
+            ],
+            projectIssueRules: {
+              preferredValidationCommands: [
+                'bun test apps/agent-daemon/src/issue-repair.test.ts',
+              ],
+              preferredAllowedFiles: [
+                'apps/agent-daemon/src/issue-repair.ts',
+              ],
+              forbiddenPaths: [
+                'apps/agent-daemon/src/dashboard.ts',
+              ],
+              reviewHints: [
+                '检查 repair 是否保留 Dependencies JSON',
+              ],
+            },
+          },
+        }
+      },
+      runConfiguredAgent: async (options) => {
+        expect(options.worktreePath).toBe('/tmp/repo-root')
+        expect(options.allowWrites).toBe(false)
+        expect(options.config.repo).toBe('JamesWuHK/agent-loop')
+
+        if (options.prompt === 'repair prompt') {
+          return {
+            ok: true,
+            exitCode: 0,
+            stdout: '',
+            stderr: '',
+            responseText: '## 用户故事\n\nrepaired markdown',
+            usedAgent: 'codex',
+            usedFallback: false,
+          }
+        }
+
+        plannerInvocation += 1
+        return {
+          ok: true,
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+          responseText: plannerInvocation === 1
+            ? '1. Simulate repair before state'
+            : '1. Simulate repair after state',
+          usedAgent: 'codex',
+          usedFallback: false,
+        }
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.repairedMarkdown).toBe('## 用户故事\n\nrepaired markdown')
+    expect(formatIssueRepairOutput(result)).toBe('## 用户故事\n\nrepaired markdown')
+    expect(shouldFailIssueRepairCommand(result)).toBe(false)
+  })
+
+  test('formats repair json output and failure exit semantics', () => {
+    const result = {
+      success: false,
+      repairedMarkdown: '## 用户故事\n\nstill broken',
+      appliedFindingCodes: ['missing_dependencies_block'],
+      blockingFindings: ['missing ### Dependencies JSON block'],
+      before: {
+        validation: {
+          source: { kind: 'file', path: 'stdin' },
+          valid: false,
+          readyGateBlocked: true,
+          readyGateStatus: 'blocked',
+          readyGateSummary: 'ready gate would still block on hard validation errors',
+          score: 60,
+          errors: ['missing ### Dependencies JSON block'],
+          warnings: [],
+          contract: {} as any,
+        },
+      },
+      after: {
+        validation: {
+          source: { kind: 'file', path: 'stdout' },
+          valid: false,
+          readyGateBlocked: true,
+          readyGateStatus: 'blocked',
+          readyGateSummary: 'ready gate would still block on hard validation errors',
+          score: 60,
+          errors: ['missing ### Dependencies JSON block'],
+          warnings: [],
+          contract: {} as any,
+        },
+      },
+      authoringContext: {
+        candidateValidationCommands: [],
+        candidateAllowedFiles: [],
+        candidateForbiddenFiles: [],
+      },
+    }
+
+    expect(shouldFailIssueRepairCommand(result as any)).toBe(true)
+    expect(JSON.parse(formatIssueRepairOutput(result as any, true))).toMatchObject({
+      success: false,
+      repairedMarkdown: '## 用户故事\n\nstill broken',
+      blockingFindings: ['missing ### Dependencies JSON block'],
+    })
   })
 
   test('executes local issue rewrite through the read-only agent runner', async () => {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
   executeBootstrapGateCommand,
+  executeBootstrapScenarioCommand,
   executeAuditIssuesCommand,
   executeIssueApplyCommand,
   executeIssueLintCommand,
@@ -19,6 +20,7 @@ import {
   executeWakeRequest,
   formatAuditIssuesOutput,
   formatBootstrapGateOutput,
+  formatBootstrapScenarioOutput,
   formatIssueApplyOutput,
   formatIssueLintOutput,
   formatIssueRepairOutput,
@@ -663,6 +665,80 @@ describe('index helpers', () => {
       ],
     })
     expect(formatBootstrapGateOutput(report)).toContain('Bootstrap Gate')
+  })
+
+  test('executes bootstrap scenarios locally and supports json output', async () => {
+    const report = await executeBootstrapScenarioCommand({
+      fixturesDir: '/tmp/self-bootstrap-suite',
+    }, {
+      evaluateBootstrapScenarioFixtureDirectory: (fixturesDir) => {
+        expect(fixturesDir).toBe('/tmp/self-bootstrap-suite')
+
+        return {
+          suite: 'self-bootstrap-v0.2',
+          ok: false,
+          cases: [
+            {
+              name: 'self-bootstrap-happy-path',
+              ok: true,
+              present: true,
+              mismatches: [],
+              actual: { claimable: 1, blocked: 0, invalid: 0 },
+              expected: { claimable: 1, blocked: 0, invalid: 0 },
+            },
+            {
+              name: 'self-bootstrap-checks-fail',
+              ok: false,
+              present: true,
+              mismatches: ['blocked: expected 0, received 1'],
+              actual: { claimable: 0, blocked: 1, invalid: 0 },
+              expected: { claimable: 0, blocked: 0, invalid: 0 },
+            },
+          ],
+          failedCases: ['self-bootstrap-checks-fail'],
+          summary: {
+            requiredCases: 4,
+            presentCases: 2,
+            passedCases: 1,
+            failedCases: 1,
+          },
+        }
+      },
+    })
+
+    expect(report.ok).toBe(false)
+    expect(JSON.parse(formatBootstrapScenarioOutput(report, true))).toMatchObject({
+      suite: 'self-bootstrap-v0.2',
+      ok: false,
+      failedCases: ['self-bootstrap-checks-fail'],
+      summary: {
+        requiredCases: 4,
+      },
+    })
+    expect(formatBootstrapScenarioOutput(report)).toContain('Bootstrap Scenarios')
+  })
+
+  test('resolves the default bootstrap fixture directory from the CLI module location', async () => {
+    const report = await executeBootstrapScenarioCommand({}, {
+      evaluateBootstrapScenarioFixtureDirectory: (fixturesDir) => {
+        expect(fixturesDir).toBe(join(import.meta.dir, 'fixtures', 'replay'))
+
+        return {
+          suite: 'self-bootstrap-v0.2',
+          ok: true,
+          cases: [],
+          failedCases: [],
+          summary: {
+            requiredCases: 4,
+            presentCases: 4,
+            passedCases: 4,
+            failedCases: 0,
+          },
+        }
+      },
+    })
+
+    expect(report.ok).toBe(true)
   })
 
   test('resolves rewrite file paths and rejects empty values', () => {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   buildManagedRestartArgs,
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
+  executeBootstrapGateCommand,
   executeAuditIssuesCommand,
   executeIssueApplyCommand,
   executeIssueLintCommand,
@@ -17,6 +18,7 @@ import {
   executeWakeCommand,
   executeWakeRequest,
   formatAuditIssuesOutput,
+  formatBootstrapGateOutput,
   formatIssueApplyOutput,
   formatIssueLintOutput,
   formatIssueRepairOutput,
@@ -556,6 +558,111 @@ describe('index helpers', () => {
         repo: 'JamesWuHK/agent-loop',
       },
     })
+  })
+
+  test('executes bootstrap gate with repo-aware config and supports json output', async () => {
+    const report = await executeBootstrapGateCommand({
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      buildBootstrapGateReportForRepo: async ({ config }) => {
+        expect(config.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          version: 'v0.2',
+          ready: false,
+          blockers: [
+            {
+              issueNumber: 37,
+              state: 'working',
+              labels: ['agent:working'],
+              title: '[AL-7] repo grounded context',
+            },
+          ],
+          requiredEvidence: [
+            {
+              code: 'self_bootstrap_suite_green',
+              satisfied: false,
+              sourceIssueNumber: 69,
+              summary: 'awaiting the deterministic self-bootstrap scenario suite tracked by #69',
+            },
+          ],
+          blockingReasons: [
+            'issue #37 is not done (state=working, labels=agent:working)',
+            'missing required evidence: self_bootstrap_suite_green',
+          ],
+        }
+      },
+    })
+
+    expect(report.ready).toBe(false)
+    expect(JSON.parse(formatBootstrapGateOutput(report, true))).toMatchObject({
+      version: 'v0.2',
+      ready: false,
+      blockers: [
+        {
+          issueNumber: 37,
+          state: 'working',
+        },
+      ],
+      requiredEvidence: [
+        {
+          code: 'self_bootstrap_suite_green',
+          satisfied: false,
+        },
+      ],
+    })
+    expect(formatBootstrapGateOutput(report)).toContain('Bootstrap Gate')
   })
 
   test('resolves rewrite file paths and rejects empty values', () => {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   buildManagedRestartArgs,
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
+  executeBootstrapConvergenceCommand,
   executeBootstrapGateCommand,
   executeBootstrapScorecardCommand,
   executeBootstrapScenarioCommand,
@@ -20,6 +21,7 @@ import {
   executeWakeCommand,
   executeWakeRequest,
   formatAuditIssuesOutput,
+  formatBootstrapConvergenceOutput,
   formatBootstrapGateOutput,
   formatBootstrapScorecardOutput,
   formatBootstrapScenarioOutput,
@@ -633,6 +635,7 @@ describe('index helpers', () => {
               title: '[AL-7] repo grounded context',
             },
           ],
+          suppressedBlockers: [],
           requiredEvidence: [
             {
               code: 'self_bootstrap_suite_green',
@@ -819,6 +822,15 @@ describe('index helpers', () => {
               reason: '2 invalid ready issue(s) require executable contracts',
             },
           ],
+          suppressedCategoryCounts: {
+            contract_failure: 0,
+            runtime_failure: 0,
+            pr_lifecycle_failure: 0,
+            review_failure: 0,
+            github_transport_failure: 0,
+            release_process_failure: 0,
+          },
+          suppressedBlockers: [],
           auditSummary: {
             managedIssueCount: 8,
             readyIssueCount: 3,
@@ -842,6 +854,66 @@ describe('index helpers', () => {
       },
     })
     expect(formatBootstrapScorecardOutput(scorecard)).toContain('Bootstrap Scorecard')
+  })
+
+  test('executes bootstrap convergence with repo-aware config and supports json output', async () => {
+    const report = await executeBootstrapConvergenceCommand({
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/agent-loop',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+        } as never
+      },
+      buildBootstrapConvergenceReportForRepo: async ({ config, repoRoot }) => {
+        expect(config.repo).toBe('JamesWuHK/agent-loop')
+        expect(repoRoot).toBe('/tmp/agent-loop')
+
+        return {
+          gateReady: true,
+          scorecardReady: true,
+          converged: false,
+          summary: {
+            totalActions: 2,
+            issueActions: 1,
+            pullRequestActions: 1,
+          },
+          actions: [
+            {
+              kind: 'issue_state_sync',
+              issueNumber: 37,
+              prNumber: null,
+              remoteState: 'failed',
+              categories: [],
+              reasons: [],
+              localImplementationHeadline: 'feat(#37): add repo authoring context',
+              recommendedAction: 'sync_issue_state',
+              summary: 'Issue #37 is still failed remotely even though the current branch already contains the implementation.',
+            },
+          ],
+        }
+      },
+    })
+
+    expect(report.converged).toBe(false)
+    expect(JSON.parse(formatBootstrapConvergenceOutput(report, true))).toMatchObject({
+      gateReady: true,
+      scorecardReady: true,
+      converged: false,
+      summary: {
+        totalActions: 2,
+      },
+    })
+    expect(formatBootstrapConvergenceOutput(report)).toContain('Bootstrap Convergence')
   })
 
   test('resolves rewrite file paths and rejects empty values', () => {

--- a/apps/agent-daemon/src/index.test.ts
+++ b/apps/agent-daemon/src/index.test.ts
@@ -8,12 +8,14 @@ import {
   buildManagedRuntimeLaunchArgs,
   cleanupManagedRuntimeRecord,
   executeIssueLintCommand,
+  executeIssueRewriteCommand,
   executeWakeCommand,
   executeWakeRequest,
   formatIssueLintOutput,
   formatManagedRuntimeLog,
   readManagedRuntimeLog,
   resolveIssueLintTarget,
+  resolveIssueRewritePath,
   resolveWakeCommand,
   startManagedRuntime,
   reconcileManagedRuntime,
@@ -199,6 +201,137 @@ describe('index helpers', () => {
         repo: 'JamesWuHK/agent-loop',
       },
     })
+  })
+
+  test('resolves rewrite file paths and rejects empty values', () => {
+    expect(resolveIssueRewritePath({
+      'rewrite-file': 'docs/issues/draft.md',
+    })).toBe('docs/issues/draft.md')
+
+    expect(resolveIssueRewritePath({})).toBeNull()
+
+    expect(() => resolveIssueRewritePath({
+      'rewrite-file': '   ',
+    })).toThrow('--rewrite-file must be a non-empty path')
+  })
+
+  test('executes local issue rewrite through the read-only agent runner', async () => {
+    const result = await executeIssueRewriteCommand({
+      path: 'docs/issues/draft.md',
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+      repoRoot: '/tmp/repo-root',
+    }, {
+      loadConfig: (args = {}) => {
+        expect(args).toEqual({
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+        })
+
+        return {
+          repo: 'JamesWuHK/agent-loop',
+          pat: 'ghp_test',
+          machineId: 'codex-dev',
+          concurrency: 1,
+          requestedConcurrency: 1,
+          concurrencyPolicy: {
+            requested: 1,
+            effective: 1,
+            repoCap: null,
+            profileCap: null,
+            projectCap: null,
+          },
+          scheduling: {
+            concurrencyByRepo: {},
+            concurrencyByProfile: {},
+          },
+          pollIntervalMs: 60_000,
+          idlePollIntervalMs: 300_000,
+          recovery: {
+            heartbeatIntervalMs: 30_000,
+            leaseTtlMs: 60_000,
+            workerIdleTimeoutMs: 300_000,
+            leaseAdoptionBackoffMs: 5_000,
+            leaseNoProgressTimeoutMs: 360_000,
+          },
+          worktreesBase: '/tmp/agent-worktrees',
+          project: {
+            profile: 'generic',
+          },
+          agent: {
+            primary: 'codex',
+            fallback: 'claude',
+            claudePath: 'claude',
+            codexPath: 'codex',
+            timeoutMs: 300_000,
+          },
+          git: {
+            defaultBranch: 'main',
+            authorName: 'agent-loop',
+            authorEmail: 'agent-loop@example.com',
+          },
+        }
+      },
+      readIssueDraftFile: (path) => {
+        expect(path).toBe('docs/issues/draft.md')
+        return '修复 ready gate 的 validation path 提示'
+      },
+      rewriteIssueDraft: async ({ issueText, repoRoot }, { runAgent }) => {
+        expect(issueText).toBe('修复 ready gate 的 validation path 提示')
+        expect(repoRoot).toBe('/tmp/repo-root')
+
+        const response = await runAgent({
+          prompt: 'rewrite prompt',
+          repoRoot,
+        })
+
+        expect(response.responseText).toBe('## 用户故事\n\nrewritten markdown')
+
+        return {
+          markdown: response.responseText,
+          validation: {
+            source: {
+              kind: 'file',
+              path: 'stdout',
+            },
+            valid: true,
+            readyGateBlocked: false,
+            readyGateStatus: 'pass',
+            readyGateSummary: 'ready gate would pass hard validation checks',
+            score: 100,
+            errors: [],
+            warnings: [],
+            contract: {
+              allowedFiles: ['apps/agent-daemon/src/ready-gate.ts'],
+            },
+          },
+          authoringContext: {
+            candidateValidationCommands: ['bun test apps/agent-daemon/src/ready-gate.test.ts'],
+            candidateAllowedFiles: ['apps/agent-daemon/src/ready-gate.ts'],
+            candidateForbiddenFiles: ['package.json'],
+          },
+        }
+      },
+      runConfiguredAgent: async (options) => {
+        expect(options.prompt).toBe('rewrite prompt')
+        expect(options.worktreePath).toBe('/tmp/repo-root')
+        expect(options.allowWrites).toBe(false)
+        expect(options.config.repo).toBe('JamesWuHK/agent-loop')
+
+        return {
+          ok: true,
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+          responseText: '## 用户故事\n\nrewritten markdown',
+          usedAgent: 'codex',
+          usedFallback: false,
+        }
+      },
+    })
+
+    expect(result.markdown).toBe('## 用户故事\n\nrewritten markdown')
+    expect(result.validation.valid).toBe(true)
   })
 
   test('resolves wake commands and validates targeted wake numbers', () => {

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -54,6 +54,11 @@ import {
   formatIssueLintReportJson,
   type IssueLintReport,
 } from './audit-issue-contracts'
+import {
+  rewriteIssueDraft,
+  type RewriteIssueDraftResult,
+} from './issue-authoring'
+import { runConfiguredAgent } from './cli-agent'
 
 type PartialHealthServerConfig = Partial<HealthServerConfig>
 type LocalDaemonIdentityResolver = typeof resolveLocalDaemonIdentity
@@ -95,6 +100,13 @@ export interface ExecuteIssueLintInput {
   target: IssueLintTarget
   repo?: string
   pat?: string
+}
+
+export interface ExecuteIssueRewriteInput {
+  path: string
+  repo?: string
+  pat?: string
+  repoRoot?: string
 }
 
 export interface RestartManagedRuntimeInput {
@@ -174,6 +186,13 @@ interface IssueLintCommandDependencies {
   buildIssueLintReportFromRemoteIssue: typeof buildIssueLintReportFromRemoteIssue
 }
 
+interface IssueRewriteCommandDependencies {
+  loadConfig: typeof loadConfig
+  readIssueDraftFile: (path: string) => string
+  rewriteIssueDraft: typeof rewriteIssueDraft
+  runConfiguredAgent: typeof runConfiguredAgent
+}
+
 const DEFAULT_RESTART_DEPENDENCIES: RestartManagedRuntimeDependencies = {
   platform: process.platform,
   resolveLocalDaemonIdentity,
@@ -198,6 +217,13 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
   loadConfig,
   buildIssueLintReportFromMarkdownFile,
   buildIssueLintReportFromRemoteIssue,
+}
+
+const DEFAULT_ISSUE_REWRITE_COMMAND_DEPENDENCIES: IssueRewriteCommandDependencies = {
+  loadConfig,
+  readIssueDraftFile: (path) => readFileSync(path, 'utf-8'),
+  rewriteIssueDraft,
+  runConfiguredAgent,
 }
 
 async function main() {
@@ -239,6 +265,7 @@ async function main() {
       'github-event-path': { type: 'string' },
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
+      'rewrite-file': { type: 'string' },
       json: { type: 'boolean' },
       help: { type: 'boolean' },
     },
@@ -265,6 +292,9 @@ async function main() {
     'lint-issue': args['lint-issue'] as string | undefined,
     'lint-file': args['lint-file'] as string | undefined,
   })
+  const issueRewritePath = resolveIssueRewritePath({
+    'rewrite-file': args['rewrite-file'] as string | undefined,
+  })
 
   if (wakeCommand) {
     assertWakeCommandCompatible(args)
@@ -272,6 +302,44 @@ async function main() {
 
   if (issueLintTarget) {
     assertIssueLintCompatible(args)
+  }
+
+  if (issueRewritePath) {
+    assertIssueRewriteCompatible({
+      'wake-now': args['wake-now'] as boolean | undefined,
+      'wake-issue': args['wake-issue'] as string | undefined,
+      'wake-pr': args['wake-pr'] as string | undefined,
+      'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'lint-issue': args['lint-issue'] as string | undefined,
+      'lint-file': args['lint-file'] as string | undefined,
+      concurrency: args.concurrency as string | undefined,
+      'poll-interval': args['poll-interval'] as string | undefined,
+      'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
+      'machine-id': args['machine-id'] as string | undefined,
+      'dry-run': args['dry-run'] as boolean | undefined,
+      'metrics-port': args['metrics-port'] as string | undefined,
+      dashboard: args.dashboard as boolean | undefined,
+      'dashboard-host': args['dashboard-host'] as string | undefined,
+      'dashboard-port': args['dashboard-port'] as string | undefined,
+      daemonize: args.daemonize as boolean | undefined,
+      'join-project': args['join-project'] as boolean | undefined,
+      'repo-cap': args['repo-cap'] as string | undefined,
+      runtimes: args.runtimes as boolean | undefined,
+      start: args.start as boolean | undefined,
+      logs: args.logs as boolean | undefined,
+      reconcile: args.reconcile as boolean | undefined,
+      restart: args.restart as boolean | undefined,
+      'launchd-install': args['launchd-install'] as boolean | undefined,
+      'launchd-uninstall': args['launchd-uninstall'] as boolean | undefined,
+      'launchd-status': args['launchd-status'] as boolean | undefined,
+      stop: args.stop as boolean | undefined,
+      once: args.once as boolean | undefined,
+      status: args.status as boolean | undefined,
+      doctor: args.doctor as boolean | undefined,
+      'health-host': args['health-host'] as string | undefined,
+      'health-port': args['health-port'] as string | undefined,
+      json: args.json as boolean | undefined,
+    })
   }
 
   if (args['wake-from-github-event']) {
@@ -352,6 +420,17 @@ async function main() {
     })
     console.log(formatIssueLintOutput(report, args.json as boolean | undefined))
     process.exit(report.readyGateBlocked ? 1 : 0)
+  }
+
+  if (issueRewritePath) {
+    const result = await executeIssueRewriteCommand({
+      path: issueRewritePath,
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+      repoRoot: process.cwd(),
+    })
+    console.log(result.markdown)
+    process.exit(0)
   }
 
   if (args['join-project']) {
@@ -711,6 +790,7 @@ Usage:
   agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
+  agent-loop --rewrite-file <path> [--repo owner/repo]
   agent-loop --reconcile [--health-port 9310]
   agent-loop --start [--health-port 9310]
   agent-loop --dashboard [--dashboard-port 9388]
@@ -745,6 +825,7 @@ Options:
       --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
+      --rewrite-file <path>   Rewrite a local issue draft into canonical contract markdown
       --json                  Print machine-readable JSON for lint commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
@@ -789,6 +870,7 @@ Examples:
   agent-loop --wake-pr 381 --health-port 9311
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
+  agent-loop --rewrite-file docs/issues/draft.md
   agent-loop --dashboard
   agent-loop --dashboard --dashboard-port 9390
   agent-loop --join-project --machine-id macbook-pro-b --health-port 9312 --metrics-port 9092 --repo-cap 2
@@ -914,6 +996,21 @@ export function resolveIssueLintTarget(args: {
   return targets[0] ?? null
 }
 
+export function resolveIssueRewritePath(args: {
+  'rewrite-file'?: string
+}): string | null {
+  if (typeof args['rewrite-file'] !== 'string') {
+    return null
+  }
+
+  const path = args['rewrite-file'].trim()
+  if (!path) {
+    throw new Error('--rewrite-file must be a non-empty path')
+  }
+
+  return path
+}
+
 export async function executeIssueLintCommand(
   input: ExecuteIssueLintInput,
   deps: IssueLintCommandDependencies = DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES,
@@ -930,6 +1027,42 @@ export async function executeIssueLintCommand(
   return deps.buildIssueLintReportFromRemoteIssue({
     issueNumber: input.target.issueNumber!,
     config,
+  })
+}
+
+export async function executeIssueRewriteCommand(
+  input: ExecuteIssueRewriteInput,
+  deps: IssueRewriteCommandDependencies = DEFAULT_ISSUE_REWRITE_COMMAND_DEPENDENCIES,
+): Promise<RewriteIssueDraftResult> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+  const issueText = deps.readIssueDraftFile(input.path)
+  const repoRoot = input.repoRoot ?? process.cwd()
+
+  return deps.rewriteIssueDraft({
+    issueText,
+    repoRoot,
+  }, {
+    runAgent: async ({ prompt, repoRoot: worktreePath }) => {
+      const result = await deps.runConfiguredAgent({
+        prompt,
+        worktreePath,
+        timeoutMs: config.agent.timeoutMs,
+        config,
+        logger: console,
+        allowWrites: false,
+      })
+
+      if (!result.ok) {
+        throw new Error(result.stderr || result.stdout || 'Issue rewrite agent execution failed')
+      }
+
+      return {
+        responseText: result.responseText,
+      }
+    },
   })
 }
 
@@ -1262,6 +1395,82 @@ function assertIssueLintCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Issue lint cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertIssueRewriteCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  'lint-issue'?: string
+  'lint-file'?: string
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+  json?: boolean
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+    args.json ? '--json' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Issue rewrite cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -68,6 +68,13 @@ import {
   type BootstrapGateReport,
 } from './bootstrap-gate'
 import {
+  buildBootstrapScorecardForRepo,
+  formatBootstrapScorecard,
+  formatBootstrapScorecardJson,
+  resolveBootstrapScorecardExitCode,
+  type BootstrapScorecard,
+} from './bootstrap-scorecard'
+import {
   rewriteIssueDraft,
   type RewriteIssueDraftResult,
 } from './issue-authoring'
@@ -162,6 +169,11 @@ export interface ExecuteBootstrapGateInput {
 
 export interface ExecuteBootstrapScenarioInput {
   fixturesDir?: string
+}
+
+export interface ExecuteBootstrapScorecardInput {
+  repo?: string
+  pat?: string
 }
 
 export interface ExecuteAuditIssuesInput {
@@ -316,6 +328,11 @@ interface BootstrapScenarioCommandDependencies {
   evaluateBootstrapScenarioFixtureDirectory: typeof evaluateBootstrapScenarioFixtureDirectory
 }
 
+interface BootstrapScorecardCommandDependencies {
+  loadConfig: typeof loadConfig
+  buildBootstrapScorecardForRepo: typeof buildBootstrapScorecardForRepo
+}
+
 interface AuditIssuesCommandDependencies {
   loadConfig: typeof loadConfig
   loadIssuesForAudit: typeof loadIssuesForAudit
@@ -393,6 +410,11 @@ const DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES: BootstrapScenarioCommandD
   evaluateBootstrapScenarioFixtureDirectory,
 }
 const DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR = join(import.meta.dir, 'fixtures', 'replay')
+
+const DEFAULT_BOOTSTRAP_SCORECARD_COMMAND_DEPENDENCIES: BootstrapScorecardCommandDependencies = {
+  loadConfig,
+  buildBootstrapScorecardForRepo,
+}
 
 const DEFAULT_AUDIT_ISSUES_COMMAND_DEPENDENCIES: AuditIssuesCommandDependencies = {
   loadConfig,
@@ -483,6 +505,7 @@ async function main() {
       'lint-file': { type: 'string' },
       'bootstrap-gate': { type: 'boolean' },
       'bootstrap-scenarios': { type: 'boolean' },
+      'bootstrap-scorecard': { type: 'boolean' },
       'simulate-issue': { type: 'string' },
       'simulate-file': { type: 'string' },
       'repair-file': { type: 'string' },
@@ -655,6 +678,54 @@ async function main() {
       'lint-issue': args['lint-issue'] as string | undefined,
       'lint-file': args['lint-file'] as string | undefined,
       'bootstrap-gate': args['bootstrap-gate'] as boolean | undefined,
+      'simulate-issue': args['simulate-issue'] as string | undefined,
+      'simulate-file': args['simulate-file'] as string | undefined,
+      'rewrite-file': args['rewrite-file'] as string | undefined,
+      'split-file': args['split-file'] as string | undefined,
+      'split-start-number': args['split-start-number'] as string | undefined,
+      simulate: args.simulate as boolean | undefined,
+      concurrency: args.concurrency as string | undefined,
+      'poll-interval': args['poll-interval'] as string | undefined,
+      'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
+      'machine-id': args['machine-id'] as string | undefined,
+      'dry-run': args['dry-run'] as boolean | undefined,
+      'metrics-port': args['metrics-port'] as string | undefined,
+      dashboard: args.dashboard as boolean | undefined,
+      'dashboard-host': args['dashboard-host'] as string | undefined,
+      'dashboard-port': args['dashboard-port'] as string | undefined,
+      daemonize: args.daemonize as boolean | undefined,
+      'join-project': args['join-project'] as boolean | undefined,
+      'repo-cap': args['repo-cap'] as string | undefined,
+      runtimes: args.runtimes as boolean | undefined,
+      start: args.start as boolean | undefined,
+      logs: args.logs as boolean | undefined,
+      reconcile: args.reconcile as boolean | undefined,
+      restart: args.restart as boolean | undefined,
+      'launchd-install': args['launchd-install'] as boolean | undefined,
+      'launchd-uninstall': args['launchd-uninstall'] as boolean | undefined,
+      'launchd-status': args['launchd-status'] as boolean | undefined,
+      stop: args.stop as boolean | undefined,
+      once: args.once as boolean | undefined,
+      status: args.status as boolean | undefined,
+      doctor: args.doctor as boolean | undefined,
+      'health-host': args['health-host'] as string | undefined,
+      'health-port': args['health-port'] as string | undefined,
+    })
+  }
+
+  if (args['bootstrap-scorecard']) {
+    assertBootstrapScorecardCompatible({
+      'wake-now': args['wake-now'] as boolean | undefined,
+      'wake-issue': args['wake-issue'] as string | undefined,
+      'wake-pr': args['wake-pr'] as string | undefined,
+      'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'audit-issues': args['audit-issues'] as boolean | undefined,
+      'apply-file': args['apply-file'] as string | undefined,
+      'repair-file': args['repair-file'] as string | undefined,
+      'lint-issue': args['lint-issue'] as string | undefined,
+      'lint-file': args['lint-file'] as string | undefined,
+      'bootstrap-gate': args['bootstrap-gate'] as boolean | undefined,
+      'bootstrap-scenarios': args['bootstrap-scenarios'] as boolean | undefined,
       'simulate-issue': args['simulate-issue'] as string | undefined,
       'simulate-file': args['simulate-file'] as string | undefined,
       'rewrite-file': args['rewrite-file'] as string | undefined,
@@ -936,6 +1007,9 @@ async function main() {
     if (args['bootstrap-scenarios']) {
       throw new Error('--wake-from-github-event cannot be combined with --bootstrap-scenarios')
     }
+    if (args['bootstrap-scorecard']) {
+      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-scorecard')
+    }
     assertWakeCommandCompatible(args)
   }
 
@@ -1026,6 +1100,15 @@ async function main() {
     const report = await executeBootstrapScenarioCommand()
     console.log(formatBootstrapScenarioOutput(report, args.json as boolean | undefined))
     process.exit(resolveBootstrapScenarioSuiteExitCode(report))
+  }
+
+  if (args['bootstrap-scorecard']) {
+    const scorecard = await executeBootstrapScorecardCommand({
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+    })
+    console.log(formatBootstrapScorecardOutput(scorecard, args.json as boolean | undefined))
+    process.exit(resolveBootstrapScorecardExitCode(scorecard))
   }
 
   if (issueApplyInput) {
@@ -1459,6 +1542,7 @@ Usage:
   agent-loop --lint-issue <number> [--repo owner/repo --json]
   agent-loop --bootstrap-gate [--repo owner/repo --json]
   agent-loop --bootstrap-scenarios [--json]
+  agent-loop --bootstrap-scorecard [--repo owner/repo --json]
   agent-loop --simulate-file <path> [--repo owner/repo --json]
   agent-loop --simulate-issue <number> [--repo owner/repo --json]
   agent-loop --rewrite-file <path> [--repo owner/repo]
@@ -1507,6 +1591,7 @@ Options:
       --lint-issue <number>   Lint a remote GitHub issue body
       --bootstrap-gate        Evaluate the deterministic self-bootstrap release gate
       --bootstrap-scenarios   Evaluate the fixed self-bootstrap replay suite
+      --bootstrap-scorecard   Evaluate the self-bootstrap failure taxonomy scorecard
       --simulate-file <path>  Run read-only executability simulation for a local issue markdown file
       --simulate-issue <number>
                               Run read-only executability simulation for a remote GitHub issue body
@@ -1514,7 +1599,7 @@ Options:
       --split-file <path>     Split a tracking parent draft into ordered child issue contracts
       --split-start-number <n>
                               First issue number to use when filling child dependency JSON
-      --json                  Print machine-readable JSON for issue audit/apply/lint/repair/simulate/bootstrap/replay commands
+      --json                  Print machine-readable JSON for issue audit/apply/lint/repair/simulate/bootstrap/replay/scorecard commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -1564,6 +1649,7 @@ Examples:
   agent-loop --lint-issue 374 --repo owner/repo --json
   agent-loop --bootstrap-gate --repo JamesWuHK/agent-loop --json
   agent-loop --bootstrap-scenarios --json
+  agent-loop --bootstrap-scorecard --repo JamesWuHK/agent-loop --json
   agent-loop --simulate-file docs/issues/ready-gate.md --json
   agent-loop --simulate-issue 374 --repo owner/repo --json
   agent-loop --rewrite-file docs/issues/draft.md
@@ -1926,6 +2012,20 @@ export async function executeBootstrapScenarioCommand(
   )
 }
 
+export async function executeBootstrapScorecardCommand(
+  input: ExecuteBootstrapScorecardInput,
+  deps: BootstrapScorecardCommandDependencies = DEFAULT_BOOTSTRAP_SCORECARD_COMMAND_DEPENDENCIES,
+): Promise<BootstrapScorecard> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+
+  return deps.buildBootstrapScorecardForRepo({
+    config,
+  })
+}
+
 export async function executeAuditIssuesCommand(
   input: ExecuteAuditIssuesInput,
   deps: AuditIssuesCommandDependencies = DEFAULT_AUDIT_ISSUES_COMMAND_DEPENDENCIES,
@@ -2219,6 +2319,13 @@ export function formatBootstrapScenarioOutput(
   asJson = false,
 ): string {
   return asJson ? formatBootstrapScenarioSuiteReportJson(report) : formatBootstrapScenarioSuiteReport(report)
+}
+
+export function formatBootstrapScorecardOutput(
+  scorecard: BootstrapScorecard,
+  asJson = false,
+): string {
+  return asJson ? formatBootstrapScorecardJson(scorecard) : formatBootstrapScorecard(scorecard)
 }
 
 export function formatAuditIssuesOutput(
@@ -2797,6 +2904,102 @@ function assertBootstrapScenarioCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Bootstrap scenarios cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertBootstrapScorecardCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  'audit-issues'?: boolean
+  'apply-file'?: string
+  'repair-file'?: string
+  'lint-issue'?: string
+  'lint-file'?: string
+  'bootstrap-gate'?: boolean
+  'bootstrap-scenarios'?: boolean
+  'simulate-issue'?: string
+  'simulate-file'?: string
+  'rewrite-file'?: string
+  'split-file'?: string
+  'split-start-number'?: string
+  simulate?: boolean
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    args['audit-issues'] ? '--audit-issues' : null,
+    typeof args['apply-file'] === 'string' ? '--apply-file' : null,
+    typeof args['repair-file'] === 'string' ? '--repair-file' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    args['bootstrap-gate'] ? '--bootstrap-gate' : null,
+    args['bootstrap-scenarios'] ? '--bootstrap-scenarios' : null,
+    typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
+    typeof args['simulate-file'] === 'string' ? '--simulate-file' : null,
+    typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
+    typeof args['split-file'] === 'string' ? '--split-file' : null,
+    typeof args['split-start-number'] === 'string' ? '--split-start-number' : null,
+    args.simulate ? '--simulate' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Bootstrap scorecard cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -11,7 +11,7 @@
 
 import { parseArgs } from 'node:util'
 import { existsSync, readFileSync } from 'node:fs'
-import { basename } from 'node:path'
+import { basename, join } from 'node:path'
 import { AgentDaemon, DEFAULT_HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_HOST, type HealthServerConfig } from './daemon'
 import { loadConfig, resolveLocalDaemonIdentity, type CliArgs } from './config'
 import { collectDaemonObservability, formatDoctorReport, formatStatusReport } from './status'
@@ -94,6 +94,13 @@ import {
   splitTrackingIssue,
   type SplitTrackingIssueResult,
 } from './issue-splitter'
+import {
+  evaluateBootstrapScenarioFixtureDirectory,
+  formatBootstrapScenarioSuiteReport,
+  formatBootstrapScenarioSuiteReportJson,
+  resolveBootstrapScenarioSuiteExitCode,
+  type BootstrapScenarioSuiteReport,
+} from './replay-eval'
 
 type PartialHealthServerConfig = Partial<HealthServerConfig>
 type LocalDaemonIdentityResolver = typeof resolveLocalDaemonIdentity
@@ -151,6 +158,10 @@ export interface ExecuteIssueLintInput {
 export interface ExecuteBootstrapGateInput {
   repo?: string
   pat?: string
+}
+
+export interface ExecuteBootstrapScenarioInput {
+  fixturesDir?: string
 }
 
 export interface ExecuteAuditIssuesInput {
@@ -301,6 +312,10 @@ interface BootstrapGateCommandDependencies {
   buildBootstrapGateReportForRepo: typeof buildBootstrapGateReportForRepo
 }
 
+interface BootstrapScenarioCommandDependencies {
+  evaluateBootstrapScenarioFixtureDirectory: typeof evaluateBootstrapScenarioFixtureDirectory
+}
+
 interface AuditIssuesCommandDependencies {
   loadConfig: typeof loadConfig
   loadIssuesForAudit: typeof loadIssuesForAudit
@@ -373,6 +388,11 @@ const DEFAULT_BOOTSTRAP_GATE_COMMAND_DEPENDENCIES: BootstrapGateCommandDependenc
   loadConfig,
   buildBootstrapGateReportForRepo,
 }
+
+const DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES: BootstrapScenarioCommandDependencies = {
+  evaluateBootstrapScenarioFixtureDirectory,
+}
+const DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR = join(import.meta.dir, 'fixtures', 'replay')
 
 const DEFAULT_AUDIT_ISSUES_COMMAND_DEPENDENCIES: AuditIssuesCommandDependencies = {
   loadConfig,
@@ -462,6 +482,7 @@ async function main() {
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
       'bootstrap-gate': { type: 'boolean' },
+      'bootstrap-scenarios': { type: 'boolean' },
       'simulate-issue': { type: 'string' },
       'simulate-file': { type: 'string' },
       'repair-file': { type: 'string' },
@@ -587,6 +608,53 @@ async function main() {
       'repair-file': args['repair-file'] as string | undefined,
       'lint-issue': args['lint-issue'] as string | undefined,
       'lint-file': args['lint-file'] as string | undefined,
+      'simulate-issue': args['simulate-issue'] as string | undefined,
+      'simulate-file': args['simulate-file'] as string | undefined,
+      'rewrite-file': args['rewrite-file'] as string | undefined,
+      'split-file': args['split-file'] as string | undefined,
+      'split-start-number': args['split-start-number'] as string | undefined,
+      simulate: args.simulate as boolean | undefined,
+      concurrency: args.concurrency as string | undefined,
+      'poll-interval': args['poll-interval'] as string | undefined,
+      'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
+      'machine-id': args['machine-id'] as string | undefined,
+      'dry-run': args['dry-run'] as boolean | undefined,
+      'metrics-port': args['metrics-port'] as string | undefined,
+      dashboard: args.dashboard as boolean | undefined,
+      'dashboard-host': args['dashboard-host'] as string | undefined,
+      'dashboard-port': args['dashboard-port'] as string | undefined,
+      daemonize: args.daemonize as boolean | undefined,
+      'join-project': args['join-project'] as boolean | undefined,
+      'repo-cap': args['repo-cap'] as string | undefined,
+      runtimes: args.runtimes as boolean | undefined,
+      start: args.start as boolean | undefined,
+      logs: args.logs as boolean | undefined,
+      reconcile: args.reconcile as boolean | undefined,
+      restart: args.restart as boolean | undefined,
+      'launchd-install': args['launchd-install'] as boolean | undefined,
+      'launchd-uninstall': args['launchd-uninstall'] as boolean | undefined,
+      'launchd-status': args['launchd-status'] as boolean | undefined,
+      stop: args.stop as boolean | undefined,
+      once: args.once as boolean | undefined,
+      status: args.status as boolean | undefined,
+      doctor: args.doctor as boolean | undefined,
+      'health-host': args['health-host'] as string | undefined,
+      'health-port': args['health-port'] as string | undefined,
+    })
+  }
+
+  if (args['bootstrap-scenarios']) {
+    assertBootstrapScenarioCompatible({
+      'wake-now': args['wake-now'] as boolean | undefined,
+      'wake-issue': args['wake-issue'] as string | undefined,
+      'wake-pr': args['wake-pr'] as string | undefined,
+      'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'audit-issues': args['audit-issues'] as boolean | undefined,
+      'apply-file': args['apply-file'] as string | undefined,
+      'repair-file': args['repair-file'] as string | undefined,
+      'lint-issue': args['lint-issue'] as string | undefined,
+      'lint-file': args['lint-file'] as string | undefined,
+      'bootstrap-gate': args['bootstrap-gate'] as boolean | undefined,
       'simulate-issue': args['simulate-issue'] as string | undefined,
       'simulate-file': args['simulate-file'] as string | undefined,
       'rewrite-file': args['rewrite-file'] as string | undefined,
@@ -865,6 +933,9 @@ async function main() {
     if (args['bootstrap-gate']) {
       throw new Error('--wake-from-github-event cannot be combined with --bootstrap-gate')
     }
+    if (args['bootstrap-scenarios']) {
+      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-scenarios')
+    }
     assertWakeCommandCompatible(args)
   }
 
@@ -949,6 +1020,12 @@ async function main() {
     })
     console.log(formatBootstrapGateOutput(report, args.json as boolean | undefined))
     process.exit(resolveBootstrapGateExitCode(report))
+  }
+
+  if (args['bootstrap-scenarios']) {
+    const report = await executeBootstrapScenarioCommand()
+    console.log(formatBootstrapScenarioOutput(report, args.json as boolean | undefined))
+    process.exit(resolveBootstrapScenarioSuiteExitCode(report))
   }
 
   if (issueApplyInput) {
@@ -1381,6 +1458,7 @@ Usage:
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
   agent-loop --bootstrap-gate [--repo owner/repo --json]
+  agent-loop --bootstrap-scenarios [--json]
   agent-loop --simulate-file <path> [--repo owner/repo --json]
   agent-loop --simulate-issue <number> [--repo owner/repo --json]
   agent-loop --rewrite-file <path> [--repo owner/repo]
@@ -1428,6 +1506,7 @@ Options:
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
       --bootstrap-gate        Evaluate the deterministic self-bootstrap release gate
+      --bootstrap-scenarios   Evaluate the fixed self-bootstrap replay suite
       --simulate-file <path>  Run read-only executability simulation for a local issue markdown file
       --simulate-issue <number>
                               Run read-only executability simulation for a remote GitHub issue body
@@ -1435,7 +1514,7 @@ Options:
       --split-file <path>     Split a tracking parent draft into ordered child issue contracts
       --split-start-number <n>
                               First issue number to use when filling child dependency JSON
-      --json                  Print machine-readable JSON for issue audit/apply/lint/repair/simulate/bootstrap commands
+      --json                  Print machine-readable JSON for issue audit/apply/lint/repair/simulate/bootstrap/replay commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -1484,6 +1563,7 @@ Examples:
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
   agent-loop --bootstrap-gate --repo JamesWuHK/agent-loop --json
+  agent-loop --bootstrap-scenarios --json
   agent-loop --simulate-file docs/issues/ready-gate.md --json
   agent-loop --simulate-issue 374 --repo owner/repo --json
   agent-loop --rewrite-file docs/issues/draft.md
@@ -1837,6 +1917,15 @@ export async function executeBootstrapGateCommand(
   })
 }
 
+export async function executeBootstrapScenarioCommand(
+  input: ExecuteBootstrapScenarioInput = {},
+  deps: BootstrapScenarioCommandDependencies = DEFAULT_BOOTSTRAP_SCENARIO_COMMAND_DEPENDENCIES,
+): Promise<BootstrapScenarioSuiteReport> {
+  return deps.evaluateBootstrapScenarioFixtureDirectory(
+    input.fixturesDir ?? DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR,
+  )
+}
+
 export async function executeAuditIssuesCommand(
   input: ExecuteAuditIssuesInput,
   deps: AuditIssuesCommandDependencies = DEFAULT_AUDIT_ISSUES_COMMAND_DEPENDENCIES,
@@ -2123,6 +2212,13 @@ export function formatBootstrapGateOutput(
   asJson = false,
 ): string {
   return asJson ? formatBootstrapGateReportJson(report) : formatBootstrapGateReport(report)
+}
+
+export function formatBootstrapScenarioOutput(
+  report: BootstrapScenarioSuiteReport,
+  asJson = false,
+): string {
+  return asJson ? formatBootstrapScenarioSuiteReportJson(report) : formatBootstrapScenarioSuiteReport(report)
 }
 
 export function formatAuditIssuesOutput(
@@ -2607,6 +2703,100 @@ function assertBootstrapGateCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Bootstrap gate cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertBootstrapScenarioCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  'audit-issues'?: boolean
+  'apply-file'?: string
+  'repair-file'?: string
+  'lint-issue'?: string
+  'lint-file'?: string
+  'bootstrap-gate'?: boolean
+  'simulate-issue'?: string
+  'simulate-file'?: string
+  'rewrite-file'?: string
+  'split-file'?: string
+  'split-start-number'?: string
+  simulate?: boolean
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    args['audit-issues'] ? '--audit-issues' : null,
+    typeof args['apply-file'] === 'string' ? '--apply-file' : null,
+    typeof args['repair-file'] === 'string' ? '--repair-file' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    args['bootstrap-gate'] ? '--bootstrap-gate' : null,
+    typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
+    typeof args['simulate-file'] === 'string' ? '--simulate-file' : null,
+    typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
+    typeof args['split-file'] === 'string' ? '--split-file' : null,
+    typeof args['split-start-number'] === 'string' ? '--split-start-number' : null,
+    args.simulate ? '--simulate' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Bootstrap scenarios cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -65,6 +65,11 @@ import {
   type RewriteIssueDraftResult,
 } from './issue-authoring'
 import {
+  applyIssueBodyUpdate,
+  formatIssueApplyResult,
+  type ApplyIssueBodyUpdateResult,
+} from './issue-apply'
+import {
   formatIssueRepairResult,
   repairIssueDraft,
   type RepairIssueDraftResult,
@@ -149,6 +154,15 @@ export interface ExecuteIssueSimulationInput {
   repo?: string
   pat?: string
   repoRoot?: string
+}
+
+export interface ExecuteIssueApplyInput {
+  path: string
+  issueNumber: number
+  expectedUpdatedAt?: string
+  force?: boolean
+  repo?: string
+  pat?: string
 }
 
 export interface ExecuteIssueRepairInput {
@@ -285,6 +299,12 @@ interface IssueSimulationCommandDependencies {
   runConfiguredAgent: typeof runConfiguredAgent
 }
 
+interface IssueApplyCommandDependencies {
+  loadConfig: typeof loadConfig
+  readIssueDraftFile: (path: string) => string
+  applyIssueBodyUpdate: typeof applyIssueBodyUpdate
+}
+
 interface IssueRepairCommandDependencies {
   loadConfig: typeof loadConfig
   readIssueDraftFile: (path: string) => string
@@ -345,6 +365,12 @@ const DEFAULT_ISSUE_SIMULATION_COMMAND_DEPENDENCIES: IssueSimulationCommandDepen
   fetchRemoteIssueDocument,
   simulateIssueExecutability,
   runConfiguredAgent,
+}
+
+const DEFAULT_ISSUE_APPLY_COMMAND_DEPENDENCIES: IssueApplyCommandDependencies = {
+  loadConfig,
+  readIssueDraftFile: (path) => readFileSync(path, 'utf-8'),
+  applyIssueBodyUpdate,
 }
 
 const DEFAULT_ISSUE_REPAIR_COMMAND_DEPENDENCIES: IssueRepairCommandDependencies = {
@@ -408,6 +434,9 @@ async function main() {
       'audit-issues': { type: 'boolean' },
       issue: { type: 'string', multiple: true },
       simulate: { type: 'boolean' },
+      'apply-file': { type: 'string' },
+      'expected-updated-at': { type: 'string' },
+      force: { type: 'boolean' },
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
       'simulate-issue': { type: 'string' },
@@ -438,6 +467,12 @@ async function main() {
     'wake-issue': args['wake-issue'] as string | undefined,
     'wake-pr': args['wake-pr'] as string | undefined,
   })
+  const issueApplyInput = resolveIssueApplyInput({
+    'apply-file': args['apply-file'] as string | undefined,
+    issue: args.issue as string[] | undefined,
+    'expected-updated-at': args['expected-updated-at'] as string | undefined,
+    force: args.force as boolean | undefined,
+  })
   const issueLintTarget = resolveIssueLintTarget({
     'lint-issue': args['lint-issue'] as string | undefined,
     'lint-file': args['lint-file'] as string | undefined,
@@ -449,6 +484,7 @@ async function main() {
   const auditIssuesInput = resolveAuditIssuesInput({
     'audit-issues': args['audit-issues'] as boolean | undefined,
     issue: args.issue as string[] | undefined,
+    'apply-file': args['apply-file'] as string | undefined,
     'repair-file': args['repair-file'] as string | undefined,
     simulate: args.simulate as boolean | undefined,
   })
@@ -463,6 +499,51 @@ async function main() {
     'split-file': args['split-file'] as string | undefined,
     'split-start-number': args['split-start-number'] as string | undefined,
   })
+
+  if (issueApplyInput) {
+    assertIssueApplyCompatible({
+      'wake-now': args['wake-now'] as boolean | undefined,
+      'wake-issue': args['wake-issue'] as string | undefined,
+      'wake-pr': args['wake-pr'] as string | undefined,
+      'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'audit-issues': args['audit-issues'] as boolean | undefined,
+      simulate: args.simulate as boolean | undefined,
+      'lint-issue': args['lint-issue'] as string | undefined,
+      'lint-file': args['lint-file'] as string | undefined,
+      'simulate-issue': args['simulate-issue'] as string | undefined,
+      'simulate-file': args['simulate-file'] as string | undefined,
+      'repair-file': args['repair-file'] as string | undefined,
+      'rewrite-file': args['rewrite-file'] as string | undefined,
+      'split-file': args['split-file'] as string | undefined,
+      'split-start-number': args['split-start-number'] as string | undefined,
+      concurrency: args.concurrency as string | undefined,
+      'poll-interval': args['poll-interval'] as string | undefined,
+      'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
+      'machine-id': args['machine-id'] as string | undefined,
+      'dry-run': args['dry-run'] as boolean | undefined,
+      'metrics-port': args['metrics-port'] as string | undefined,
+      dashboard: args.dashboard as boolean | undefined,
+      'dashboard-host': args['dashboard-host'] as string | undefined,
+      'dashboard-port': args['dashboard-port'] as string | undefined,
+      daemonize: args.daemonize as boolean | undefined,
+      'join-project': args['join-project'] as boolean | undefined,
+      'repo-cap': args['repo-cap'] as string | undefined,
+      runtimes: args.runtimes as boolean | undefined,
+      start: args.start as boolean | undefined,
+      logs: args.logs as boolean | undefined,
+      reconcile: args.reconcile as boolean | undefined,
+      restart: args.restart as boolean | undefined,
+      'launchd-install': args['launchd-install'] as boolean | undefined,
+      'launchd-uninstall': args['launchd-uninstall'] as boolean | undefined,
+      'launchd-status': args['launchd-status'] as boolean | undefined,
+      stop: args.stop as boolean | undefined,
+      once: args.once as boolean | undefined,
+      status: args.status as boolean | undefined,
+      doctor: args.doctor as boolean | undefined,
+      'health-host': args['health-host'] as string | undefined,
+      'health-port': args['health-port'] as string | undefined,
+    })
+  }
 
   if (wakeCommand) {
     assertWakeCommandCompatible(args)
@@ -521,6 +602,7 @@ async function main() {
       'wake-issue': args['wake-issue'] as string | undefined,
       'wake-pr': args['wake-pr'] as string | undefined,
       'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'apply-file': args['apply-file'] as string | undefined,
       'lint-issue': args['lint-issue'] as string | undefined,
       'lint-file': args['lint-file'] as string | undefined,
       'simulate-issue': args['simulate-issue'] as string | undefined,
@@ -690,6 +772,9 @@ async function main() {
     if (wakeCommand) {
       throw new Error('--wake-from-github-event cannot be combined with --wake-now, --wake-issue, or --wake-pr')
     }
+    if (issueApplyInput) {
+      throw new Error('--wake-from-github-event cannot be combined with --apply-file')
+    }
     if (issueLintTarget) {
       throw new Error('--wake-from-github-event cannot be combined with --lint-issue or --lint-file')
     }
@@ -783,6 +868,16 @@ async function main() {
     })
     console.log(formatIssueLintOutput(report, args.json as boolean | undefined))
     process.exit(report.readyGateBlocked ? 1 : 0)
+  }
+
+  if (issueApplyInput) {
+    const result = await executeIssueApplyCommand({
+      ...issueApplyInput,
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+    })
+    console.log(formatIssueApplyOutput(result, args.json as boolean | undefined))
+    process.exit(shouldFailIssueApplyCommand(result) ? 1 : 0)
   }
 
   if (issueRewritePath) {
@@ -1200,6 +1295,7 @@ Usage:
   agent-loop --wake-pr <number> [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
   agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
   agent-loop --audit-issues [--issue <number> ...] [--simulate] [--repo owner/repo --json]
+  agent-loop --apply-file <path> --issue <number> [--expected-updated-at <iso> | --force] [--repo owner/repo --json]
   agent-loop --repair-file <path> [--simulate] [--repo owner/repo --json]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
@@ -1240,7 +1336,11 @@ Options:
       --github-event-name     Override the GitHub event name used by --wake-from-github-event
       --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
       --audit-issues          Audit open managed issues or an explicit repeated --issue set
-      --issue <number>        With --audit-issues, restrict auditing to the selected issue numbers
+      --issue <number>        With --audit-issues, restrict auditing to selected issue numbers; with --apply-file, target the remote issue to update
+      --apply-file <path>     Apply a local canonical issue markdown file back to an existing GitHub issue
+      --expected-updated-at <iso>
+                              Expected remote issue updatedAt for stale-write protection
+      --force                 Bypass --expected-updated-at conflict protection for --apply-file
       --simulate              With --audit-issues or --repair-file, include read-only simulation findings
       --repair-file <path>    Repair a local issue draft by consuming lint and optional simulate findings
       --lint-file <path>      Lint a local issue markdown file
@@ -1252,7 +1352,7 @@ Options:
       --split-file <path>     Split a tracking parent draft into ordered child issue contracts
       --split-start-number <n>
                               First issue number to use when filling child dependency JSON
-      --json                  Print machine-readable JSON for lint and simulate commands
+      --json                  Print machine-readable JSON for issue audit/apply/lint/repair/simulate commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -1296,6 +1396,7 @@ Examples:
   agent-loop --wake-pr 381 --health-port 9311
   agent-loop --audit-issues --json
   agent-loop --audit-issues --issue 50 --issue 53 --simulate --repo owner/repo --json
+  agent-loop --apply-file docs/issues/ready-gate.md --issue 54 --expected-updated-at 2026-04-12T08:00:00.000Z --repo owner/repo --json
   agent-loop --repair-file docs/issues/broken.md --simulate --json
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
@@ -1431,13 +1532,14 @@ export function resolveIssueLintTarget(args: {
 export function resolveAuditIssuesInput(args: {
   'audit-issues'?: boolean
   issue?: string[]
+  'apply-file'?: string
   'repair-file'?: string
   simulate?: boolean
 }): AuditIssuesCommandInput | null {
   const rawIssueArgs = Array.isArray(args.issue) ? args.issue : []
 
   if (!args['audit-issues']) {
-    if (rawIssueArgs.length > 0) {
+    if (rawIssueArgs.length > 0 && typeof args['apply-file'] !== 'string') {
       throw new Error('--issue requires --audit-issues')
     }
     if (args.simulate && typeof args['repair-file'] !== 'string') {
@@ -1459,6 +1561,68 @@ export function resolveAuditIssuesInput(args: {
   return {
     issueNumbers,
     includeSimulation: Boolean(args.simulate),
+  }
+}
+
+export function resolveIssueApplyInput(args: {
+  'apply-file'?: string
+  issue?: string[]
+  'expected-updated-at'?: string
+  force?: boolean
+}): {
+  path: string
+  issueNumber: number
+  expectedUpdatedAt?: string
+  force: boolean
+} | null {
+  const rawIssueArgs = Array.isArray(args.issue) ? args.issue : []
+  const hasApplyFile = typeof args['apply-file'] === 'string'
+  const hasExpectedUpdatedAt = typeof args['expected-updated-at'] === 'string'
+
+  if (!hasApplyFile) {
+    if (hasExpectedUpdatedAt) {
+      throw new Error('--expected-updated-at requires --apply-file')
+    }
+    if (args.force) {
+      throw new Error('--force requires --apply-file')
+    }
+    return null
+  }
+
+  const path = args['apply-file']!.trim()
+  if (!path) {
+    throw new Error('--apply-file must be a non-empty path')
+  }
+
+  if (rawIssueArgs.length === 0) {
+    throw new Error('--apply-file requires --issue')
+  }
+
+  if (rawIssueArgs.length !== 1) {
+    throw new Error('--apply-file requires exactly one --issue')
+  }
+
+  const expectedUpdatedAt = hasExpectedUpdatedAt
+    ? args['expected-updated-at']!.trim()
+    : undefined
+
+  if (hasExpectedUpdatedAt && !expectedUpdatedAt) {
+    throw new Error('--expected-updated-at must be a non-empty ISO-8601 timestamp')
+  }
+
+  if (expectedUpdatedAt && !Number.isFinite(Date.parse(expectedUpdatedAt))) {
+    throw new Error('--expected-updated-at must be a valid ISO-8601 timestamp')
+  }
+
+  if (!args.force && !expectedUpdatedAt) {
+    throw new Error('--apply-file requires --expected-updated-at unless --force is provided')
+  }
+
+  return {
+    path,
+    issueNumber: parseWakeTargetNumber(rawIssueArgs[0]!, '--issue'),
+    expectedUpdatedAt,
+    force: Boolean(args.force),
   }
 }
 
@@ -1620,6 +1784,25 @@ export async function executeAuditIssuesCommand(
     report,
     explicitIssueNumbers,
   }
+}
+
+export async function executeIssueApplyCommand(
+  input: ExecuteIssueApplyInput,
+  deps: IssueApplyCommandDependencies = DEFAULT_ISSUE_APPLY_COMMAND_DEPENDENCIES,
+): Promise<ApplyIssueBodyUpdateResult> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+  const markdown = deps.readIssueDraftFile(input.path)
+
+  return deps.applyIssueBodyUpdate({
+    issueNumber: input.issueNumber,
+    markdown,
+    expectedUpdatedAt: input.expectedUpdatedAt,
+    force: input.force,
+    config,
+  })
 }
 
 export async function executeIssueRewriteCommand(
@@ -1844,6 +2027,13 @@ export function formatAuditIssuesOutput(
   return formatAuditOutput(report, asJson)
 }
 
+export function formatIssueApplyOutput(
+  result: ApplyIssueBodyUpdateResult,
+  asJson = false,
+): string {
+  return formatIssueApplyResult(result, asJson)
+}
+
 export function formatIssueRepairOutput(
   result: RepairIssueDraftResult,
   asJson = false,
@@ -1861,6 +2051,12 @@ export function shouldFailAuditIssuesCommand(
   result: ExecuteAuditIssuesResult,
 ): boolean {
   return result.explicitIssueNumbers.length > 0 && result.report.summary.invalidIssueCount > 0
+}
+
+export function shouldFailIssueApplyCommand(
+  result: ApplyIssueBodyUpdateResult,
+): boolean {
+  return result.status === 'conflict' || result.status === 'invalid'
 }
 
 export function shouldFailIssueRepairCommand(
@@ -2084,6 +2280,7 @@ function isManagedRuntimeBooleanFlag(flag: string): boolean {
 }
 
 function assertWakeCommandCompatible(args: {
+  'apply-file'?: string
   pat?: string
   concurrency?: string
   'poll-interval'?: string
@@ -2111,6 +2308,7 @@ function assertWakeCommandCompatible(args: {
   'health-host'?: string
 }): void {
   const incompatibleFlags = [
+    typeof args['apply-file'] === 'string' ? '--apply-file' : null,
     typeof args.pat === 'string' ? '--pat' : null,
     typeof args.concurrency === 'string' ? '--concurrency' : null,
     typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
@@ -2144,6 +2342,7 @@ function assertWakeCommandCompatible(args: {
 }
 
 function assertIssueLintCompatible(args: {
+  'apply-file'?: string
   'wake-now'?: boolean
   'wake-issue'?: string
   'wake-pr'?: string
@@ -2176,6 +2375,7 @@ function assertIssueLintCompatible(args: {
   'health-port'?: string
 }): void {
   const incompatibleFlags = [
+    typeof args['apply-file'] === 'string' ? '--apply-file' : null,
     args['wake-now'] ? '--wake-now' : null,
     typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
     typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
@@ -2218,6 +2418,7 @@ function assertAuditIssuesCompatible(args: {
   'wake-issue'?: string
   'wake-pr'?: string
   'wake-from-github-event'?: boolean
+  'apply-file'?: string
   'repair-file'?: string
   'lint-issue'?: string
   'lint-file'?: string
@@ -2258,6 +2459,7 @@ function assertAuditIssuesCompatible(args: {
     typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
     typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
     args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['apply-file'] === 'string' ? '--apply-file' : null,
     typeof args['repair-file'] === 'string' ? '--repair-file' : null,
     typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
     typeof args['lint-file'] === 'string' ? '--lint-file' : null,
@@ -2296,6 +2498,96 @@ function assertAuditIssuesCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Issue audit cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertIssueApplyCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  'audit-issues'?: boolean
+  simulate?: boolean
+  'lint-issue'?: string
+  'lint-file'?: string
+  'simulate-issue'?: string
+  'simulate-file'?: string
+  'repair-file'?: string
+  'rewrite-file'?: string
+  'split-file'?: string
+  'split-start-number'?: string
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    args['audit-issues'] ? '--audit-issues' : null,
+    args.simulate ? '--simulate' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
+    typeof args['simulate-file'] === 'string' ? '--simulate-file' : null,
+    typeof args['repair-file'] === 'string' ? '--repair-file' : null,
+    typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
+    typeof args['split-file'] === 'string' ? '--split-file' : null,
+    typeof args['split-start-number'] === 'string' ? '--split-start-number' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Issue apply cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -11,6 +11,7 @@
 
 import { parseArgs } from 'node:util'
 import { existsSync, readFileSync } from 'node:fs'
+import { basename } from 'node:path'
 import { AgentDaemon, DEFAULT_HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_HOST, type HealthServerConfig } from './daemon'
 import { loadConfig, resolveLocalDaemonIdentity, type CliArgs } from './config'
 import { collectDaemonObservability, formatDoctorReport, formatStatusReport } from './status'
@@ -59,6 +60,12 @@ import {
   type RewriteIssueDraftResult,
 } from './issue-authoring'
 import { runConfiguredAgent } from './cli-agent'
+import {
+  formatSplitTrackingIssueResult,
+  parseTrackingIssueDocument,
+  splitTrackingIssue,
+  type SplitTrackingIssueResult,
+} from './issue-splitter'
 
 type PartialHealthServerConfig = Partial<HealthServerConfig>
 type LocalDaemonIdentityResolver = typeof resolveLocalDaemonIdentity
@@ -104,6 +111,17 @@ export interface ExecuteIssueLintInput {
 
 export interface ExecuteIssueRewriteInput {
   path: string
+  repo?: string
+  pat?: string
+  repoRoot?: string
+}
+
+export interface IssueSplitInput {
+  path: string
+  startingIssueNumber: number
+}
+
+export interface ExecuteIssueSplitInput extends IssueSplitInput {
   repo?: string
   pat?: string
   repoRoot?: string
@@ -193,6 +211,13 @@ interface IssueRewriteCommandDependencies {
   runConfiguredAgent: typeof runConfiguredAgent
 }
 
+interface IssueSplitCommandDependencies {
+  loadConfig: typeof loadConfig
+  readIssueDraftFile: (path: string) => string
+  splitTrackingIssue: typeof splitTrackingIssue
+  runConfiguredAgent: typeof runConfiguredAgent
+}
+
 const DEFAULT_RESTART_DEPENDENCIES: RestartManagedRuntimeDependencies = {
   platform: process.platform,
   resolveLocalDaemonIdentity,
@@ -223,6 +248,13 @@ const DEFAULT_ISSUE_REWRITE_COMMAND_DEPENDENCIES: IssueRewriteCommandDependencie
   loadConfig,
   readIssueDraftFile: (path) => readFileSync(path, 'utf-8'),
   rewriteIssueDraft,
+  runConfiguredAgent,
+}
+
+const DEFAULT_ISSUE_SPLIT_COMMAND_DEPENDENCIES: IssueSplitCommandDependencies = {
+  loadConfig,
+  readIssueDraftFile: (path) => readFileSync(path, 'utf-8'),
+  splitTrackingIssue,
   runConfiguredAgent,
 }
 
@@ -266,6 +298,8 @@ async function main() {
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
       'rewrite-file': { type: 'string' },
+      'split-file': { type: 'string' },
+      'split-start-number': { type: 'string' },
       json: { type: 'boolean' },
       help: { type: 'boolean' },
     },
@@ -294,6 +328,10 @@ async function main() {
   })
   const issueRewritePath = resolveIssueRewritePath({
     'rewrite-file': args['rewrite-file'] as string | undefined,
+  })
+  const issueSplitInput = resolveIssueSplitInput({
+    'split-file': args['split-file'] as string | undefined,
+    'split-start-number': args['split-start-number'] as string | undefined,
   })
 
   if (wakeCommand) {
@@ -342,6 +380,45 @@ async function main() {
     })
   }
 
+  if (issueSplitInput) {
+    assertIssueSplitCompatible({
+      'wake-now': args['wake-now'] as boolean | undefined,
+      'wake-issue': args['wake-issue'] as string | undefined,
+      'wake-pr': args['wake-pr'] as string | undefined,
+      'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'lint-issue': args['lint-issue'] as string | undefined,
+      'lint-file': args['lint-file'] as string | undefined,
+      'rewrite-file': args['rewrite-file'] as string | undefined,
+      concurrency: args.concurrency as string | undefined,
+      'poll-interval': args['poll-interval'] as string | undefined,
+      'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
+      'machine-id': args['machine-id'] as string | undefined,
+      'dry-run': args['dry-run'] as boolean | undefined,
+      'metrics-port': args['metrics-port'] as string | undefined,
+      dashboard: args.dashboard as boolean | undefined,
+      'dashboard-host': args['dashboard-host'] as string | undefined,
+      'dashboard-port': args['dashboard-port'] as string | undefined,
+      daemonize: args.daemonize as boolean | undefined,
+      'join-project': args['join-project'] as boolean | undefined,
+      'repo-cap': args['repo-cap'] as string | undefined,
+      runtimes: args.runtimes as boolean | undefined,
+      start: args.start as boolean | undefined,
+      logs: args.logs as boolean | undefined,
+      reconcile: args.reconcile as boolean | undefined,
+      restart: args.restart as boolean | undefined,
+      'launchd-install': args['launchd-install'] as boolean | undefined,
+      'launchd-uninstall': args['launchd-uninstall'] as boolean | undefined,
+      'launchd-status': args['launchd-status'] as boolean | undefined,
+      stop: args.stop as boolean | undefined,
+      once: args.once as boolean | undefined,
+      status: args.status as boolean | undefined,
+      doctor: args.doctor as boolean | undefined,
+      'health-host': args['health-host'] as string | undefined,
+      'health-port': args['health-port'] as string | undefined,
+      json: args.json as boolean | undefined,
+    })
+  }
+
   if (args['wake-from-github-event']) {
     if (wakeCommand) {
       throw new Error('--wake-from-github-event cannot be combined with --wake-now, --wake-issue, or --wake-pr')
@@ -349,11 +426,21 @@ async function main() {
     if (issueLintTarget) {
       throw new Error('--wake-from-github-event cannot be combined with --lint-issue or --lint-file')
     }
+    if (issueRewritePath) {
+      throw new Error('--wake-from-github-event cannot be combined with --rewrite-file')
+    }
+    if (issueSplitInput) {
+      throw new Error('--wake-from-github-event cannot be combined with --split-file')
+    }
     assertWakeCommandCompatible(args)
   }
 
   if (wakeCommand && issueLintTarget) {
     throw new Error('--lint-issue/--lint-file cannot be combined with wake commands')
+  }
+
+  if (issueRewritePath && issueSplitInput) {
+    throw new Error('--rewrite-file cannot be combined with --split-file')
   }
 
   if (args['repo-cap'] && !args['join-project']) {
@@ -430,6 +517,17 @@ async function main() {
       repoRoot: process.cwd(),
     })
     console.log(result.markdown)
+    process.exit(0)
+  }
+
+  if (issueSplitInput) {
+    const result = await executeIssueSplitCommand({
+      ...issueSplitInput,
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+      repoRoot: process.cwd(),
+    })
+    console.log(formatIssueSplitOutput(result))
     process.exit(0)
   }
 
@@ -791,6 +889,7 @@ Usage:
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
   agent-loop --rewrite-file <path> [--repo owner/repo]
+  agent-loop --split-file <path> --split-start-number <n> [--repo owner/repo]
   agent-loop --reconcile [--health-port 9310]
   agent-loop --start [--health-port 9310]
   agent-loop --dashboard [--dashboard-port 9388]
@@ -826,6 +925,9 @@ Options:
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
       --rewrite-file <path>   Rewrite a local issue draft into canonical contract markdown
+      --split-file <path>     Split a tracking parent draft into ordered child issue contracts
+      --split-start-number <n>
+                              First issue number to use when filling child dependency JSON
       --json                  Print machine-readable JSON for lint commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
@@ -871,6 +973,7 @@ Examples:
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
   agent-loop --rewrite-file docs/issues/draft.md
+  agent-loop --split-file docs/issues/epic.md --split-start-number 41
   agent-loop --dashboard
   agent-loop --dashboard --dashboard-port 9390
   agent-loop --join-project --machine-id macbook-pro-b --health-port 9312 --metrics-port 9092 --repo-cap 2
@@ -1011,6 +1114,32 @@ export function resolveIssueRewritePath(args: {
   return path
 }
 
+export function resolveIssueSplitInput(args: {
+  'split-file'?: string
+  'split-start-number'?: string
+}): IssueSplitInput | null {
+  if (typeof args['split-file'] !== 'string') {
+    if (typeof args['split-start-number'] === 'string') {
+      throw new Error('--split-start-number requires --split-file')
+    }
+    return null
+  }
+
+  const path = args['split-file'].trim()
+  if (!path) {
+    throw new Error('--split-file must be a non-empty path')
+  }
+
+  if (typeof args['split-start-number'] !== 'string') {
+    throw new Error('--split-file requires --split-start-number')
+  }
+
+  return {
+    path,
+    startingIssueNumber: parseWakeTargetNumber(args['split-start-number'], '--split-start-number'),
+  }
+}
+
 export async function executeIssueLintCommand(
   input: ExecuteIssueLintInput,
   deps: IssueLintCommandDependencies = DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES,
@@ -1066,11 +1195,61 @@ export async function executeIssueRewriteCommand(
   })
 }
 
+export async function executeIssueSplitCommand(
+  input: ExecuteIssueSplitInput,
+  deps: IssueSplitCommandDependencies = DEFAULT_ISSUE_SPLIT_COMMAND_DEPENDENCIES,
+): Promise<SplitTrackingIssueResult> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+  const markdown = deps.readIssueDraftFile(input.path)
+  const document = parseTrackingIssueDocument(markdown, basename(input.path))
+  const repoRoot = input.repoRoot ?? process.cwd()
+  let nextIssueNumber = input.startingIssueNumber
+
+  return deps.splitTrackingIssue({
+    title: document.title,
+    body: document.body,
+    repoRoot,
+    issueNumberAllocator: () => {
+      const current = nextIssueNumber
+      nextIssueNumber += 1
+      return current
+    },
+  }, {
+    runAgent: async ({ prompt, repoRoot: worktreePath }) => {
+      const result = await deps.runConfiguredAgent({
+        prompt,
+        worktreePath,
+        timeoutMs: config.agent.timeoutMs,
+        config,
+        logger: console,
+        allowWrites: false,
+      })
+
+      if (!result.ok) {
+        throw new Error(result.stderr || result.stdout || 'Issue split agent execution failed')
+      }
+
+      return {
+        responseText: result.responseText,
+      }
+    },
+  })
+}
+
 export function formatIssueLintOutput(
   report: IssueLintReport,
   asJson = false,
 ): string {
   return asJson ? formatIssueLintReportJson(report) : formatIssueLintReport(report)
+}
+
+export function formatIssueSplitOutput(
+  result: SplitTrackingIssueResult,
+): string {
+  return formatSplitTrackingIssueResult(result)
 }
 
 export function buildWakeRequestFromCli(
@@ -1471,6 +1650,84 @@ function assertIssueRewriteCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Issue rewrite cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertIssueSplitCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  'lint-issue'?: string
+  'lint-file'?: string
+  'rewrite-file'?: string
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+  json?: boolean
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+    args.json ? '--json' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Issue split cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -49,11 +49,15 @@ import {
   startDashboardServer,
 } from './dashboard'
 import {
+  auditIssues,
   buildIssueLintReportFromMarkdownFile,
   buildIssueLintReportFromRemoteIssue,
   fetchRemoteIssueDocument,
+  formatAuditOutput,
   formatIssueLintReport,
   formatIssueLintReportJson,
+  loadIssuesForAudit,
+  type AuditIssuesReport,
   type IssueLintReport,
 } from './audit-issue-contracts'
 import {
@@ -90,6 +94,11 @@ export interface IssueLintTarget {
   issueNumber?: number
 }
 
+export interface AuditIssuesCommandInput {
+  issueNumbers: number[]
+  includeSimulation: boolean
+}
+
 export interface IssueSimulationTarget {
   kind: 'file' | 'issue'
   path?: string
@@ -120,6 +129,14 @@ export interface ExecuteIssueLintInput {
   target: IssueLintTarget
   repo?: string
   pat?: string
+}
+
+export interface ExecuteAuditIssuesInput {
+  issueNumbers?: number[]
+  includeSimulation?: boolean
+  repo?: string
+  pat?: string
+  repoRoot?: string
 }
 
 export interface ExecuteIssueSimulationInput {
@@ -198,6 +215,11 @@ export type ManagedRuntimeCleanupResult =
   | 'not-owned'
   | 'unreadable'
 
+export interface ExecuteAuditIssuesResult {
+  report: AuditIssuesReport
+  explicitIssueNumbers: number[]
+}
+
 export interface ExecuteIssueSimulationResult {
   source: {
     kind: 'file' | 'issue'
@@ -233,6 +255,13 @@ interface IssueLintCommandDependencies {
   loadConfig: typeof loadConfig
   buildIssueLintReportFromMarkdownFile: typeof buildIssueLintReportFromMarkdownFile
   buildIssueLintReportFromRemoteIssue: typeof buildIssueLintReportFromRemoteIssue
+}
+
+interface AuditIssuesCommandDependencies {
+  loadConfig: typeof loadConfig
+  loadIssuesForAudit: typeof loadIssuesForAudit
+  auditIssues: typeof auditIssues
+  runConfiguredAgent: typeof runConfiguredAgent
 }
 
 interface IssueSimulationCommandDependencies {
@@ -281,6 +310,13 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
   loadConfig,
   buildIssueLintReportFromMarkdownFile,
   buildIssueLintReportFromRemoteIssue,
+}
+
+const DEFAULT_AUDIT_ISSUES_COMMAND_DEPENDENCIES: AuditIssuesCommandDependencies = {
+  loadConfig,
+  loadIssuesForAudit,
+  auditIssues,
+  runConfiguredAgent,
 }
 
 const DEFAULT_ISSUE_SIMULATION_COMMAND_DEPENDENCIES: IssueSimulationCommandDependencies = {
@@ -342,6 +378,9 @@ async function main() {
       'wake-from-github-event': { type: 'boolean' },
       'github-event-name': { type: 'string' },
       'github-event-path': { type: 'string' },
+      'audit-issues': { type: 'boolean' },
+      issue: { type: 'string', multiple: true },
+      simulate: { type: 'boolean' },
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
       'simulate-issue': { type: 'string' },
@@ -375,6 +414,11 @@ async function main() {
     'lint-issue': args['lint-issue'] as string | undefined,
     'lint-file': args['lint-file'] as string | undefined,
   })
+  const auditIssuesInput = resolveAuditIssuesInput({
+    'audit-issues': args['audit-issues'] as boolean | undefined,
+    issue: args.issue as string[] | undefined,
+    simulate: args.simulate as boolean | undefined,
+  })
   const issueSimulationTarget = resolveIssueSimulationTarget({
     'simulate-issue': args['simulate-issue'] as string | undefined,
     'simulate-file': args['simulate-file'] as string | undefined,
@@ -393,6 +437,48 @@ async function main() {
 
   if (issueLintTarget) {
     assertIssueLintCompatible(args)
+  }
+
+  if (auditIssuesInput) {
+    assertAuditIssuesCompatible({
+      'wake-now': args['wake-now'] as boolean | undefined,
+      'wake-issue': args['wake-issue'] as string | undefined,
+      'wake-pr': args['wake-pr'] as string | undefined,
+      'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'lint-issue': args['lint-issue'] as string | undefined,
+      'lint-file': args['lint-file'] as string | undefined,
+      'simulate-issue': args['simulate-issue'] as string | undefined,
+      'simulate-file': args['simulate-file'] as string | undefined,
+      'rewrite-file': args['rewrite-file'] as string | undefined,
+      'split-file': args['split-file'] as string | undefined,
+      'split-start-number': args['split-start-number'] as string | undefined,
+      concurrency: args.concurrency as string | undefined,
+      'poll-interval': args['poll-interval'] as string | undefined,
+      'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
+      'machine-id': args['machine-id'] as string | undefined,
+      'dry-run': args['dry-run'] as boolean | undefined,
+      'metrics-port': args['metrics-port'] as string | undefined,
+      dashboard: args.dashboard as boolean | undefined,
+      'dashboard-host': args['dashboard-host'] as string | undefined,
+      'dashboard-port': args['dashboard-port'] as string | undefined,
+      daemonize: args.daemonize as boolean | undefined,
+      'join-project': args['join-project'] as boolean | undefined,
+      'repo-cap': args['repo-cap'] as string | undefined,
+      runtimes: args.runtimes as boolean | undefined,
+      start: args.start as boolean | undefined,
+      logs: args.logs as boolean | undefined,
+      reconcile: args.reconcile as boolean | undefined,
+      restart: args.restart as boolean | undefined,
+      'launchd-install': args['launchd-install'] as boolean | undefined,
+      'launchd-uninstall': args['launchd-uninstall'] as boolean | undefined,
+      'launchd-status': args['launchd-status'] as boolean | undefined,
+      stop: args.stop as boolean | undefined,
+      once: args.once as boolean | undefined,
+      status: args.status as boolean | undefined,
+      doctor: args.doctor as boolean | undefined,
+      'health-host': args['health-host'] as string | undefined,
+      'health-port': args['health-port'] as string | undefined,
+    })
   }
 
   if (issueRewritePath) {
@@ -529,6 +615,9 @@ async function main() {
     if (issueSplitInput) {
       throw new Error('--wake-from-github-event cannot be combined with --split-file')
     }
+    if (auditIssuesInput) {
+      throw new Error('--wake-from-github-event cannot be combined with --audit-issues')
+    }
     if (issueSimulationTarget) {
       throw new Error('--wake-from-github-event cannot be combined with --simulate-issue or --simulate-file')
     }
@@ -629,6 +718,18 @@ async function main() {
     })
     console.log(formatIssueSplitOutput(result))
     process.exit(0)
+  }
+
+  if (auditIssuesInput) {
+    const result = await executeAuditIssuesCommand({
+      issueNumbers: auditIssuesInput.issueNumbers,
+      includeSimulation: auditIssuesInput.includeSimulation,
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+      repoRoot: process.cwd(),
+    })
+    console.log(formatAuditIssuesOutput(result.report, args.json as boolean | undefined))
+    process.exit(shouldFailAuditIssuesCommand(result) ? 1 : 0)
   }
 
   if (issueSimulationTarget) {
@@ -997,6 +1098,7 @@ Usage:
   agent-loop --wake-issue <number> [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
   agent-loop --wake-pr <number> [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
   agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
+  agent-loop --audit-issues [--issue <number> ...] [--simulate] [--repo owner/repo --json]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
   agent-loop --simulate-file <path> [--repo owner/repo --json]
@@ -1035,6 +1137,9 @@ Options:
                               Translate the current GitHub Actions event into a local wake request
       --github-event-name     Override the GitHub event name used by --wake-from-github-event
       --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
+      --audit-issues          Audit open managed issues or an explicit repeated --issue set
+      --issue <number>        With --audit-issues, restrict auditing to the selected issue numbers
+      --simulate              With --audit-issues, include read-only simulation findings
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
       --simulate-file <path>  Run read-only executability simulation for a local issue markdown file
@@ -1086,6 +1191,8 @@ Examples:
   agent-loop --wake-now --repo owner/repo
   agent-loop --wake-issue 374 --repo owner/repo --machine-id macbook-pro-b
   agent-loop --wake-pr 381 --health-port 9311
+  agent-loop --audit-issues --json
+  agent-loop --audit-issues --issue 50 --issue 53 --simulate --repo owner/repo --json
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
   agent-loop --simulate-file docs/issues/ready-gate.md --json
@@ -1217,6 +1324,39 @@ export function resolveIssueLintTarget(args: {
   return targets[0] ?? null
 }
 
+export function resolveAuditIssuesInput(args: {
+  'audit-issues'?: boolean
+  issue?: string[]
+  simulate?: boolean
+}): AuditIssuesCommandInput | null {
+  const rawIssueArgs = Array.isArray(args.issue) ? args.issue : []
+
+  if (!args['audit-issues']) {
+    if (rawIssueArgs.length > 0) {
+      throw new Error('--issue requires --audit-issues')
+    }
+    if (args.simulate) {
+      throw new Error('--simulate requires --audit-issues')
+    }
+    return null
+  }
+
+  const seen = new Set<number>()
+  const issueNumbers: number[] = []
+
+  for (const value of rawIssueArgs) {
+    const issueNumber = parseWakeTargetNumber(value, '--issue')
+    if (seen.has(issueNumber)) continue
+    seen.add(issueNumber)
+    issueNumbers.push(issueNumber)
+  }
+
+  return {
+    issueNumbers,
+    includeSimulation: Boolean(args.simulate),
+  }
+}
+
 export function resolveIssueSimulationTarget(args: {
   'simulate-issue'?: string
   'simulate-file'?: string
@@ -1306,6 +1446,53 @@ export async function executeIssueLintCommand(
     issueNumber: input.target.issueNumber!,
     config,
   })
+}
+
+export async function executeAuditIssuesCommand(
+  input: ExecuteAuditIssuesInput,
+  deps: AuditIssuesCommandDependencies = DEFAULT_AUDIT_ISSUES_COMMAND_DEPENDENCIES,
+): Promise<ExecuteAuditIssuesResult> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+  const explicitIssueNumbers = input.issueNumbers ?? []
+  const issues = await deps.loadIssuesForAudit({
+    config,
+    issueNumbers: explicitIssueNumbers,
+  })
+  const repoRoot = input.repoRoot ?? process.cwd()
+  const report = await deps.auditIssues({
+    issues,
+    repo: config.repo,
+    includeSimulation: input.includeSimulation,
+    repoRoot,
+    runPlanner: input.includeSimulation
+      ? async ({ prompt, repoRoot: worktreePath }) => {
+          const result = await deps.runConfiguredAgent({
+            prompt,
+            worktreePath,
+            timeoutMs: config.agent.timeoutMs,
+            config,
+            logger: console,
+            allowWrites: false,
+          })
+
+          if (!result.ok) {
+            throw new Error(result.stderr || result.stdout || 'Issue audit agent execution failed')
+          }
+
+          return {
+            responseText: result.responseText,
+          }
+        }
+      : undefined,
+  })
+
+  return {
+    report,
+    explicitIssueNumbers,
+  }
 }
 
 export async function executeIssueRewriteCommand(
@@ -1466,10 +1653,23 @@ export function formatIssueLintOutput(
   return asJson ? formatIssueLintReportJson(report) : formatIssueLintReport(report)
 }
 
+export function formatAuditIssuesOutput(
+  report: AuditIssuesReport,
+  asJson = false,
+): string {
+  return formatAuditOutput(report, asJson)
+}
+
 export function formatIssueSplitOutput(
   result: SplitTrackingIssueResult,
 ): string {
   return formatSplitTrackingIssueResult(result)
+}
+
+export function shouldFailAuditIssuesCommand(
+  result: ExecuteAuditIssuesResult,
+): boolean {
+  return result.explicitIssueNumbers.length > 0 && result.report.summary.invalidIssueCount > 0
 }
 
 export function formatIssueSimulationOutput(
@@ -1813,6 +2013,90 @@ function assertIssueLintCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Issue lint cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertAuditIssuesCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  'lint-issue'?: string
+  'lint-file'?: string
+  'simulate-issue'?: string
+  'simulate-file'?: string
+  'rewrite-file'?: string
+  'split-file'?: string
+  'split-start-number'?: string
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
+    typeof args['simulate-file'] === 'string' ? '--simulate-file' : null,
+    typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
+    typeof args['split-file'] === 'string' ? '--split-file' : null,
+    typeof args['split-start-number'] === 'string' ? '--split-start-number' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Issue audit cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -51,6 +51,7 @@ import {
 import {
   buildIssueLintReportFromMarkdownFile,
   buildIssueLintReportFromRemoteIssue,
+  fetchRemoteIssueDocument,
   formatIssueLintReport,
   formatIssueLintReportJson,
   type IssueLintReport,
@@ -60,6 +61,12 @@ import {
   type RewriteIssueDraftResult,
 } from './issue-authoring'
 import { runConfiguredAgent } from './cli-agent'
+import {
+  formatIssueSimulationResult,
+  parseIssueSimulationDocument,
+  simulateIssueExecutability,
+  type IssueSimulationResult,
+} from './issue-simulate'
 import {
   formatSplitTrackingIssueResult,
   parseTrackingIssueDocument,
@@ -78,6 +85,12 @@ export interface WakeCommand {
 }
 
 export interface IssueLintTarget {
+  kind: 'file' | 'issue'
+  path?: string
+  issueNumber?: number
+}
+
+export interface IssueSimulationTarget {
   kind: 'file' | 'issue'
   path?: string
   issueNumber?: number
@@ -107,6 +120,13 @@ export interface ExecuteIssueLintInput {
   target: IssueLintTarget
   repo?: string
   pat?: string
+}
+
+export interface ExecuteIssueSimulationInput {
+  target: IssueSimulationTarget
+  repo?: string
+  pat?: string
+  repoRoot?: string
 }
 
 export interface ExecuteIssueRewriteInput {
@@ -178,6 +198,17 @@ export type ManagedRuntimeCleanupResult =
   | 'not-owned'
   | 'unreadable'
 
+export interface ExecuteIssueSimulationResult {
+  source: {
+    kind: 'file' | 'issue'
+    title: string
+    path?: string
+    issueNumber?: number
+    repo?: string
+  }
+  result: IssueSimulationResult
+}
+
 interface RestartManagedRuntimeDependencies {
   platform: NodeJS.Platform
   resolveLocalDaemonIdentity: LocalDaemonIdentityResolver
@@ -202,6 +233,14 @@ interface IssueLintCommandDependencies {
   loadConfig: typeof loadConfig
   buildIssueLintReportFromMarkdownFile: typeof buildIssueLintReportFromMarkdownFile
   buildIssueLintReportFromRemoteIssue: typeof buildIssueLintReportFromRemoteIssue
+}
+
+interface IssueSimulationCommandDependencies {
+  loadConfig: typeof loadConfig
+  readIssueDraftFile: (path: string) => string
+  fetchRemoteIssueDocument: typeof fetchRemoteIssueDocument
+  simulateIssueExecutability: typeof simulateIssueExecutability
+  runConfiguredAgent: typeof runConfiguredAgent
 }
 
 interface IssueRewriteCommandDependencies {
@@ -242,6 +281,14 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
   loadConfig,
   buildIssueLintReportFromMarkdownFile,
   buildIssueLintReportFromRemoteIssue,
+}
+
+const DEFAULT_ISSUE_SIMULATION_COMMAND_DEPENDENCIES: IssueSimulationCommandDependencies = {
+  loadConfig,
+  readIssueDraftFile: (path) => readFileSync(path, 'utf-8'),
+  fetchRemoteIssueDocument,
+  simulateIssueExecutability,
+  runConfiguredAgent,
 }
 
 const DEFAULT_ISSUE_REWRITE_COMMAND_DEPENDENCIES: IssueRewriteCommandDependencies = {
@@ -297,6 +344,8 @@ async function main() {
       'github-event-path': { type: 'string' },
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
+      'simulate-issue': { type: 'string' },
+      'simulate-file': { type: 'string' },
       'rewrite-file': { type: 'string' },
       'split-file': { type: 'string' },
       'split-start-number': { type: 'string' },
@@ -326,6 +375,10 @@ async function main() {
     'lint-issue': args['lint-issue'] as string | undefined,
     'lint-file': args['lint-file'] as string | undefined,
   })
+  const issueSimulationTarget = resolveIssueSimulationTarget({
+    'simulate-issue': args['simulate-issue'] as string | undefined,
+    'simulate-file': args['simulate-file'] as string | undefined,
+  })
   const issueRewritePath = resolveIssueRewritePath({
     'rewrite-file': args['rewrite-file'] as string | undefined,
   })
@@ -350,6 +403,8 @@ async function main() {
       'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
       'lint-issue': args['lint-issue'] as string | undefined,
       'lint-file': args['lint-file'] as string | undefined,
+      'simulate-issue': args['simulate-issue'] as string | undefined,
+      'simulate-file': args['simulate-file'] as string | undefined,
       concurrency: args.concurrency as string | undefined,
       'poll-interval': args['poll-interval'] as string | undefined,
       'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
@@ -388,6 +443,8 @@ async function main() {
       'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
       'lint-issue': args['lint-issue'] as string | undefined,
       'lint-file': args['lint-file'] as string | undefined,
+      'simulate-issue': args['simulate-issue'] as string | undefined,
+      'simulate-file': args['simulate-file'] as string | undefined,
       'rewrite-file': args['rewrite-file'] as string | undefined,
       concurrency: args.concurrency as string | undefined,
       'poll-interval': args['poll-interval'] as string | undefined,
@@ -419,6 +476,46 @@ async function main() {
     })
   }
 
+  if (issueSimulationTarget) {
+    assertIssueSimulationCompatible({
+      'wake-now': args['wake-now'] as boolean | undefined,
+      'wake-issue': args['wake-issue'] as string | undefined,
+      'wake-pr': args['wake-pr'] as string | undefined,
+      'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'lint-issue': args['lint-issue'] as string | undefined,
+      'lint-file': args['lint-file'] as string | undefined,
+      'rewrite-file': args['rewrite-file'] as string | undefined,
+      'split-file': args['split-file'] as string | undefined,
+      'split-start-number': args['split-start-number'] as string | undefined,
+      concurrency: args.concurrency as string | undefined,
+      'poll-interval': args['poll-interval'] as string | undefined,
+      'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
+      'machine-id': args['machine-id'] as string | undefined,
+      'dry-run': args['dry-run'] as boolean | undefined,
+      'metrics-port': args['metrics-port'] as string | undefined,
+      dashboard: args.dashboard as boolean | undefined,
+      'dashboard-host': args['dashboard-host'] as string | undefined,
+      'dashboard-port': args['dashboard-port'] as string | undefined,
+      daemonize: args.daemonize as boolean | undefined,
+      'join-project': args['join-project'] as boolean | undefined,
+      'repo-cap': args['repo-cap'] as string | undefined,
+      runtimes: args.runtimes as boolean | undefined,
+      start: args.start as boolean | undefined,
+      logs: args.logs as boolean | undefined,
+      reconcile: args.reconcile as boolean | undefined,
+      restart: args.restart as boolean | undefined,
+      'launchd-install': args['launchd-install'] as boolean | undefined,
+      'launchd-uninstall': args['launchd-uninstall'] as boolean | undefined,
+      'launchd-status': args['launchd-status'] as boolean | undefined,
+      stop: args.stop as boolean | undefined,
+      once: args.once as boolean | undefined,
+      status: args.status as boolean | undefined,
+      doctor: args.doctor as boolean | undefined,
+      'health-host': args['health-host'] as string | undefined,
+      'health-port': args['health-port'] as string | undefined,
+    })
+  }
+
   if (args['wake-from-github-event']) {
     if (wakeCommand) {
       throw new Error('--wake-from-github-event cannot be combined with --wake-now, --wake-issue, or --wake-pr')
@@ -431,6 +528,9 @@ async function main() {
     }
     if (issueSplitInput) {
       throw new Error('--wake-from-github-event cannot be combined with --split-file')
+    }
+    if (issueSimulationTarget) {
+      throw new Error('--wake-from-github-event cannot be combined with --simulate-issue or --simulate-file')
     }
     assertWakeCommandCompatible(args)
   }
@@ -529,6 +629,17 @@ async function main() {
     })
     console.log(formatIssueSplitOutput(result))
     process.exit(0)
+  }
+
+  if (issueSimulationTarget) {
+    const result = await executeIssueSimulationCommand({
+      target: issueSimulationTarget,
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+      repoRoot: process.cwd(),
+    })
+    console.log(formatIssueSimulationOutput(result, args.json as boolean | undefined))
+    process.exit(result.result.valid ? 0 : 1)
   }
 
   if (args['join-project']) {
@@ -888,6 +999,8 @@ Usage:
   agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
+  agent-loop --simulate-file <path> [--repo owner/repo --json]
+  agent-loop --simulate-issue <number> [--repo owner/repo --json]
   agent-loop --rewrite-file <path> [--repo owner/repo]
   agent-loop --split-file <path> --split-start-number <n> [--repo owner/repo]
   agent-loop --reconcile [--health-port 9310]
@@ -924,11 +1037,14 @@ Options:
       --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
+      --simulate-file <path>  Run read-only executability simulation for a local issue markdown file
+      --simulate-issue <number>
+                              Run read-only executability simulation for a remote GitHub issue body
       --rewrite-file <path>   Rewrite a local issue draft into canonical contract markdown
       --split-file <path>     Split a tracking parent draft into ordered child issue contracts
       --split-start-number <n>
                               First issue number to use when filling child dependency JSON
-      --json                  Print machine-readable JSON for lint commands
+      --json                  Print machine-readable JSON for lint and simulate commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -972,6 +1088,8 @@ Examples:
   agent-loop --wake-pr 381 --health-port 9311
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
+  agent-loop --simulate-file docs/issues/ready-gate.md --json
+  agent-loop --simulate-issue 374 --repo owner/repo --json
   agent-loop --rewrite-file docs/issues/draft.md
   agent-loop --split-file docs/issues/epic.md --split-start-number 41
   agent-loop --dashboard
@@ -1099,6 +1217,37 @@ export function resolveIssueLintTarget(args: {
   return targets[0] ?? null
 }
 
+export function resolveIssueSimulationTarget(args: {
+  'simulate-issue'?: string
+  'simulate-file'?: string
+}): IssueSimulationTarget | null {
+  const targets: IssueSimulationTarget[] = []
+
+  if (typeof args['simulate-issue'] === 'string') {
+    targets.push({
+      kind: 'issue',
+      issueNumber: parseWakeTargetNumber(args['simulate-issue'], '--simulate-issue'),
+    })
+  }
+
+  if (typeof args['simulate-file'] === 'string') {
+    const path = args['simulate-file'].trim()
+    if (!path) {
+      throw new Error('--simulate-file must be a non-empty path')
+    }
+    targets.push({
+      kind: 'file',
+      path,
+    })
+  }
+
+  if (targets.length > 1) {
+    throw new Error('Only one of --simulate-issue or --simulate-file can be used at a time')
+  }
+
+  return targets[0] ?? null
+}
+
 export function resolveIssueRewritePath(args: {
   'rewrite-file'?: string
 }): string | null {
@@ -1195,6 +1344,77 @@ export async function executeIssueRewriteCommand(
   })
 }
 
+export async function executeIssueSimulationCommand(
+  input: ExecuteIssueSimulationInput,
+  deps: IssueSimulationCommandDependencies = DEFAULT_ISSUE_SIMULATION_COMMAND_DEPENDENCIES,
+): Promise<ExecuteIssueSimulationResult> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+  const repoRoot = input.repoRoot ?? process.cwd()
+
+  const source = input.target.kind === 'file'
+    ? (() => {
+        const markdown = deps.readIssueDraftFile(input.target.path!)
+        const document = parseIssueSimulationDocument(markdown, basename(input.target.path!))
+        return {
+          source: {
+            kind: 'file' as const,
+            path: input.target.path!,
+            title: document.title,
+          },
+          issueTitle: document.title,
+          issueBody: document.body,
+        }
+      })()
+    : await (async () => {
+        const issue = await deps.fetchRemoteIssueDocument({
+          issueNumber: input.target.issueNumber!,
+          config,
+        })
+        return {
+          source: {
+            kind: 'issue' as const,
+            issueNumber: issue.number,
+            repo: config.repo,
+            title: issue.title,
+          },
+          issueTitle: issue.title,
+          issueBody: issue.body,
+        }
+      })()
+
+  const result = await deps.simulateIssueExecutability({
+    issueTitle: source.issueTitle,
+    issueBody: source.issueBody,
+    repoRoot,
+    runPlanner: async ({ prompt, repoRoot: worktreePath }) => {
+      const plannerResult = await deps.runConfiguredAgent({
+        prompt,
+        worktreePath,
+        timeoutMs: config.agent.timeoutMs,
+        config,
+        logger: console,
+        allowWrites: false,
+      })
+
+      if (!plannerResult.ok) {
+        throw new Error(plannerResult.stderr || plannerResult.stdout || 'Issue simulate agent execution failed')
+      }
+
+      return {
+        responseText: plannerResult.responseText,
+      }
+    },
+  })
+
+  return {
+    source: source.source,
+    result,
+  }
+}
+
 export async function executeIssueSplitCommand(
   input: ExecuteIssueSplitInput,
   deps: IssueSplitCommandDependencies = DEFAULT_ISSUE_SPLIT_COMMAND_DEPENDENCIES,
@@ -1250,6 +1470,25 @@ export function formatIssueSplitOutput(
   result: SplitTrackingIssueResult,
 ): string {
   return formatSplitTrackingIssueResult(result)
+}
+
+export function formatIssueSimulationOutput(
+  output: ExecuteIssueSimulationResult,
+  asJson = false,
+): string {
+  if (asJson) {
+    return JSON.stringify(output, null, 2)
+  }
+
+  const source = output.source.kind === 'file'
+    ? `source=file:${output.source.path!}`
+    : `source=issue:${output.source.repo}#${output.source.issueNumber!}`
+
+  return [
+    source,
+    `title=${output.source.title}`,
+    formatIssueSimulationResult(output.result),
+  ].join('\n')
 }
 
 export function buildWakeRequestFromCli(
@@ -1584,6 +1823,8 @@ function assertIssueRewriteCompatible(args: {
   'wake-from-github-event'?: boolean
   'lint-issue'?: string
   'lint-file'?: string
+  'simulate-issue'?: string
+  'simulate-file'?: string
   concurrency?: string
   'poll-interval'?: string
   'idle-poll-interval'?: string
@@ -1619,6 +1860,8 @@ function assertIssueRewriteCompatible(args: {
     args['wake-from-github-event'] ? '--wake-from-github-event' : null,
     typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
     typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
+    typeof args['simulate-file'] === 'string' ? '--simulate-file' : null,
     typeof args.concurrency === 'string' ? '--concurrency' : null,
     typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
     typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
@@ -1660,6 +1903,8 @@ function assertIssueSplitCompatible(args: {
   'wake-from-github-event'?: boolean
   'lint-issue'?: string
   'lint-file'?: string
+  'simulate-issue'?: string
+  'simulate-file'?: string
   'rewrite-file'?: string
   concurrency?: string
   'poll-interval'?: string
@@ -1696,6 +1941,8 @@ function assertIssueSplitCompatible(args: {
     args['wake-from-github-event'] ? '--wake-from-github-event' : null,
     typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
     typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
+    typeof args['simulate-file'] === 'string' ? '--simulate-file' : null,
     typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
     typeof args.concurrency === 'string' ? '--concurrency' : null,
     typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
@@ -1728,6 +1975,86 @@ function assertIssueSplitCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Issue split cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertIssueSimulationCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  'lint-issue'?: string
+  'lint-file'?: string
+  'rewrite-file'?: string
+  'split-file'?: string
+  'split-start-number'?: string
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
+    typeof args['split-file'] === 'string' ? '--split-file' : null,
+    typeof args['split-start-number'] === 'string' ? '--split-start-number' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Issue simulate cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -68,6 +68,13 @@ import {
   type BootstrapGateReport,
 } from './bootstrap-gate'
 import {
+  buildBootstrapConvergenceReportForRepo,
+  formatBootstrapConvergenceReport,
+  formatBootstrapConvergenceReportJson,
+  resolveBootstrapConvergenceExitCode,
+  type BootstrapConvergenceReport,
+} from './bootstrap-convergence'
+import {
   buildBootstrapScorecardForRepo,
   formatBootstrapScorecard,
   formatBootstrapScorecardJson,
@@ -174,6 +181,12 @@ export interface ExecuteBootstrapScenarioInput {
 export interface ExecuteBootstrapScorecardInput {
   repo?: string
   pat?: string
+}
+
+export interface ExecuteBootstrapConvergenceInput {
+  repo?: string
+  pat?: string
+  repoRoot?: string
 }
 
 export interface ExecuteAuditIssuesInput {
@@ -333,6 +346,11 @@ interface BootstrapScorecardCommandDependencies {
   buildBootstrapScorecardForRepo: typeof buildBootstrapScorecardForRepo
 }
 
+interface BootstrapConvergenceCommandDependencies {
+  loadConfig: typeof loadConfig
+  buildBootstrapConvergenceReportForRepo: typeof buildBootstrapConvergenceReportForRepo
+}
+
 interface AuditIssuesCommandDependencies {
   loadConfig: typeof loadConfig
   loadIssuesForAudit: typeof loadIssuesForAudit
@@ -414,6 +432,11 @@ const DEFAULT_BOOTSTRAP_SCENARIO_FIXTURES_DIR = join(import.meta.dir, 'fixtures'
 const DEFAULT_BOOTSTRAP_SCORECARD_COMMAND_DEPENDENCIES: BootstrapScorecardCommandDependencies = {
   loadConfig,
   buildBootstrapScorecardForRepo,
+}
+
+const DEFAULT_BOOTSTRAP_CONVERGENCE_COMMAND_DEPENDENCIES: BootstrapConvergenceCommandDependencies = {
+  loadConfig,
+  buildBootstrapConvergenceReportForRepo,
 }
 
 const DEFAULT_AUDIT_ISSUES_COMMAND_DEPENDENCIES: AuditIssuesCommandDependencies = {
@@ -506,6 +529,7 @@ async function main() {
       'bootstrap-gate': { type: 'boolean' },
       'bootstrap-scenarios': { type: 'boolean' },
       'bootstrap-scorecard': { type: 'boolean' },
+      'bootstrap-convergence': { type: 'boolean' },
       'simulate-issue': { type: 'string' },
       'simulate-file': { type: 'string' },
       'repair-file': { type: 'string' },
@@ -726,6 +750,55 @@ async function main() {
       'lint-file': args['lint-file'] as string | undefined,
       'bootstrap-gate': args['bootstrap-gate'] as boolean | undefined,
       'bootstrap-scenarios': args['bootstrap-scenarios'] as boolean | undefined,
+      'simulate-issue': args['simulate-issue'] as string | undefined,
+      'simulate-file': args['simulate-file'] as string | undefined,
+      'rewrite-file': args['rewrite-file'] as string | undefined,
+      'split-file': args['split-file'] as string | undefined,
+      'split-start-number': args['split-start-number'] as string | undefined,
+      simulate: args.simulate as boolean | undefined,
+      concurrency: args.concurrency as string | undefined,
+      'poll-interval': args['poll-interval'] as string | undefined,
+      'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
+      'machine-id': args['machine-id'] as string | undefined,
+      'dry-run': args['dry-run'] as boolean | undefined,
+      'metrics-port': args['metrics-port'] as string | undefined,
+      dashboard: args.dashboard as boolean | undefined,
+      'dashboard-host': args['dashboard-host'] as string | undefined,
+      'dashboard-port': args['dashboard-port'] as string | undefined,
+      daemonize: args.daemonize as boolean | undefined,
+      'join-project': args['join-project'] as boolean | undefined,
+      'repo-cap': args['repo-cap'] as string | undefined,
+      runtimes: args.runtimes as boolean | undefined,
+      start: args.start as boolean | undefined,
+      logs: args.logs as boolean | undefined,
+      reconcile: args.reconcile as boolean | undefined,
+      restart: args.restart as boolean | undefined,
+      'launchd-install': args['launchd-install'] as boolean | undefined,
+      'launchd-uninstall': args['launchd-uninstall'] as boolean | undefined,
+      'launchd-status': args['launchd-status'] as boolean | undefined,
+      stop: args.stop as boolean | undefined,
+      once: args.once as boolean | undefined,
+      status: args.status as boolean | undefined,
+      doctor: args.doctor as boolean | undefined,
+      'health-host': args['health-host'] as string | undefined,
+      'health-port': args['health-port'] as string | undefined,
+    })
+  }
+
+  if (args['bootstrap-convergence']) {
+    assertBootstrapConvergenceCompatible({
+      'wake-now': args['wake-now'] as boolean | undefined,
+      'wake-issue': args['wake-issue'] as string | undefined,
+      'wake-pr': args['wake-pr'] as string | undefined,
+      'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'audit-issues': args['audit-issues'] as boolean | undefined,
+      'apply-file': args['apply-file'] as string | undefined,
+      'repair-file': args['repair-file'] as string | undefined,
+      'lint-issue': args['lint-issue'] as string | undefined,
+      'lint-file': args['lint-file'] as string | undefined,
+      'bootstrap-gate': args['bootstrap-gate'] as boolean | undefined,
+      'bootstrap-scenarios': args['bootstrap-scenarios'] as boolean | undefined,
+      'bootstrap-scorecard': args['bootstrap-scorecard'] as boolean | undefined,
       'simulate-issue': args['simulate-issue'] as string | undefined,
       'simulate-file': args['simulate-file'] as string | undefined,
       'rewrite-file': args['rewrite-file'] as string | undefined,
@@ -1010,6 +1083,9 @@ async function main() {
     if (args['bootstrap-scorecard']) {
       throw new Error('--wake-from-github-event cannot be combined with --bootstrap-scorecard')
     }
+    if (args['bootstrap-convergence']) {
+      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-convergence')
+    }
     assertWakeCommandCompatible(args)
   }
 
@@ -1109,6 +1185,16 @@ async function main() {
     })
     console.log(formatBootstrapScorecardOutput(scorecard, args.json as boolean | undefined))
     process.exit(resolveBootstrapScorecardExitCode(scorecard))
+  }
+
+  if (args['bootstrap-convergence']) {
+    const report = await executeBootstrapConvergenceCommand({
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+      repoRoot: process.cwd(),
+    })
+    console.log(formatBootstrapConvergenceOutput(report, args.json as boolean | undefined))
+    process.exit(resolveBootstrapConvergenceExitCode(report))
   }
 
   if (issueApplyInput) {
@@ -1543,6 +1629,7 @@ Usage:
   agent-loop --bootstrap-gate [--repo owner/repo --json]
   agent-loop --bootstrap-scenarios [--json]
   agent-loop --bootstrap-scorecard [--repo owner/repo --json]
+  agent-loop --bootstrap-convergence [--repo owner/repo --json]
   agent-loop --simulate-file <path> [--repo owner/repo --json]
   agent-loop --simulate-issue <number> [--repo owner/repo --json]
   agent-loop --rewrite-file <path> [--repo owner/repo]
@@ -1592,6 +1679,7 @@ Options:
       --bootstrap-gate        Evaluate the deterministic self-bootstrap release gate
       --bootstrap-scenarios   Evaluate the fixed self-bootstrap replay suite
       --bootstrap-scorecard   Evaluate the self-bootstrap failure taxonomy scorecard
+      --bootstrap-convergence Report suppressed remote drift that still needs GitHub-side convergence
       --simulate-file <path>  Run read-only executability simulation for a local issue markdown file
       --simulate-issue <number>
                               Run read-only executability simulation for a remote GitHub issue body
@@ -1650,6 +1738,7 @@ Examples:
   agent-loop --bootstrap-gate --repo JamesWuHK/agent-loop --json
   agent-loop --bootstrap-scenarios --json
   agent-loop --bootstrap-scorecard --repo JamesWuHK/agent-loop --json
+  agent-loop --bootstrap-convergence --repo JamesWuHK/agent-loop --json
   agent-loop --simulate-file docs/issues/ready-gate.md --json
   agent-loop --simulate-issue 374 --repo owner/repo --json
   agent-loop --rewrite-file docs/issues/draft.md
@@ -2026,6 +2115,21 @@ export async function executeBootstrapScorecardCommand(
   })
 }
 
+export async function executeBootstrapConvergenceCommand(
+  input: ExecuteBootstrapConvergenceInput,
+  deps: BootstrapConvergenceCommandDependencies = DEFAULT_BOOTSTRAP_CONVERGENCE_COMMAND_DEPENDENCIES,
+): Promise<BootstrapConvergenceReport> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+
+  return deps.buildBootstrapConvergenceReportForRepo({
+    config,
+    repoRoot: input.repoRoot,
+  })
+}
+
 export async function executeAuditIssuesCommand(
   input: ExecuteAuditIssuesInput,
   deps: AuditIssuesCommandDependencies = DEFAULT_AUDIT_ISSUES_COMMAND_DEPENDENCIES,
@@ -2326,6 +2430,13 @@ export function formatBootstrapScorecardOutput(
   asJson = false,
 ): string {
   return asJson ? formatBootstrapScorecardJson(scorecard) : formatBootstrapScorecard(scorecard)
+}
+
+export function formatBootstrapConvergenceOutput(
+  report: BootstrapConvergenceReport,
+  asJson = false,
+): string {
+  return asJson ? formatBootstrapConvergenceReportJson(report) : formatBootstrapConvergenceReport(report)
 }
 
 export function formatAuditIssuesOutput(
@@ -3000,6 +3111,104 @@ function assertBootstrapScorecardCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Bootstrap scorecard cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertBootstrapConvergenceCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  'audit-issues'?: boolean
+  'apply-file'?: string
+  'repair-file'?: string
+  'lint-issue'?: string
+  'lint-file'?: string
+  'bootstrap-gate'?: boolean
+  'bootstrap-scenarios'?: boolean
+  'bootstrap-scorecard'?: boolean
+  'simulate-issue'?: string
+  'simulate-file'?: string
+  'rewrite-file'?: string
+  'split-file'?: string
+  'split-start-number'?: string
+  simulate?: boolean
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    args['audit-issues'] ? '--audit-issues' : null,
+    typeof args['apply-file'] === 'string' ? '--apply-file' : null,
+    typeof args['repair-file'] === 'string' ? '--repair-file' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    args['bootstrap-gate'] ? '--bootstrap-gate' : null,
+    args['bootstrap-scenarios'] ? '--bootstrap-scenarios' : null,
+    args['bootstrap-scorecard'] ? '--bootstrap-scorecard' : null,
+    typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
+    typeof args['simulate-file'] === 'string' ? '--simulate-file' : null,
+    typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
+    typeof args['split-file'] === 'string' ? '--split-file' : null,
+    typeof args['split-start-number'] === 'string' ? '--split-start-number' : null,
+    args.simulate ? '--simulate' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Bootstrap convergence cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -61,6 +61,13 @@ import {
   type IssueLintReport,
 } from './audit-issue-contracts'
 import {
+  buildBootstrapGateReportForRepo,
+  formatBootstrapGateReport,
+  formatBootstrapGateReportJson,
+  resolveBootstrapGateExitCode,
+  type BootstrapGateReport,
+} from './bootstrap-gate'
+import {
   rewriteIssueDraft,
   type RewriteIssueDraftResult,
 } from './issue-authoring'
@@ -137,6 +144,11 @@ export interface ExecuteWakeCommandResult {
 
 export interface ExecuteIssueLintInput {
   target: IssueLintTarget
+  repo?: string
+  pat?: string
+}
+
+export interface ExecuteBootstrapGateInput {
   repo?: string
   pat?: string
 }
@@ -284,6 +296,11 @@ interface IssueLintCommandDependencies {
   buildIssueLintReportFromRemoteIssue: typeof buildIssueLintReportFromRemoteIssue
 }
 
+interface BootstrapGateCommandDependencies {
+  loadConfig: typeof loadConfig
+  buildBootstrapGateReportForRepo: typeof buildBootstrapGateReportForRepo
+}
+
 interface AuditIssuesCommandDependencies {
   loadConfig: typeof loadConfig
   loadIssuesForAudit: typeof loadIssuesForAudit
@@ -350,6 +367,11 @@ const DEFAULT_ISSUE_LINT_COMMAND_DEPENDENCIES: IssueLintCommandDependencies = {
   loadConfig,
   buildIssueLintReportFromMarkdownFile,
   buildIssueLintReportFromRemoteIssue,
+}
+
+const DEFAULT_BOOTSTRAP_GATE_COMMAND_DEPENDENCIES: BootstrapGateCommandDependencies = {
+  loadConfig,
+  buildBootstrapGateReportForRepo,
 }
 
 const DEFAULT_AUDIT_ISSUES_COMMAND_DEPENDENCIES: AuditIssuesCommandDependencies = {
@@ -439,6 +461,7 @@ async function main() {
       force: { type: 'boolean' },
       'lint-issue': { type: 'string' },
       'lint-file': { type: 'string' },
+      'bootstrap-gate': { type: 'boolean' },
       'simulate-issue': { type: 'string' },
       'simulate-file': { type: 'string' },
       'repair-file': { type: 'string' },
@@ -551,6 +574,52 @@ async function main() {
 
   if (issueLintTarget) {
     assertIssueLintCompatible(args)
+  }
+
+  if (args['bootstrap-gate']) {
+    assertBootstrapGateCompatible({
+      'wake-now': args['wake-now'] as boolean | undefined,
+      'wake-issue': args['wake-issue'] as string | undefined,
+      'wake-pr': args['wake-pr'] as string | undefined,
+      'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'audit-issues': args['audit-issues'] as boolean | undefined,
+      'apply-file': args['apply-file'] as string | undefined,
+      'repair-file': args['repair-file'] as string | undefined,
+      'lint-issue': args['lint-issue'] as string | undefined,
+      'lint-file': args['lint-file'] as string | undefined,
+      'simulate-issue': args['simulate-issue'] as string | undefined,
+      'simulate-file': args['simulate-file'] as string | undefined,
+      'rewrite-file': args['rewrite-file'] as string | undefined,
+      'split-file': args['split-file'] as string | undefined,
+      'split-start-number': args['split-start-number'] as string | undefined,
+      simulate: args.simulate as boolean | undefined,
+      concurrency: args.concurrency as string | undefined,
+      'poll-interval': args['poll-interval'] as string | undefined,
+      'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
+      'machine-id': args['machine-id'] as string | undefined,
+      'dry-run': args['dry-run'] as boolean | undefined,
+      'metrics-port': args['metrics-port'] as string | undefined,
+      dashboard: args.dashboard as boolean | undefined,
+      'dashboard-host': args['dashboard-host'] as string | undefined,
+      'dashboard-port': args['dashboard-port'] as string | undefined,
+      daemonize: args.daemonize as boolean | undefined,
+      'join-project': args['join-project'] as boolean | undefined,
+      'repo-cap': args['repo-cap'] as string | undefined,
+      runtimes: args.runtimes as boolean | undefined,
+      start: args.start as boolean | undefined,
+      logs: args.logs as boolean | undefined,
+      reconcile: args.reconcile as boolean | undefined,
+      restart: args.restart as boolean | undefined,
+      'launchd-install': args['launchd-install'] as boolean | undefined,
+      'launchd-uninstall': args['launchd-uninstall'] as boolean | undefined,
+      'launchd-status': args['launchd-status'] as boolean | undefined,
+      stop: args.stop as boolean | undefined,
+      once: args.once as boolean | undefined,
+      status: args.status as boolean | undefined,
+      doctor: args.doctor as boolean | undefined,
+      'health-host': args['health-host'] as string | undefined,
+      'health-port': args['health-port'] as string | undefined,
+    })
   }
 
   if (issueRepairInput) {
@@ -793,6 +862,9 @@ async function main() {
     if (issueSimulationTarget) {
       throw new Error('--wake-from-github-event cannot be combined with --simulate-issue or --simulate-file')
     }
+    if (args['bootstrap-gate']) {
+      throw new Error('--wake-from-github-event cannot be combined with --bootstrap-gate')
+    }
     assertWakeCommandCompatible(args)
   }
 
@@ -868,6 +940,15 @@ async function main() {
     })
     console.log(formatIssueLintOutput(report, args.json as boolean | undefined))
     process.exit(report.readyGateBlocked ? 1 : 0)
+  }
+
+  if (args['bootstrap-gate']) {
+    const report = await executeBootstrapGateCommand({
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+    })
+    console.log(formatBootstrapGateOutput(report, args.json as boolean | undefined))
+    process.exit(resolveBootstrapGateExitCode(report))
   }
 
   if (issueApplyInput) {
@@ -1299,6 +1380,7 @@ Usage:
   agent-loop --repair-file <path> [--simulate] [--repo owner/repo --json]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
+  agent-loop --bootstrap-gate [--repo owner/repo --json]
   agent-loop --simulate-file <path> [--repo owner/repo --json]
   agent-loop --simulate-issue <number> [--repo owner/repo --json]
   agent-loop --rewrite-file <path> [--repo owner/repo]
@@ -1345,6 +1427,7 @@ Options:
       --repair-file <path>    Repair a local issue draft by consuming lint and optional simulate findings
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
+      --bootstrap-gate        Evaluate the deterministic self-bootstrap release gate
       --simulate-file <path>  Run read-only executability simulation for a local issue markdown file
       --simulate-issue <number>
                               Run read-only executability simulation for a remote GitHub issue body
@@ -1352,7 +1435,7 @@ Options:
       --split-file <path>     Split a tracking parent draft into ordered child issue contracts
       --split-start-number <n>
                               First issue number to use when filling child dependency JSON
-      --json                  Print machine-readable JSON for issue audit/apply/lint/repair/simulate commands
+      --json                  Print machine-readable JSON for issue audit/apply/lint/repair/simulate/bootstrap commands
       --dashboard             Start the local monitoring page for the current repo
       --dashboard-host <host> Dashboard server host (default: 127.0.0.1)
       --dashboard-port <port> Dashboard server port (default: 9388)
@@ -1400,6 +1483,7 @@ Examples:
   agent-loop --repair-file docs/issues/broken.md --simulate --json
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
+  agent-loop --bootstrap-gate --repo JamesWuHK/agent-loop --json
   agent-loop --simulate-file docs/issues/ready-gate.md --json
   agent-loop --simulate-issue 374 --repo owner/repo --json
   agent-loop --rewrite-file docs/issues/draft.md
@@ -1739,6 +1823,20 @@ export async function executeIssueLintCommand(
   })
 }
 
+export async function executeBootstrapGateCommand(
+  input: ExecuteBootstrapGateInput,
+  deps: BootstrapGateCommandDependencies = DEFAULT_BOOTSTRAP_GATE_COMMAND_DEPENDENCIES,
+): Promise<BootstrapGateReport> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+
+  return deps.buildBootstrapGateReportForRepo({
+    config,
+  })
+}
+
 export async function executeAuditIssuesCommand(
   input: ExecuteAuditIssuesInput,
   deps: AuditIssuesCommandDependencies = DEFAULT_AUDIT_ISSUES_COMMAND_DEPENDENCIES,
@@ -2018,6 +2116,13 @@ export function formatIssueLintOutput(
   asJson = false,
 ): string {
   return asJson ? formatIssueLintReportJson(report) : formatIssueLintReport(report)
+}
+
+export function formatBootstrapGateOutput(
+  report: BootstrapGateReport,
+  asJson = false,
+): string {
+  return asJson ? formatBootstrapGateReportJson(report) : formatBootstrapGateReport(report)
 }
 
 export function formatAuditIssuesOutput(
@@ -2410,6 +2515,98 @@ function assertIssueLintCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Issue lint cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertBootstrapGateCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  'audit-issues'?: boolean
+  'apply-file'?: string
+  'repair-file'?: string
+  'lint-issue'?: string
+  'lint-file'?: string
+  'simulate-issue'?: string
+  'simulate-file'?: string
+  'rewrite-file'?: string
+  'split-file'?: string
+  'split-start-number'?: string
+  simulate?: boolean
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    args['audit-issues'] ? '--audit-issues' : null,
+    typeof args['apply-file'] === 'string' ? '--apply-file' : null,
+    typeof args['repair-file'] === 'string' ? '--repair-file' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
+    typeof args['simulate-file'] === 'string' ? '--simulate-file' : null,
+    typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
+    typeof args['split-file'] === 'string' ? '--split-file' : null,
+    typeof args['split-start-number'] === 'string' ? '--split-start-number' : null,
+    args.simulate ? '--simulate' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Bootstrap gate cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/index.ts
+++ b/apps/agent-daemon/src/index.ts
@@ -64,6 +64,11 @@ import {
   rewriteIssueDraft,
   type RewriteIssueDraftResult,
 } from './issue-authoring'
+import {
+  formatIssueRepairResult,
+  repairIssueDraft,
+  type RepairIssueDraftResult,
+} from './issue-repair'
 import { runConfiguredAgent } from './cli-agent'
 import {
   formatIssueSimulationResult,
@@ -141,6 +146,14 @@ export interface ExecuteAuditIssuesInput {
 
 export interface ExecuteIssueSimulationInput {
   target: IssueSimulationTarget
+  repo?: string
+  pat?: string
+  repoRoot?: string
+}
+
+export interface ExecuteIssueRepairInput {
+  path: string
+  includeSimulation?: boolean
   repo?: string
   pat?: string
   repoRoot?: string
@@ -272,6 +285,13 @@ interface IssueSimulationCommandDependencies {
   runConfiguredAgent: typeof runConfiguredAgent
 }
 
+interface IssueRepairCommandDependencies {
+  loadConfig: typeof loadConfig
+  readIssueDraftFile: (path: string) => string
+  repairIssueDraft: typeof repairIssueDraft
+  runConfiguredAgent: typeof runConfiguredAgent
+}
+
 interface IssueRewriteCommandDependencies {
   loadConfig: typeof loadConfig
   readIssueDraftFile: (path: string) => string
@@ -324,6 +344,13 @@ const DEFAULT_ISSUE_SIMULATION_COMMAND_DEPENDENCIES: IssueSimulationCommandDepen
   readIssueDraftFile: (path) => readFileSync(path, 'utf-8'),
   fetchRemoteIssueDocument,
   simulateIssueExecutability,
+  runConfiguredAgent,
+}
+
+const DEFAULT_ISSUE_REPAIR_COMMAND_DEPENDENCIES: IssueRepairCommandDependencies = {
+  loadConfig,
+  readIssueDraftFile: (path) => readFileSync(path, 'utf-8'),
+  repairIssueDraft,
   runConfiguredAgent,
 }
 
@@ -385,6 +412,7 @@ async function main() {
       'lint-file': { type: 'string' },
       'simulate-issue': { type: 'string' },
       'simulate-file': { type: 'string' },
+      'repair-file': { type: 'string' },
       'rewrite-file': { type: 'string' },
       'split-file': { type: 'string' },
       'split-start-number': { type: 'string' },
@@ -414,9 +442,14 @@ async function main() {
     'lint-issue': args['lint-issue'] as string | undefined,
     'lint-file': args['lint-file'] as string | undefined,
   })
+  const issueRepairInput = resolveIssueRepairInput({
+    'repair-file': args['repair-file'] as string | undefined,
+    simulate: args.simulate as boolean | undefined,
+  })
   const auditIssuesInput = resolveAuditIssuesInput({
     'audit-issues': args['audit-issues'] as boolean | undefined,
     issue: args.issue as string[] | undefined,
+    'repair-file': args['repair-file'] as string | undefined,
     simulate: args.simulate as boolean | undefined,
   })
   const issueSimulationTarget = resolveIssueSimulationTarget({
@@ -439,6 +472,49 @@ async function main() {
     assertIssueLintCompatible(args)
   }
 
+  if (issueRepairInput) {
+    assertIssueRepairCompatible({
+      'wake-now': args['wake-now'] as boolean | undefined,
+      'wake-issue': args['wake-issue'] as string | undefined,
+      'wake-pr': args['wake-pr'] as string | undefined,
+      'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'audit-issues': args['audit-issues'] as boolean | undefined,
+      'lint-issue': args['lint-issue'] as string | undefined,
+      'lint-file': args['lint-file'] as string | undefined,
+      'simulate-issue': args['simulate-issue'] as string | undefined,
+      'simulate-file': args['simulate-file'] as string | undefined,
+      'rewrite-file': args['rewrite-file'] as string | undefined,
+      'split-file': args['split-file'] as string | undefined,
+      'split-start-number': args['split-start-number'] as string | undefined,
+      concurrency: args.concurrency as string | undefined,
+      'poll-interval': args['poll-interval'] as string | undefined,
+      'idle-poll-interval': args['idle-poll-interval'] as string | undefined,
+      'machine-id': args['machine-id'] as string | undefined,
+      'dry-run': args['dry-run'] as boolean | undefined,
+      'metrics-port': args['metrics-port'] as string | undefined,
+      dashboard: args.dashboard as boolean | undefined,
+      'dashboard-host': args['dashboard-host'] as string | undefined,
+      'dashboard-port': args['dashboard-port'] as string | undefined,
+      daemonize: args.daemonize as boolean | undefined,
+      'join-project': args['join-project'] as boolean | undefined,
+      'repo-cap': args['repo-cap'] as string | undefined,
+      runtimes: args.runtimes as boolean | undefined,
+      start: args.start as boolean | undefined,
+      logs: args.logs as boolean | undefined,
+      reconcile: args.reconcile as boolean | undefined,
+      restart: args.restart as boolean | undefined,
+      'launchd-install': args['launchd-install'] as boolean | undefined,
+      'launchd-uninstall': args['launchd-uninstall'] as boolean | undefined,
+      'launchd-status': args['launchd-status'] as boolean | undefined,
+      stop: args.stop as boolean | undefined,
+      once: args.once as boolean | undefined,
+      status: args.status as boolean | undefined,
+      doctor: args.doctor as boolean | undefined,
+      'health-host': args['health-host'] as string | undefined,
+      'health-port': args['health-port'] as string | undefined,
+    })
+  }
+
   if (auditIssuesInput) {
     assertAuditIssuesCompatible({
       'wake-now': args['wake-now'] as boolean | undefined,
@@ -449,6 +525,7 @@ async function main() {
       'lint-file': args['lint-file'] as string | undefined,
       'simulate-issue': args['simulate-issue'] as string | undefined,
       'simulate-file': args['simulate-file'] as string | undefined,
+      'repair-file': args['repair-file'] as string | undefined,
       'rewrite-file': args['rewrite-file'] as string | undefined,
       'split-file': args['split-file'] as string | undefined,
       'split-start-number': args['split-start-number'] as string | undefined,
@@ -487,6 +564,7 @@ async function main() {
       'wake-issue': args['wake-issue'] as string | undefined,
       'wake-pr': args['wake-pr'] as string | undefined,
       'wake-from-github-event': args['wake-from-github-event'] as boolean | undefined,
+      'repair-file': args['repair-file'] as string | undefined,
       'lint-issue': args['lint-issue'] as string | undefined,
       'lint-file': args['lint-file'] as string | undefined,
       'simulate-issue': args['simulate-issue'] as string | undefined,
@@ -531,6 +609,7 @@ async function main() {
       'lint-file': args['lint-file'] as string | undefined,
       'simulate-issue': args['simulate-issue'] as string | undefined,
       'simulate-file': args['simulate-file'] as string | undefined,
+      'repair-file': args['repair-file'] as string | undefined,
       'rewrite-file': args['rewrite-file'] as string | undefined,
       concurrency: args.concurrency as string | undefined,
       'poll-interval': args['poll-interval'] as string | undefined,
@@ -571,6 +650,7 @@ async function main() {
       'lint-issue': args['lint-issue'] as string | undefined,
       'lint-file': args['lint-file'] as string | undefined,
       'rewrite-file': args['rewrite-file'] as string | undefined,
+      'repair-file': args['repair-file'] as string | undefined,
       'split-file': args['split-file'] as string | undefined,
       'split-start-number': args['split-start-number'] as string | undefined,
       concurrency: args.concurrency as string | undefined,
@@ -602,6 +682,10 @@ async function main() {
     })
   }
 
+  if (args.simulate && !auditIssuesInput && !issueRepairInput) {
+    throw new Error('--simulate requires --audit-issues or --repair-file')
+  }
+
   if (args['wake-from-github-event']) {
     if (wakeCommand) {
       throw new Error('--wake-from-github-event cannot be combined with --wake-now, --wake-issue, or --wake-pr')
@@ -614,6 +698,9 @@ async function main() {
     }
     if (issueSplitInput) {
       throw new Error('--wake-from-github-event cannot be combined with --split-file')
+    }
+    if (issueRepairInput) {
+      throw new Error('--wake-from-github-event cannot be combined with --repair-file')
     }
     if (auditIssuesInput) {
       throw new Error('--wake-from-github-event cannot be combined with --audit-issues')
@@ -718,6 +805,20 @@ async function main() {
     })
     console.log(formatIssueSplitOutput(result))
     process.exit(0)
+  }
+
+  if (issueRepairInput) {
+    const result = await executeIssueRepairCommand({
+      ...issueRepairInput,
+      repo: args.repo as string | undefined,
+      pat: args.pat as string | undefined,
+      repoRoot: process.cwd(),
+    })
+    console.log(formatIssueRepairOutput(result, args.json as boolean | undefined))
+    if (!result.success && !(args.json as boolean | undefined)) {
+      console.error(result.blockingFindings.map((finding) => `[repair] ${finding}`).join('\n'))
+    }
+    process.exit(shouldFailIssueRepairCommand(result) ? 1 : 0)
   }
 
   if (auditIssuesInput) {
@@ -1099,6 +1200,7 @@ Usage:
   agent-loop --wake-pr <number> [--repo owner/repo --machine-id my-dev-machine --health-port 9310]
   agent-loop --wake-from-github-event [--repo owner/repo --health-port 9310]
   agent-loop --audit-issues [--issue <number> ...] [--simulate] [--repo owner/repo --json]
+  agent-loop --repair-file <path> [--simulate] [--repo owner/repo --json]
   agent-loop --lint-file <path> [--json]
   agent-loop --lint-issue <number> [--repo owner/repo --json]
   agent-loop --simulate-file <path> [--repo owner/repo --json]
@@ -1139,7 +1241,8 @@ Options:
       --github-event-path     Override the GitHub event payload path used by --wake-from-github-event
       --audit-issues          Audit open managed issues or an explicit repeated --issue set
       --issue <number>        With --audit-issues, restrict auditing to the selected issue numbers
-      --simulate              With --audit-issues, include read-only simulation findings
+      --simulate              With --audit-issues or --repair-file, include read-only simulation findings
+      --repair-file <path>    Repair a local issue draft by consuming lint and optional simulate findings
       --lint-file <path>      Lint a local issue markdown file
       --lint-issue <number>   Lint a remote GitHub issue body
       --simulate-file <path>  Run read-only executability simulation for a local issue markdown file
@@ -1193,6 +1296,7 @@ Examples:
   agent-loop --wake-pr 381 --health-port 9311
   agent-loop --audit-issues --json
   agent-loop --audit-issues --issue 50 --issue 53 --simulate --repo owner/repo --json
+  agent-loop --repair-file docs/issues/broken.md --simulate --json
   agent-loop --lint-file docs/issues/ready-gate.md --json
   agent-loop --lint-issue 374 --repo owner/repo --json
   agent-loop --simulate-file docs/issues/ready-gate.md --json
@@ -1327,6 +1431,7 @@ export function resolveIssueLintTarget(args: {
 export function resolveAuditIssuesInput(args: {
   'audit-issues'?: boolean
   issue?: string[]
+  'repair-file'?: string
   simulate?: boolean
 }): AuditIssuesCommandInput | null {
   const rawIssueArgs = Array.isArray(args.issue) ? args.issue : []
@@ -1335,7 +1440,7 @@ export function resolveAuditIssuesInput(args: {
     if (rawIssueArgs.length > 0) {
       throw new Error('--issue requires --audit-issues')
     }
-    if (args.simulate) {
+    if (args.simulate && typeof args['repair-file'] !== 'string') {
       throw new Error('--simulate requires --audit-issues')
     }
     return null
@@ -1353,6 +1458,28 @@ export function resolveAuditIssuesInput(args: {
 
   return {
     issueNumbers,
+    includeSimulation: Boolean(args.simulate),
+  }
+}
+
+export function resolveIssueRepairInput(args: {
+  'repair-file'?: string
+  simulate?: boolean
+}): {
+  path: string
+  includeSimulation: boolean
+} | null {
+  if (typeof args['repair-file'] !== 'string') {
+    return null
+  }
+
+  const path = args['repair-file'].trim()
+  if (!path) {
+    throw new Error('--repair-file must be a non-empty path')
+  }
+
+  return {
+    path,
     includeSimulation: Boolean(args.simulate),
   }
 }
@@ -1531,6 +1658,63 @@ export async function executeIssueRewriteCommand(
   })
 }
 
+export async function executeIssueRepairCommand(
+  input: ExecuteIssueRepairInput,
+  deps: IssueRepairCommandDependencies = DEFAULT_ISSUE_REPAIR_COMMAND_DEPENDENCIES,
+): Promise<RepairIssueDraftResult> {
+  const config = deps.loadConfig({
+    repo: input.repo,
+    pat: input.pat,
+  })
+  const issueText = deps.readIssueDraftFile(input.path)
+  const repoRoot = input.repoRoot ?? process.cwd()
+
+  return deps.repairIssueDraft({
+    issueText,
+    repoRoot,
+    includeSimulation: input.includeSimulation,
+  }, {
+    runAgent: async ({ prompt, repoRoot: worktreePath }) => {
+      const result = await deps.runConfiguredAgent({
+        prompt,
+        worktreePath,
+        timeoutMs: config.agent.timeoutMs,
+        config,
+        logger: console,
+        allowWrites: false,
+      })
+
+      if (!result.ok) {
+        throw new Error(result.stderr || result.stdout || 'Issue repair agent execution failed')
+      }
+
+      return {
+        responseText: result.responseText,
+      }
+    },
+    runPlanner: input.includeSimulation
+      ? async ({ prompt, repoRoot: worktreePath }) => {
+          const result = await deps.runConfiguredAgent({
+            prompt,
+            worktreePath,
+            timeoutMs: config.agent.timeoutMs,
+            config,
+            logger: console,
+            allowWrites: false,
+          })
+
+          if (!result.ok) {
+            throw new Error(result.stderr || result.stdout || 'Issue repair simulation execution failed')
+          }
+
+          return {
+            responseText: result.responseText,
+          }
+        }
+      : undefined,
+  })
+}
+
 export async function executeIssueSimulationCommand(
   input: ExecuteIssueSimulationInput,
   deps: IssueSimulationCommandDependencies = DEFAULT_ISSUE_SIMULATION_COMMAND_DEPENDENCIES,
@@ -1660,6 +1844,13 @@ export function formatAuditIssuesOutput(
   return formatAuditOutput(report, asJson)
 }
 
+export function formatIssueRepairOutput(
+  result: RepairIssueDraftResult,
+  asJson = false,
+): string {
+  return formatIssueRepairResult(result, asJson)
+}
+
 export function formatIssueSplitOutput(
   result: SplitTrackingIssueResult,
 ): string {
@@ -1670,6 +1861,12 @@ export function shouldFailAuditIssuesCommand(
   result: ExecuteAuditIssuesResult,
 ): boolean {
   return result.explicitIssueNumbers.length > 0 && result.report.summary.invalidIssueCount > 0
+}
+
+export function shouldFailIssueRepairCommand(
+  result: RepairIssueDraftResult,
+): boolean {
+  return !result.success
 }
 
 export function formatIssueSimulationOutput(
@@ -2021,6 +2218,7 @@ function assertAuditIssuesCompatible(args: {
   'wake-issue'?: string
   'wake-pr'?: string
   'wake-from-github-event'?: boolean
+  'repair-file'?: string
   'lint-issue'?: string
   'lint-file'?: string
   'simulate-issue'?: string
@@ -2060,6 +2258,7 @@ function assertAuditIssuesCompatible(args: {
     typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
     typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
     args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['repair-file'] === 'string' ? '--repair-file' : null,
     typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
     typeof args['lint-file'] === 'string' ? '--lint-file' : null,
     typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
@@ -2105,6 +2304,7 @@ function assertIssueRewriteCompatible(args: {
   'wake-issue'?: string
   'wake-pr'?: string
   'wake-from-github-event'?: boolean
+  'repair-file'?: string
   'lint-issue'?: string
   'lint-file'?: string
   'simulate-issue'?: string
@@ -2142,6 +2342,7 @@ function assertIssueRewriteCompatible(args: {
     typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
     typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
     args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['repair-file'] === 'string' ? '--repair-file' : null,
     typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
     typeof args['lint-file'] === 'string' ? '--lint-file' : null,
     typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
@@ -2185,6 +2386,7 @@ function assertIssueSplitCompatible(args: {
   'wake-issue'?: string
   'wake-pr'?: string
   'wake-from-github-event'?: boolean
+  'repair-file'?: string
   'lint-issue'?: string
   'lint-file'?: string
   'simulate-issue'?: string
@@ -2223,6 +2425,7 @@ function assertIssueSplitCompatible(args: {
     typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
     typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
     args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['repair-file'] === 'string' ? '--repair-file' : null,
     typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
     typeof args['lint-file'] === 'string' ? '--lint-file' : null,
     typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
@@ -2267,6 +2470,7 @@ function assertIssueSimulationCompatible(args: {
   'wake-issue'?: string
   'wake-pr'?: string
   'wake-from-github-event'?: boolean
+  'repair-file'?: string
   'lint-issue'?: string
   'lint-file'?: string
   'rewrite-file'?: string
@@ -2304,6 +2508,7 @@ function assertIssueSimulationCompatible(args: {
     typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
     typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
     args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    typeof args['repair-file'] === 'string' ? '--repair-file' : null,
     typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
     typeof args['lint-file'] === 'string' ? '--lint-file' : null,
     typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
@@ -2339,6 +2544,92 @@ function assertIssueSimulationCompatible(args: {
 
   if (incompatibleFlags.length > 0) {
     throw new Error(`Issue simulate cannot be combined with ${incompatibleFlags.join(', ')}`)
+  }
+}
+
+function assertIssueRepairCompatible(args: {
+  'wake-now'?: boolean
+  'wake-issue'?: string
+  'wake-pr'?: string
+  'wake-from-github-event'?: boolean
+  'audit-issues'?: boolean
+  'lint-issue'?: string
+  'lint-file'?: string
+  'simulate-issue'?: string
+  'simulate-file'?: string
+  'rewrite-file'?: string
+  'split-file'?: string
+  'split-start-number'?: string
+  concurrency?: string
+  'poll-interval'?: string
+  'idle-poll-interval'?: string
+  'machine-id'?: string
+  'dry-run'?: boolean
+  'metrics-port'?: string
+  dashboard?: boolean
+  'dashboard-host'?: string
+  'dashboard-port'?: string
+  daemonize?: boolean
+  'join-project'?: boolean
+  'repo-cap'?: string
+  runtimes?: boolean
+  start?: boolean
+  logs?: boolean
+  reconcile?: boolean
+  restart?: boolean
+  'launchd-install'?: boolean
+  'launchd-uninstall'?: boolean
+  'launchd-status'?: boolean
+  stop?: boolean
+  once?: boolean
+  status?: boolean
+  doctor?: boolean
+  'health-host'?: string
+  'health-port'?: string
+}): void {
+  const incompatibleFlags = [
+    args['wake-now'] ? '--wake-now' : null,
+    typeof args['wake-issue'] === 'string' ? '--wake-issue' : null,
+    typeof args['wake-pr'] === 'string' ? '--wake-pr' : null,
+    args['wake-from-github-event'] ? '--wake-from-github-event' : null,
+    args['audit-issues'] ? '--audit-issues' : null,
+    typeof args['lint-issue'] === 'string' ? '--lint-issue' : null,
+    typeof args['lint-file'] === 'string' ? '--lint-file' : null,
+    typeof args['simulate-issue'] === 'string' ? '--simulate-issue' : null,
+    typeof args['simulate-file'] === 'string' ? '--simulate-file' : null,
+    typeof args['rewrite-file'] === 'string' ? '--rewrite-file' : null,
+    typeof args['split-file'] === 'string' ? '--split-file' : null,
+    typeof args['split-start-number'] === 'string' ? '--split-start-number' : null,
+    typeof args.concurrency === 'string' ? '--concurrency' : null,
+    typeof args['poll-interval'] === 'string' ? '--poll-interval' : null,
+    typeof args['idle-poll-interval'] === 'string' ? '--idle-poll-interval' : null,
+    typeof args['machine-id'] === 'string' ? '--machine-id' : null,
+    args['dry-run'] ? '--dry-run' : null,
+    typeof args['metrics-port'] === 'string' ? '--metrics-port' : null,
+    args.dashboard ? '--dashboard' : null,
+    typeof args['dashboard-host'] === 'string' ? '--dashboard-host' : null,
+    typeof args['dashboard-port'] === 'string' ? '--dashboard-port' : null,
+    args.daemonize ? '--daemonize' : null,
+    args['join-project'] ? '--join-project' : null,
+    typeof args['repo-cap'] === 'string' ? '--repo-cap' : null,
+    args.runtimes ? '--runtimes' : null,
+    args.start ? '--start' : null,
+    args.logs ? '--logs' : null,
+    args.reconcile ? '--reconcile' : null,
+    args.restart ? '--restart' : null,
+    args['launchd-install'] ? '--launchd-install' : null,
+    args['launchd-uninstall'] ? '--launchd-uninstall' : null,
+    args['launchd-status'] ? '--launchd-status' : null,
+    args.stop ? '--stop' : null,
+    args.once ? '--once' : null,
+    args.status ? '--status' : null,
+    args.doctor ? '--doctor' : null,
+    typeof args['health-host'] === 'string' ? '--health-host' : null,
+    typeof args['health-port'] === 'string' ? '--health-port' : null,
+  ].filter((flag): flag is string => flag !== null)
+
+  if (incompatibleFlags.length > 0) {
+    throw new Error(`Issue repair cannot be combined with ${incompatibleFlags.join(', ')}`)
   }
 }
 

--- a/apps/agent-daemon/src/issue-apply.test.ts
+++ b/apps/agent-daemon/src/issue-apply.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  applyIssueBodyUpdate,
+  formatIssueApplyResult,
+} from './issue-apply'
+
+const VALID_MARKDOWN = [
+  '## 用户故事',
+  '作为维护者，我希望安全回写 issue contract。',
+  '',
+  '## Context',
+  '### Dependencies',
+  '```json',
+  '{ "dependsOn": [53] }',
+  '```',
+  '### Constraints',
+  '- 只更新 issue body',
+  '### AllowedFiles',
+  '- apps/agent-daemon/src/issue-apply.ts',
+  '### ForbiddenFiles',
+  '- apps/agent-daemon/src/dashboard.ts',
+  '### MustPreserve',
+  '- stale write 必须失败',
+  '### OutOfScope',
+  '- 自动加 label',
+  '### RequiredSemantics',
+  '- apply 只回写 canonical markdown',
+  '### ReviewHints',
+  '- 优先检查并发保护',
+  '### Validation',
+  '- `bun test apps/agent-daemon/src/issue-apply.test.ts`',
+  '',
+  '## RED 测试',
+  '```ts',
+  'expect(true).toBe(false)',
+  '```',
+  '',
+  '## 实现步骤',
+  '1. 先做远端并发保护',
+  '',
+  '## 验收',
+  '- [ ] stale write 被阻止',
+].join('\n')
+
+describe('applyIssueBodyUpdate', () => {
+  test('returns conflict when the remote issue changed after the expected timestamp', async () => {
+    const result = await applyIssueBodyUpdate({
+      issueNumber: 54,
+      markdown: VALID_MARKDOWN,
+      expectedUpdatedAt: '2026-04-11T10:00:00.000Z',
+      config: { repo: 'owner/repo' } as never,
+      fetchIssue: async () => ({
+        number: 54,
+        title: '[AL-14] apply',
+        body: 'remote body',
+        url: 'https://github.com/owner/repo/issues/54',
+        updatedAt: '2026-04-11T10:05:00.000Z',
+      }),
+      updateIssueBody: async () => {
+        throw new Error('should not patch on conflict')
+      },
+    })
+
+    expect(result.status).toBe('conflict')
+    expect(result.updated).toBe(false)
+  })
+
+  test('patches the remote issue only when the snapshot still matches expectations', async () => {
+    const calls: string[] = []
+    const result = await applyIssueBodyUpdate({
+      issueNumber: 54,
+      markdown: VALID_MARKDOWN,
+      expectedUpdatedAt: '2026-04-11T10:00:00.000Z',
+      config: { repo: 'owner/repo' } as never,
+      fetchIssue: async () => ({
+        number: 54,
+        title: '[AL-14] apply',
+        body: 'older body',
+        url: 'https://github.com/owner/repo/issues/54',
+        updatedAt: '2026-04-11T10:00:00.000Z',
+      }),
+      updateIssueBody: async ({ issueNumber, body }) => {
+        calls.push(`patch:${issueNumber}`)
+        expect(body).toBe(VALID_MARKDOWN)
+        return {
+          number: issueNumber,
+          url: 'https://github.com/owner/repo/issues/54',
+          updatedAt: '2026-04-11T10:06:00.000Z',
+        }
+      },
+    })
+
+    expect(calls).toEqual(['patch:54'])
+    expect(result.status).toBe('updated')
+    expect(result.updated).toBe(true)
+    expect(result.newUpdatedAt).toBe('2026-04-11T10:06:00.000Z')
+  })
+
+  test('returns noop without patching when the remote body already matches', async () => {
+    const result = await applyIssueBodyUpdate({
+      issueNumber: 54,
+      markdown: VALID_MARKDOWN,
+      expectedUpdatedAt: '2026-04-11T10:00:00.000Z',
+      config: { repo: 'owner/repo' } as never,
+      fetchIssue: async () => ({
+        number: 54,
+        title: '[AL-14] apply',
+        body: VALID_MARKDOWN,
+        url: 'https://github.com/owner/repo/issues/54',
+        updatedAt: '2026-04-11T10:05:00.000Z',
+      }),
+      updateIssueBody: async () => {
+        throw new Error('should not patch when the body already matches')
+      },
+    })
+
+    expect(result.status).toBe('noop')
+    expect(result.updated).toBe(false)
+    expect(result.newUpdatedAt).toBe('2026-04-11T10:05:00.000Z')
+  })
+
+  test('rejects invalid markdown before reading the remote issue', async () => {
+    const result = await applyIssueBodyUpdate({
+      issueNumber: 54,
+      markdown: '## 用户故事\n只有用户故事',
+      config: { repo: 'owner/repo' } as never,
+      expectedUpdatedAt: '2026-04-11T10:00:00.000Z',
+      fetchIssue: async () => {
+        throw new Error('should not fetch the remote issue for invalid markdown')
+      },
+    })
+
+    expect(result.status).toBe('invalid')
+    expect(result.updated).toBe(false)
+    expect(result.validation.valid).toBe(false)
+    expect(formatIssueApplyResult(result, true)).toContain('"status": "invalid"')
+  })
+})

--- a/apps/agent-daemon/src/issue-apply.ts
+++ b/apps/agent-daemon/src/issue-apply.ts
@@ -1,0 +1,164 @@
+import {
+  fetchIssueBodySnapshot,
+  type AgentConfig,
+  type IssueBodySnapshot,
+  type IssueBodyUpdateResult,
+  updateIssueBody,
+} from '@agent/shared'
+import {
+  buildIssueLintReport,
+  formatIssueLintReport,
+  type IssueLintReport,
+} from './audit-issue-contracts'
+
+export type ApplyIssueBodyUpdateStatus =
+  | 'updated'
+  | 'noop'
+  | 'conflict'
+  | 'invalid'
+
+export interface ApplyIssueBodyUpdateResult {
+  status: ApplyIssueBodyUpdateStatus
+  updated: boolean
+  issueNumber: number
+  issueUrl: string | null
+  oldUpdatedAt: string | null
+  newUpdatedAt: string | null
+  expectedUpdatedAt: string | null
+  validation: IssueLintReport
+  message: string
+}
+
+export type IssueBodySnapshotFetcher = (input: {
+  issueNumber: number
+  config: AgentConfig
+}) => Promise<IssueBodySnapshot>
+
+export type IssueBodyRemoteUpdater = (input: {
+  issueNumber: number
+  body: string
+  config: AgentConfig
+}) => Promise<IssueBodyUpdateResult>
+
+export interface ApplyIssueBodyUpdateInput {
+  issueNumber: number
+  markdown: string
+  config: AgentConfig
+  expectedUpdatedAt?: string
+  force?: boolean
+  fetchIssue?: IssueBodySnapshotFetcher
+  updateIssueBody?: IssueBodyRemoteUpdater
+}
+
+export async function applyIssueBodyUpdate(
+  input: ApplyIssueBodyUpdateInput,
+): Promise<ApplyIssueBodyUpdateResult> {
+  const validation = buildIssueLintReport(input.markdown, {
+    kind: 'file',
+    path: 'stdin',
+  })
+
+  if (!validation.valid) {
+    return {
+      status: 'invalid',
+      updated: false,
+      issueNumber: input.issueNumber,
+      issueUrl: null,
+      oldUpdatedAt: null,
+      newUpdatedAt: null,
+      expectedUpdatedAt: input.expectedUpdatedAt ?? null,
+      validation,
+      message: `Local issue contract failed validation:\n${formatIssueLintReport(validation)}`,
+    }
+  }
+
+  const fetchIssue = input.fetchIssue ?? (async ({ issueNumber, config }: {
+    issueNumber: number
+    config: AgentConfig
+  }) => fetchIssueBodySnapshot(issueNumber, config))
+  const remoteIssue = await fetchIssue({
+    issueNumber: input.issueNumber,
+    config: input.config,
+  })
+
+  if (remoteIssue.body === input.markdown) {
+    return {
+      status: 'noop',
+      updated: false,
+      issueNumber: remoteIssue.number,
+      issueUrl: remoteIssue.url,
+      oldUpdatedAt: remoteIssue.updatedAt,
+      newUpdatedAt: remoteIssue.updatedAt,
+      expectedUpdatedAt: input.expectedUpdatedAt ?? null,
+      validation,
+      message: 'Remote issue body already matches target markdown',
+    }
+  }
+
+  if (
+    !input.force
+    && typeof input.expectedUpdatedAt === 'string'
+    && remoteIssue.updatedAt !== input.expectedUpdatedAt
+  ) {
+    return {
+      status: 'conflict',
+      updated: false,
+      issueNumber: remoteIssue.number,
+      issueUrl: remoteIssue.url,
+      oldUpdatedAt: remoteIssue.updatedAt,
+      newUpdatedAt: null,
+      expectedUpdatedAt: input.expectedUpdatedAt,
+      validation,
+      message: `Remote issue updatedAt changed from expected ${input.expectedUpdatedAt} to ${remoteIssue.updatedAt}`,
+    }
+  }
+
+  const updateRemoteIssueBody = input.updateIssueBody ?? (async ({ issueNumber, body, config }: {
+    issueNumber: number
+    body: string
+    config: AgentConfig
+  }) => updateIssueBody(issueNumber, body, config))
+  const updatedIssue = await updateRemoteIssueBody({
+    issueNumber: input.issueNumber,
+    body: input.markdown,
+    config: input.config,
+  })
+
+  return {
+    status: 'updated',
+    updated: true,
+    issueNumber: updatedIssue.number,
+    issueUrl: updatedIssue.url,
+    oldUpdatedAt: remoteIssue.updatedAt,
+    newUpdatedAt: updatedIssue.updatedAt,
+    expectedUpdatedAt: input.expectedUpdatedAt ?? null,
+    validation,
+    message: 'Remote issue body updated',
+  }
+}
+
+export function formatIssueApplyResult(
+  result: ApplyIssueBodyUpdateResult,
+  asJson = false,
+): string {
+  if (asJson) {
+    return JSON.stringify(result, null, 2)
+  }
+
+  const lines = [
+    `status=${result.status}`,
+    `updated=${result.updated}`,
+    `issue=${result.issueNumber}`,
+    `url=${result.issueUrl ?? '-'}`,
+    `oldUpdatedAt=${result.oldUpdatedAt ?? '-'}`,
+    `newUpdatedAt=${result.newUpdatedAt ?? '-'}`,
+  ]
+
+  if (result.expectedUpdatedAt) {
+    lines.push(`expectedUpdatedAt=${result.expectedUpdatedAt}`)
+  }
+
+  lines.push(`message=${result.message}`)
+
+  return lines.join('\n')
+}

--- a/apps/agent-daemon/src/issue-authoring-context.test.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.test.ts
@@ -63,4 +63,46 @@ describe('buildRepoAuthoringContext', () => {
     expect(context.candidateForbiddenFiles).toContain('tsconfig.json')
     expect(context.candidateForbiddenFiles.some((value) => value.startsWith(root))).toBe(false)
   })
+
+  test('merges project issue authoring rules ahead of repo-grounded candidates', async () => {
+    const context = await buildRepoAuthoringContext({
+      repoRoot: '/repo',
+      issueText: '增加 issue repair CLI',
+      repoRelativeFilePaths: [
+        'apps/agent-daemon/src/issue-repair.ts',
+        'apps/agent-daemon/src/issue-repair.test.ts',
+        'apps/agent-daemon/src/dashboard.ts',
+      ],
+      project: {
+        profile: 'generic',
+        issueAuthoring: {
+          preferredValidationCommands: [
+            'bun test apps/agent-daemon/src/issue-repair.test.ts',
+          ],
+          preferredAllowedFiles: [
+            'apps/agent-daemon/src/issue-repair.ts',
+            'apps/agent-daemon/src/issue-repair.test.ts',
+          ],
+          forbiddenPaths: [
+            'apps/agent-daemon/src/dashboard.ts',
+          ],
+          reviewHints: [
+            '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+          ],
+        },
+      },
+    })
+
+    expect(context.candidateValidationCommands).toContain(
+      'bun test apps/agent-daemon/src/issue-repair.test.ts',
+    )
+    expect(context.candidateAllowedFiles.slice(0, 2)).toEqual([
+      'apps/agent-daemon/src/issue-repair.ts',
+      'apps/agent-daemon/src/issue-repair.test.ts',
+    ])
+    expect(context.candidateForbiddenFiles).toContain('apps/agent-daemon/src/dashboard.ts')
+    expect(context.candidateReviewHints).toContain(
+      '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+    )
+  })
 })

--- a/apps/agent-daemon/src/issue-authoring-context.test.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildRepoAuthoringContext } from './issue-authoring-context'
+
+describe('buildRepoAuthoringContext', () => {
+  test('collects workspace validation commands and repo-relative file candidates', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-'))
+    mkdirSync(join(root, 'apps/example/src/pages'), { recursive: true })
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+        typecheck: 'bun run typecheck',
+      },
+      workspaces: ['apps/*'],
+    }))
+    writeFileSync(join(root, 'apps/example/package.json'), JSON.stringify({
+      name: 'example',
+      scripts: {
+        test: 'bun run --bun test src/pages/LoginPage.test.tsx',
+      },
+    }))
+    writeFileSync(join(root, 'apps/example/src/pages/LoginPage.tsx'), 'export function LoginPage() { return null }\n')
+    writeFileSync(join(root, 'apps/example/src/pages/LoginPage.test.tsx'), 'export {}\n')
+
+    const context = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '修复 LoginPage 的登录重定向，并补上对应测试',
+    })
+
+    expect(context.candidateValidationCommands).toContain(
+      'bun run --bun test apps/example/src/pages/LoginPage.test.tsx',
+    )
+    expect(context.candidateAllowedFiles).toContain('apps/example/src/pages/LoginPage.tsx')
+    expect(context.candidateAllowedFiles).toContain('apps/example/src/pages/LoginPage.test.tsx')
+    expect(context.candidateAllowedFiles.some((value) => value.startsWith(root))).toBe(false)
+  })
+
+  test('keeps config-like forbidden candidates repo-relative for product issues', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-authoring-forbidden-'))
+    mkdirSync(join(root, 'apps/example/src/pages'), { recursive: true })
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+      },
+    }))
+    writeFileSync(join(root, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        strict: true,
+      },
+    }))
+    writeFileSync(join(root, 'apps/example/src/pages/BillingPage.tsx'), 'export function BillingPage() { return null }\n')
+
+    const context = await buildRepoAuthoringContext({
+      repoRoot: root,
+      issueText: '调整 BillingPage 的文案和状态展示',
+    })
+
+    expect(context.candidateForbiddenFiles).toContain('package.json')
+    expect(context.candidateForbiddenFiles).toContain('tsconfig.json')
+    expect(context.candidateForbiddenFiles.some((value) => value.startsWith(root))).toBe(false)
+  })
+})

--- a/apps/agent-daemon/src/issue-authoring-context.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.ts
@@ -1,0 +1,475 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, posix, relative, resolve } from 'node:path'
+import type {
+  BuildRepoAuthoringContextInput,
+  RepoAuthoringContext,
+} from '../../../packages/agent-shared/src'
+
+interface PackageScriptRecord {
+  packageDir: string
+  scriptName: string
+  command: string
+}
+
+interface FileScore {
+  path: string
+  score: number
+}
+
+const SKIPPED_DIRECTORIES = new Set<string>([
+  '.agent-loop',
+  '.git',
+  '.runtime',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+])
+
+const VALIDATION_SCRIPT_NAME_PATTERN = /(?:^|:)(test|typecheck|lint|check|verify|validate|build)$/i
+const TEST_INTENT_PATTERN = /\b(test|tests|spec|jest|vitest|coverage|e2e)\b|测试|用例/i
+const CONFIG_INTENT_PATTERN = /\b(config|tsconfig|package|dependency|dependencies|deps|lockfile|workspace|script|build|ci)\b|配置|依赖|脚本|构建/i
+const ROOT_FORBIDDEN_FILE_PATTERNS = [
+  /^package\.json$/,
+  /^bun\.lockb?$/,
+  /^package-lock\.json$/,
+  /^pnpm-lock\.yaml$/,
+  /^yarn\.lock$/,
+  /^tsconfig(?:\..+)?\.json$/,
+] as const
+
+export async function buildRepoAuthoringContext(
+  input: BuildRepoAuthoringContextInput,
+): Promise<RepoAuthoringContext> {
+  const repoRoot = resolve(input.repoRoot)
+  const repoFiles = await listRepoFiles(repoRoot)
+  const issueTokens = tokenize(input.issueText)
+  const candidateAllowedFiles = collectCandidateAllowedFiles({
+    issueText: input.issueText,
+    issueTokens,
+    repoFiles,
+    limit: input.maxAllowedFiles ?? 8,
+  })
+  const candidateValidationCommands = await collectCandidateValidationCommands({
+    repoRoot,
+    repoFiles,
+    issueTokens,
+    candidateAllowedFiles,
+    limit: input.maxValidationCommands ?? 8,
+  })
+  const candidateForbiddenFiles = collectCandidateForbiddenFiles({
+    issueText: input.issueText,
+    repoFiles,
+    candidateAllowedFiles,
+    limit: input.maxForbiddenFiles ?? 5,
+  })
+
+  return {
+    candidateValidationCommands,
+    candidateAllowedFiles,
+    candidateForbiddenFiles,
+  }
+}
+
+async function collectCandidateValidationCommands(input: {
+  repoRoot: string
+  repoFiles: string[]
+  issueTokens: string[]
+  candidateAllowedFiles: string[]
+  limit: number
+}): Promise<string[]> {
+  const packageScriptRecords = await listPackageScriptRecords(input.repoRoot, input.repoFiles)
+  const allowedPackages = new Set(
+    packageScriptRecords
+      .map((record) => record.packageDir)
+      .filter((packageDir) => (
+        input.candidateAllowedFiles.some((file) => isFileInsidePackage(file, packageDir))
+      )),
+  )
+  const allowedFileSet = new Set(input.candidateAllowedFiles)
+
+  const scored = packageScriptRecords.map((record) => ({
+    command: record.command,
+    score: scoreValidationCommand({
+      ...record,
+      issueTokens: input.issueTokens,
+      candidateAllowedFiles: allowedFileSet,
+      isRelevantPackage: allowedPackages.has(record.packageDir),
+    }),
+  }))
+
+  const deduped = new Map<string, number>()
+  for (const record of scored) {
+    const previous = deduped.get(record.command)
+    if (previous === undefined || record.score > previous) {
+      deduped.set(record.command, record.score)
+    }
+  }
+
+  const preferred = [...deduped.entries()]
+    .filter(([, score]) => score > 0)
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .map(([command]) => command)
+
+  if (preferred.length >= input.limit) {
+    return preferred.slice(0, input.limit)
+  }
+
+  const fallback = [...deduped.keys()]
+    .filter(command => !preferred.includes(command))
+    .sort((left, right) => left.localeCompare(right))
+
+  return [...preferred, ...fallback].slice(0, input.limit)
+}
+
+async function listPackageScriptRecords(
+  repoRoot: string,
+  repoFiles: string[],
+): Promise<PackageScriptRecord[]> {
+  const records: PackageScriptRecord[] = []
+
+  for (const file of repoFiles) {
+    if (!file.endsWith('/package.json') && file !== 'package.json') {
+      continue
+    }
+
+    const packageJsonPath = resolve(repoRoot, file)
+    const manifest = await readJsonFile(packageJsonPath)
+    if (!manifest || typeof manifest !== 'object') {
+      continue
+    }
+
+    const scripts = readStringMap((manifest as { scripts?: unknown }).scripts)
+    const packageDir = dirname(file)
+
+    for (const [scriptName, command] of Object.entries(scripts)) {
+      if (!isValidationScript(scriptName, command)) {
+        continue
+      }
+
+      records.push({
+        packageDir: packageDir === '.' ? '' : packageDir,
+        scriptName,
+        command: rewriteWorkspaceCommandPaths(command, {
+          repoRoot,
+          packageDir: packageDir === '.' ? '' : packageDir,
+          repoFiles,
+        }),
+      })
+    }
+  }
+
+  return records.sort((left, right) => (
+    left.packageDir.localeCompare(right.packageDir)
+    || left.scriptName.localeCompare(right.scriptName)
+    || left.command.localeCompare(right.command)
+  ))
+}
+
+function collectCandidateAllowedFiles(input: {
+  issueText: string
+  issueTokens: string[]
+  repoFiles: string[]
+  limit: number
+}): string[] {
+  const hasTestIntent = TEST_INTENT_PATTERN.test(input.issueText)
+  const scored = input.repoFiles
+    .map((file) => ({
+      path: file,
+      score: scoreCandidateFile(file, input.issueText, input.issueTokens, hasTestIntent),
+    }))
+    .filter((record) => record.score > 0)
+    .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
+
+  const selected = new Map<string, FileScore>()
+  for (const record of scored) {
+    if (selected.size >= input.limit) break
+    selected.set(record.path, record)
+  }
+
+  if (hasTestIntent) {
+    for (const companion of collectCompanionTestFiles([...selected.keys()], input.repoFiles)) {
+      if (selected.size >= input.limit) break
+      selected.set(companion.path, companion)
+    }
+  }
+
+  return [...selected.values()]
+    .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
+    .map(record => record.path)
+}
+
+function collectCandidateForbiddenFiles(input: {
+  issueText: string
+  repoFiles: string[]
+  candidateAllowedFiles: string[]
+  limit: number
+}): string[] {
+  if (CONFIG_INTENT_PATTERN.test(input.issueText)) {
+    return []
+  }
+
+  const allowed = new Set(input.candidateAllowedFiles)
+
+  return input.repoFiles
+    .filter((file) => !file.includes('/'))
+    .filter((file) => ROOT_FORBIDDEN_FILE_PATTERNS.some(pattern => pattern.test(file)))
+    .filter(file => !allowed.has(file))
+    .sort((left, right) => left.localeCompare(right))
+    .slice(0, input.limit)
+}
+
+function scoreValidationCommand(input: PackageScriptRecord & {
+  issueTokens: string[]
+  candidateAllowedFiles: Set<string>
+  isRelevantPackage: boolean
+}): number {
+  const commandTokens = tokenize(`${input.scriptName} ${input.command}`)
+  const overlapScore = countTokenOverlap(input.issueTokens, commandTokens)
+  const allowedFileMentionScore = [...input.candidateAllowedFiles]
+    .some(file => input.command.includes(file))
+    ? 4
+    : 0
+  const packageScore = input.isRelevantPackage ? 3 : input.packageDir === '' ? 1 : 0
+
+  return allowedFileMentionScore + packageScore + overlapScore
+}
+
+function scoreCandidateFile(
+  file: string,
+  issueText: string,
+  issueTokens: string[],
+  hasTestIntent: boolean,
+): number {
+  const fileTokens = tokenize(file)
+  const overlap = countTokenOverlap(issueTokens, fileTokens)
+  const basename = posix.basename(file)
+  const comparableStem = compactToken(stripKnownFileSuffixes(basename))
+  const exactStemMention = comparableStem.length > 0 && compactToken(issueText).includes(comparableStem)
+    ? 4
+    : 0
+  const testBonus = hasTestIntent && isTestFile(file) ? 1 : 0
+  const packagePenalty = basename === 'package.json' ? 1 : 0
+
+  return (overlap * 2) + exactStemMention + testBonus - packagePenalty
+}
+
+function collectCompanionTestFiles(
+  selectedFiles: string[],
+  repoFiles: string[],
+): FileScore[] {
+  const selected = new Set(selectedFiles)
+  const companions: FileScore[] = []
+
+  for (const file of selectedFiles) {
+    const parent = posix.dirname(file)
+    const stem = stripKnownFileSuffixes(posix.basename(file))
+
+    for (const candidate of repoFiles) {
+      if (selected.has(candidate) || !isTestFile(candidate)) continue
+      if (posix.dirname(candidate) !== parent) continue
+      if (stripKnownFileSuffixes(posix.basename(candidate)) !== stem) continue
+
+      companions.push({
+        path: candidate,
+        score: 1,
+      })
+    }
+  }
+
+  return companions.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+function rewriteWorkspaceCommandPaths(
+  command: string,
+  input: {
+    repoRoot: string
+    packageDir: string
+    repoFiles: string[]
+  },
+): string {
+  if (!input.packageDir) {
+    return command
+  }
+
+  const repoPathSet = new Set(input.repoFiles)
+  const tokens = command.match(/"[^"]*"|'[^']*'|`[^`]*`|[^\s]+/g) ?? []
+
+  return tokens
+    .map((token) => rewriteCommandToken(token, input.repoRoot, input.packageDir, repoPathSet))
+    .join(' ')
+}
+
+function rewriteCommandToken(
+  token: string,
+  repoRoot: string,
+  packageDir: string,
+  repoPathSet: ReadonlySet<string>,
+): string {
+  const quote = token[0]
+  const isQuoted = quote === '"' || quote === '\'' || quote === '`'
+  const rawValue = isQuoted ? token.slice(1, -1) : token
+
+  if (!looksLikeRelativePathToken(rawValue)) {
+    return token
+  }
+
+  const absolute = resolve(repoRoot, packageDir, rawValue)
+  const repoRelative = toRepoRelative(repoRoot, absolute)
+  if (!repoRelative) {
+    return token
+  }
+
+  if (!repoContainsPath(repoRelative, repoPathSet)) {
+    return token
+  }
+
+  return isQuoted ? `${quote}${repoRelative}${quote}` : repoRelative
+}
+
+function looksLikeRelativePathToken(value: string): boolean {
+  if (!value) return false
+  if (value.startsWith('-')) return false
+  if (value.startsWith('$')) return false
+  if (value.includes('://')) return false
+  if (value.startsWith('/')) return false
+  if (value.includes('=')) return false
+
+  return value.includes('/') || value.startsWith('./') || value.startsWith('../')
+}
+
+function repoContainsPath(
+  repoRelative: string,
+  repoPathSet: ReadonlySet<string>,
+): boolean {
+  if (repoPathSet.has(repoRelative)) {
+    return true
+  }
+
+  return [...repoPathSet].some((path) => path.startsWith(`${repoRelative}/`))
+}
+
+function isValidationScript(scriptName: string, command: string): boolean {
+  return VALIDATION_SCRIPT_NAME_PATTERN.test(scriptName) || VALIDATION_SCRIPT_NAME_PATTERN.test(command)
+}
+
+function isFileInsidePackage(
+  file: string,
+  packageDir: string,
+): boolean {
+  if (!packageDir) {
+    return !file.includes('/')
+  }
+
+  return file === packageDir || file.startsWith(`${packageDir}/`)
+}
+
+function countTokenOverlap(left: string[], right: string[]): number {
+  const rightSet = new Set(right)
+  return left.filter(token => rightSet.has(token)).length
+}
+
+function tokenize(value: string): string[] {
+  const spaced = value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .toLowerCase()
+
+  return [...new Set(
+    spaced
+      .split(/\s+/)
+      .map(token => token.trim())
+      .filter(token => token.length >= 2),
+  )]
+}
+
+function compactToken(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+}
+
+function stripKnownFileSuffixes(value: string): string {
+  return value
+    .replace(/\.(test|spec)(?=\.[^.]+$)/i, '')
+    .replace(/\.[^.]+$/, '')
+}
+
+function isTestFile(file: string): boolean {
+  return /\.(test|spec)\.[^.]+$/i.test(file)
+}
+
+async function listRepoFiles(repoRoot: string): Promise<string[]> {
+  const files: string[] = []
+
+  await walkDirectory(repoRoot, '', files)
+
+  return files.sort((left, right) => left.localeCompare(right))
+}
+
+async function walkDirectory(
+  root: string,
+  relativeDir: string,
+  files: string[],
+): Promise<void> {
+  const directoryPath = relativeDir ? resolve(root, relativeDir) : root
+  const entries = await readdir(directoryPath, { withFileTypes: true })
+  entries.sort((left, right) => left.name.localeCompare(right.name))
+
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) {
+      continue
+    }
+
+    const nextRelative = relativeDir
+      ? posix.join(relativeDir, entry.name)
+      : entry.name
+
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIRECTORIES.has(entry.name)) {
+        continue
+      }
+
+      await walkDirectory(root, nextRelative, files)
+      continue
+    }
+
+    if (entry.isFile()) {
+      files.push(nextRelative)
+    }
+  }
+}
+
+function toRepoRelative(
+  repoRoot: string,
+  absolutePath: string,
+): string | null {
+  const relativePath = relative(repoRoot, absolutePath)
+  if (!relativePath || relativePath.startsWith('..')) {
+    return null
+  }
+
+  return relativePath.split('\\').join('/')
+}
+
+function readStringMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object') {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+      .sort((left, right) => left[0].localeCompare(right[0])),
+  )
+}
+
+async function readJsonFile(filePath: string): Promise<unknown | null> {
+  try {
+    const raw = await readFile(filePath, 'utf8')
+    return JSON.parse(raw) as unknown
+  } catch {
+    return null
+  }
+}

--- a/apps/agent-daemon/src/issue-authoring-context.ts
+++ b/apps/agent-daemon/src/issue-authoring-context.ts
@@ -1,8 +1,10 @@
 import { readdir, readFile } from 'node:fs/promises'
 import { dirname, posix, relative, resolve } from 'node:path'
-import type {
+import {
   BuildRepoAuthoringContextInput,
   RepoAuthoringContext,
+  getProjectIssueAuthoringRules,
+  type ProjectProfileConfig,
 } from '../../../packages/agent-shared/src'
 
 interface PackageScriptRecord {
@@ -42,33 +44,67 @@ export async function buildRepoAuthoringContext(
   input: BuildRepoAuthoringContextInput,
 ): Promise<RepoAuthoringContext> {
   const repoRoot = resolve(input.repoRoot)
-  const repoFiles = await listRepoFiles(repoRoot)
+  const repoFiles = input.repoRelativeFilePaths
+    ? [...input.repoRelativeFilePaths].sort((left, right) => left.localeCompare(right))
+    : await listRepoFiles(repoRoot)
+  const project = await resolveProjectProfileConfig(repoRoot, input.project)
+  const projectIssueRules = getProjectIssueAuthoringRules(project)
   const issueTokens = tokenize(input.issueText)
-  const candidateAllowedFiles = collectCandidateAllowedFiles({
+  const scannedAllowedFiles = collectCandidateAllowedFiles({
     issueText: input.issueText,
     issueTokens,
     repoFiles,
     limit: input.maxAllowedFiles ?? 8,
   })
-  const candidateValidationCommands = await collectCandidateValidationCommands({
+  const candidateAllowedFiles = uniqueStrings([
+    ...projectIssueRules.preferredAllowedFiles,
+    ...scannedAllowedFiles,
+  ]).slice(0, input.maxAllowedFiles ?? 8)
+  const scannedValidationCommands = await collectCandidateValidationCommands({
     repoRoot,
     repoFiles,
     issueTokens,
     candidateAllowedFiles,
     limit: input.maxValidationCommands ?? 8,
   })
-  const candidateForbiddenFiles = collectCandidateForbiddenFiles({
+  const candidateValidationCommands = uniqueStrings([
+    ...projectIssueRules.preferredValidationCommands,
+    ...scannedValidationCommands,
+  ]).slice(0, input.maxValidationCommands ?? 8)
+  const scannedForbiddenFiles = collectCandidateForbiddenFiles({
     issueText: input.issueText,
     repoFiles,
     candidateAllowedFiles,
     limit: input.maxForbiddenFiles ?? 5,
   })
+  const candidateForbiddenFiles = uniqueStrings([
+    ...projectIssueRules.forbiddenPaths,
+    ...scannedForbiddenFiles,
+  ]).slice(0, input.maxForbiddenFiles ?? 5)
 
   return {
     candidateValidationCommands,
     candidateAllowedFiles,
     candidateForbiddenFiles,
+    candidateReviewHints: [...projectIssueRules.reviewHints],
+    projectIssueRules,
   }
+}
+
+async function resolveProjectProfileConfig(
+  repoRoot: string,
+  explicitProject: ProjectProfileConfig | undefined,
+): Promise<ProjectProfileConfig | undefined> {
+  if (explicitProject) {
+    return explicitProject
+  }
+
+  const repoConfig = await readJsonFile(resolve(repoRoot, '.agent-loop', 'project.json'))
+  const project = (repoConfig as { project?: ProjectProfileConfig } | null)?.project
+
+  return project && typeof project === 'object'
+    ? project
+    : undefined
 }
 
 async function collectCandidateValidationCommands(input: {
@@ -463,6 +499,20 @@ function readStringMap(value: unknown): Record<string, string> {
       .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
       .sort((left, right) => left[0].localeCompare(right[0])),
   )
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>()
+  const deduped: string[] = []
+
+  for (const value of values) {
+    const trimmed = value.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    deduped.push(trimmed)
+  }
+
+  return deduped
 }
 
 async function readJsonFile(filePath: string): Promise<unknown | null> {

--- a/apps/agent-daemon/src/issue-authoring.test.ts
+++ b/apps/agent-daemon/src/issue-authoring.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { rewriteIssueDraft } from './issue-authoring'
+
+describe('rewriteIssueDraft', () => {
+  test('returns canonical executable contract markdown validated against local rules', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-rewrite-'))
+    mkdirSync(join(root, 'apps/agent-daemon/src'), { recursive: true })
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+        typecheck: 'bun run typecheck',
+      },
+      workspaces: ['apps/*'],
+    }))
+    writeFileSync(join(root, 'apps/agent-daemon/src/ready-gate.ts'), 'export const readyGate = true\n')
+    writeFileSync(join(root, 'apps/agent-daemon/src/ready-gate.test.ts'), 'export {}\n')
+
+    const output = await rewriteIssueDraft({
+      issueText: '修复 ready gate 对 Validation 缺失路径的提示，并补测试',
+      repoRoot: root,
+    }, {
+      runAgent: async ({ prompt }) => {
+        expect(prompt).toContain('apps/agent-daemon/src/ready-gate.ts')
+        expect(prompt).toContain('apps/agent-daemon/src/ready-gate.test.ts')
+
+        return {
+          responseText: `## 用户故事
+
+作为 维护者，我希望 ready gate 能明确指出 validation 引用缺失的路径，从而更快修复不可执行 issue。
+
+## Context
+
+### Dependencies
+\`\`\`json
+{"dependsOn":[]}
+\`\`\`
+
+### Constraints
+- 只修 ready gate 的 validation path 提示
+
+### AllowedFiles
+- apps/agent-daemon/src/ready-gate.ts
+- apps/agent-daemon/src/ready-gate.test.ts
+
+### ForbiddenFiles
+- apps/agent-daemon/src/daemon.ts
+
+### MustPreserve
+- 已有 hard validation 错误语义保持不变
+
+### OutOfScope
+- issue simulate
+
+### RequiredSemantics
+- 缺失路径时错误里包含 repo-relative path
+
+### ReviewHints
+- 检查 path 解析是否只影响 validation target 分支
+
+### Validation
+- \`bun test apps/agent-daemon/src/ready-gate.test.ts\`
+- \`git diff --stat origin/main...HEAD\`
+
+## RED 测试
+
+\`\`\`ts
+throw new Error('red')
+\`\`\`
+
+## 实现步骤
+
+1. 先补失败测试
+2. 再补最小实现
+3. 最后跑验证
+
+## 验收
+
+- [ ] 只改 ready gate 相关文件
+- [ ] RED 测试转绿`,
+        }
+      },
+    })
+
+    expect(output.validation.valid).toBe(true)
+    expect(output.markdown.startsWith('## 用户故事')).toBe(true)
+    expect(output.markdown).toContain('### Dependencies')
+    expect(output.markdown).toContain('### AllowedFiles')
+  })
+
+  test('fails when the rewritten contract is still invalid', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agent-loop-rewrite-invalid-'))
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      name: 'fixture-repo',
+      scripts: {
+        test: 'bun test',
+      },
+    }))
+
+    await expect(rewriteIssueDraft({
+      issueText: '把 issue 改成可执行 contract',
+      repoRoot: root,
+    }, {
+      runAgent: async () => ({
+        responseText: `## 用户故事
+
+作为 维护者，我希望 rewrite 能工作。
+
+## Context
+
+### Dependencies
+\`\`\`json
+{"dependsOn":[]}
+\`\`\`
+
+### AllowedFiles
+- frontend files`,
+      }),
+    })).rejects.toThrow('Rewritten issue contract failed local validation')
+  })
+})

--- a/apps/agent-daemon/src/issue-authoring.test.ts
+++ b/apps/agent-daemon/src/issue-authoring.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from 'bun:test'
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { rewriteIssueDraft } from './issue-authoring'
+import {
+  buildIssueRewritePrompt,
+  rewriteIssueDraft,
+} from './issue-authoring'
 
 describe('rewriteIssueDraft', () => {
   test('returns canonical executable contract markdown validated against local rules', async () => {
@@ -120,5 +123,62 @@ throw new Error('red')
 - frontend files`,
       }),
     })).rejects.toThrow('Rewritten issue contract failed local validation')
+  })
+
+  test('includes project issue rules in rewrite prompts without adding empty noise when unset', () => {
+    const prompt = buildIssueRewritePrompt({
+      issueText: '增加 issue repair CLI',
+      authoringContext: {
+        candidateValidationCommands: [
+          'bun test apps/agent-daemon/src/issue-repair.test.ts',
+        ],
+        candidateAllowedFiles: [
+          'apps/agent-daemon/src/issue-repair.ts',
+          'apps/agent-daemon/src/issue-repair.test.ts',
+        ],
+        candidateForbiddenFiles: [
+          'apps/agent-daemon/src/dashboard.ts',
+        ],
+        candidateReviewHints: [
+          '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+        ],
+        projectIssueRules: {
+          preferredValidationCommands: [
+            'bun test apps/agent-daemon/src/issue-repair.test.ts',
+          ],
+          preferredAllowedFiles: [
+            'apps/agent-daemon/src/issue-repair.ts',
+            'apps/agent-daemon/src/issue-repair.test.ts',
+          ],
+          forbiddenPaths: [
+            'apps/agent-daemon/src/dashboard.ts',
+          ],
+          reviewHints: [
+            '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+          ],
+        },
+      },
+    })
+
+    expect(prompt).toContain('Project Issue Rules:')
+    expect(prompt).toContain('优先检查 repair 流程是否保留合法的 Dependencies JSON')
+
+    const promptWithoutRules = buildIssueRewritePrompt({
+      issueText: '增加 issue repair CLI',
+      authoringContext: {
+        candidateValidationCommands: [],
+        candidateAllowedFiles: [],
+        candidateForbiddenFiles: [],
+        candidateReviewHints: [],
+        projectIssueRules: {
+          preferredValidationCommands: [],
+          preferredAllowedFiles: [],
+          forbiddenPaths: [],
+          reviewHints: [],
+        },
+      },
+    })
+
+    expect(promptWithoutRules).not.toContain('Project Issue Rules:')
   })
 })

--- a/apps/agent-daemon/src/issue-authoring.ts
+++ b/apps/agent-daemon/src/issue-authoring.ts
@@ -75,11 +75,12 @@ export async function rewriteIssueDraft(
   }
 }
 
-function buildIssueRewritePrompt(input: {
+export function buildIssueRewritePrompt(input: {
   issueText: string
   authoringContext: RepoAuthoringContext
-  draftQuality: ReturnType<typeof buildIssueQualityReport>
+  draftQuality?: ReturnType<typeof buildIssueQualityReport>
 }): string {
+  const draftQuality = input.draftQuality ?? buildIssueQualityReport(parseIssueContract(input.issueText))
   const candidateAllowedFiles = input.authoringContext.candidateAllowedFiles.length > 0
     ? input.authoringContext.candidateAllowedFiles.map((value) => `- ${value}`).join('\n')
     : '- none'
@@ -89,12 +90,13 @@ function buildIssueRewritePrompt(input: {
   const candidateValidationCommands = input.authoringContext.candidateValidationCommands.length > 0
     ? input.authoringContext.candidateValidationCommands.map((value) => `- \`${value}\``).join('\n')
     : '- none'
-  const currentErrors = input.draftQuality.errors.length > 0
-    ? input.draftQuality.errors.map((value) => `- ${value}`).join('\n')
+  const currentErrors = draftQuality.errors.length > 0
+    ? draftQuality.errors.map((value) => `- ${value}`).join('\n')
     : '- none'
-  const currentWarnings = input.draftQuality.warnings.length > 0
-    ? input.draftQuality.warnings.map((value) => `- ${value}`).join('\n')
+  const currentWarnings = draftQuality.warnings.length > 0
+    ? draftQuality.warnings.map((value) => `- ${value}`).join('\n')
     : '- none'
+  const projectIssueRules = formatProjectIssueRules(input.authoringContext)
 
   return `你正在把一条模糊或不完整的 issue 草稿重写成 agent-loop 可直接消费的 canonical executable contract。
 
@@ -131,14 +133,16 @@ throw new Error('red')
 - 如果当前草稿缺少信息，可以补齐最小可执行 contract，但不要夹带额外说明 prose
 
 当前草稿质量：
-- valid: ${input.draftQuality.valid}
-- score: ${input.draftQuality.score}
+- valid: ${draftQuality.valid}
+- score: ${draftQuality.score}
 
 当前草稿 errors:
 ${currentErrors}
 
 当前草稿 warnings:
 ${currentWarnings}
+
+${projectIssueRules}
 
 Repo-grounded candidate AllowedFiles:
 ${candidateAllowedFiles}
@@ -152,6 +156,39 @@ ${candidateValidationCommands}
 原始草稿：
 ${input.issueText.trim() || '(empty draft)'}
 `
+}
+
+function formatProjectIssueRules(authoringContext: RepoAuthoringContext): string {
+  const rules = authoringContext.projectIssueRules ?? {
+    preferredValidationCommands: [],
+    preferredAllowedFiles: [],
+    forbiddenPaths: [],
+    reviewHints: [],
+  }
+  if (
+    rules.preferredValidationCommands.length === 0
+    && rules.preferredAllowedFiles.length === 0
+    && rules.forbiddenPaths.length === 0
+    && rules.reviewHints.length === 0
+  ) {
+    return ''
+  }
+
+  return [
+    'Project Issue Rules:',
+    rules.preferredAllowedFiles.length > 0
+      ? `Preferred AllowedFiles:\n${rules.preferredAllowedFiles.map((value) => `- ${value}`).join('\n')}`
+      : null,
+    rules.forbiddenPaths.length > 0
+      ? `Forbidden paths:\n${rules.forbiddenPaths.map((value) => `- ${value}`).join('\n')}`
+      : null,
+    rules.preferredValidationCommands.length > 0
+      ? `Preferred Validation commands:\n${rules.preferredValidationCommands.map((value) => `- \`${value}\``).join('\n')}`
+      : null,
+    rules.reviewHints.length > 0
+      ? `Review hints:\n${rules.reviewHints.map((value) => `- ${value}`).join('\n')}`
+      : null,
+  ].filter((value): value is string => value !== null).join('\n\n')
 }
 
 function normalizeRewrittenIssueMarkdown(responseText: string): string {

--- a/apps/agent-daemon/src/issue-authoring.ts
+++ b/apps/agent-daemon/src/issue-authoring.ts
@@ -1,0 +1,176 @@
+import {
+  buildIssueLintReport,
+  formatIssueLintReport,
+  type IssueLintReport,
+} from './audit-issue-contracts'
+import { buildRepoAuthoringContext } from './issue-authoring-context'
+import {
+  buildIssueQualityReport,
+  parseIssueContract,
+  type BuildRepoAuthoringContextInput,
+  type RepoAuthoringContext,
+} from '@agent/shared'
+
+export interface RewriteIssueDraftInput {
+  issueText: string
+  repoRoot: string
+}
+
+export interface RewriteIssueDraftResult {
+  markdown: string
+  validation: IssueLintReport
+  authoringContext: RepoAuthoringContext
+}
+
+export interface IssueAuthoringAgentResponse {
+  responseText: string
+}
+
+export type IssueAuthoringAgentRunner = (input: {
+  prompt: string
+  repoRoot: string
+}) => Promise<IssueAuthoringAgentResponse>
+
+interface RewriteIssueDraftDependencies {
+  buildRepoAuthoringContext?: (input: BuildRepoAuthoringContextInput) => Promise<RepoAuthoringContext>
+  runAgent: IssueAuthoringAgentRunner
+}
+
+export async function rewriteIssueDraft(
+  input: RewriteIssueDraftInput,
+  deps: RewriteIssueDraftDependencies,
+): Promise<RewriteIssueDraftResult> {
+  const authoringContext = await (deps.buildRepoAuthoringContext ?? buildRepoAuthoringContext)({
+    repoRoot: input.repoRoot,
+    issueText: input.issueText,
+  })
+  const draftContract = parseIssueContract(input.issueText)
+  const draftQuality = buildIssueQualityReport(draftContract)
+  const prompt = buildIssueRewritePrompt({
+    issueText: input.issueText,
+    authoringContext,
+    draftQuality,
+  })
+
+  const response = await deps.runAgent({
+    prompt,
+    repoRoot: input.repoRoot,
+  })
+  const markdown = normalizeRewrittenIssueMarkdown(response.responseText)
+  const validation = buildIssueLintReport(markdown, {
+    kind: 'file',
+    path: 'stdout',
+  })
+
+  if (!validation.valid) {
+    throw new Error(
+      `Rewritten issue contract failed local validation:\n${formatIssueLintReport(validation)}`,
+    )
+  }
+
+  return {
+    markdown,
+    validation,
+    authoringContext,
+  }
+}
+
+function buildIssueRewritePrompt(input: {
+  issueText: string
+  authoringContext: RepoAuthoringContext
+  draftQuality: ReturnType<typeof buildIssueQualityReport>
+}): string {
+  const candidateAllowedFiles = input.authoringContext.candidateAllowedFiles.length > 0
+    ? input.authoringContext.candidateAllowedFiles.map((value) => `- ${value}`).join('\n')
+    : '- none'
+  const candidateForbiddenFiles = input.authoringContext.candidateForbiddenFiles.length > 0
+    ? input.authoringContext.candidateForbiddenFiles.map((value) => `- ${value}`).join('\n')
+    : '- none'
+  const candidateValidationCommands = input.authoringContext.candidateValidationCommands.length > 0
+    ? input.authoringContext.candidateValidationCommands.map((value) => `- \`${value}\``).join('\n')
+    : '- none'
+  const currentErrors = input.draftQuality.errors.length > 0
+    ? input.draftQuality.errors.map((value) => `- ${value}`).join('\n')
+    : '- none'
+  const currentWarnings = input.draftQuality.warnings.length > 0
+    ? input.draftQuality.warnings.map((value) => `- ${value}`).join('\n')
+    : '- none'
+
+  return `你正在把一条模糊或不完整的 issue 草稿重写成 agent-loop 可直接消费的 canonical executable contract。
+
+只返回 markdown 本体，不要加解释、前言、结尾，也不要包在代码块里。
+输出必须以 \`## 用户故事\` 开头，并严格保留下面这组 section 顺序：
+
+## 用户故事
+## Context
+### Dependencies
+\`\`\`json
+{"dependsOn":[]}
+\`\`\`
+### Constraints
+### AllowedFiles
+### ForbiddenFiles
+### MustPreserve
+### OutOfScope
+### RequiredSemantics
+### ReviewHints
+### Validation
+## RED 测试
+\`\`\`ts
+throw new Error('red')
+\`\`\`
+## 实现步骤
+## 验收
+
+重写要求：
+- 继续使用现有 canonical contract 结构，不要发明新的 section
+- \`### Dependencies\` 必须始终保留 fenced JSON block
+- 优先把 repo-grounded 上下文里的 repo-relative 路径和命令融入 \`AllowedFiles\`、\`ForbiddenFiles\`、\`Validation\`
+- \`AllowedFiles\` 必须尽量精确，优先写具体文件或紧边界目录
+- \`Validation\` 必须写可执行命令，避免泛泛而谈
+- 如果当前草稿缺少信息，可以补齐最小可执行 contract，但不要夹带额外说明 prose
+
+当前草稿质量：
+- valid: ${input.draftQuality.valid}
+- score: ${input.draftQuality.score}
+
+当前草稿 errors:
+${currentErrors}
+
+当前草稿 warnings:
+${currentWarnings}
+
+Repo-grounded candidate AllowedFiles:
+${candidateAllowedFiles}
+
+Repo-grounded candidate ForbiddenFiles:
+${candidateForbiddenFiles}
+
+Repo-grounded candidate Validation commands:
+${candidateValidationCommands}
+
+原始草稿：
+${input.issueText.trim() || '(empty draft)'}
+`
+}
+
+function normalizeRewrittenIssueMarkdown(responseText: string): string {
+  let normalized = responseText.trim()
+
+  const firstHeadingIndex = normalized.search(/^##\s*(用户故事|User Story)\b/m)
+  if (firstHeadingIndex >= 0) {
+    normalized = normalized.slice(firstHeadingIndex).trim()
+  }
+
+  normalized = normalized
+    .replace(/^```(?:markdown|md)?\s*/i, '')
+    .replace(/\s*```$/, '')
+    .trim()
+
+  const headingIndexAfterFenceTrim = normalized.search(/^##\s*(用户故事|User Story)\b/m)
+  if (headingIndexAfterFenceTrim >= 0) {
+    normalized = normalized.slice(headingIndexAfterFenceTrim).trim()
+  }
+
+  return normalized
+}

--- a/apps/agent-daemon/src/issue-authoring.ts
+++ b/apps/agent-daemon/src/issue-authoring.ts
@@ -56,7 +56,7 @@ export async function rewriteIssueDraft(
     prompt,
     repoRoot: input.repoRoot,
   })
-  const markdown = normalizeRewrittenIssueMarkdown(response.responseText)
+  const markdown = normalizeCanonicalIssueMarkdown(response.responseText)
   const validation = buildIssueLintReport(markdown, {
     kind: 'file',
     path: 'stdout',
@@ -191,7 +191,7 @@ function formatProjectIssueRules(authoringContext: RepoAuthoringContext): string
   ].filter((value): value is string => value !== null).join('\n\n')
 }
 
-function normalizeRewrittenIssueMarkdown(responseText: string): string {
+export function normalizeCanonicalIssueMarkdown(responseText: string): string {
   let normalized = responseText.trim()
 
   const firstHeadingIndex = normalized.search(/^##\s*(用户故事|User Story)\b/m)

--- a/apps/agent-daemon/src/issue-repair.test.ts
+++ b/apps/agent-daemon/src/issue-repair.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  formatIssueRepairResult,
+  repairIssueDraft,
+} from './issue-repair'
+
+const BROKEN_ISSUE = [
+  '## 用户故事',
+  '作为维护者，我希望修复 issue contract。',
+  '',
+  '## Context',
+  '### Dependencies',
+  '```json',
+  '{ "dependsOn": [50, 51] }',
+  '```',
+  '### AllowedFiles',
+  '- frontend files',
+  '### ForbiddenFiles',
+  '- apps/agent-daemon/src/dashboard.ts',
+  '### MustPreserve',
+  '- `dependsOn` JSON 必须保持机器可解析',
+  '### OutOfScope',
+  '- GitHub 远端写回',
+  '### RequiredSemantics',
+  '- repair 结果必须仍然是 canonical markdown',
+  '### ReviewHints',
+  '- 优先检查是否偷偷删掉 Dependencies',
+  '### Validation',
+  '- 观察一下 issue 看起来是否更清楚',
+  '',
+  '## RED 测试',
+  '```ts',
+  'expect(true).toBe(false)',
+  '```',
+  '',
+  '## 实现步骤',
+  '1. 修一下',
+  '',
+  '## 验收',
+  '- [ ] issue 更好一些',
+].join('\n')
+
+const REPAIRED_ISSUE = [
+  '## 用户故事',
+  '作为维护者，我希望修复 issue contract，从而让 agent-loop 可以稳定消费高质量 issue。',
+  '',
+  '## Context',
+  '### Dependencies',
+  '```json',
+  '{ "dependsOn": [50, 51] }',
+  '```',
+  '### Constraints',
+  '- 只修 contract 本身，不写 GitHub 远端',
+  '### AllowedFiles',
+  '- apps/agent-daemon/src/issue-repair.ts',
+  '- apps/agent-daemon/src/issue-repair.test.ts',
+  '### ForbiddenFiles',
+  '- apps/agent-daemon/src/dashboard.ts',
+  '### MustPreserve',
+  '- `dependsOn` JSON 必须保持机器可解析',
+  '### OutOfScope',
+  '- GitHub 远端写回',
+  '### RequiredSemantics',
+  '- repair 结果必须仍然是 canonical markdown',
+  '### ReviewHints',
+  '- 优先检查是否偷偷删掉 Dependencies',
+  '### Validation',
+  '- `bun test apps/agent-daemon/src/issue-repair.test.ts`',
+  '- `git diff --stat origin/master...HEAD`',
+  '',
+  '## RED 测试',
+  '```ts',
+  'expect(true).toBe(false)',
+  '```',
+  '',
+  '## 实现步骤',
+  '1. 先让 repair flow 消费 findings',
+  '',
+  '## 验收',
+  '- [ ] repair 输出通过本地 contract 校验',
+].join('\n')
+
+describe('repairIssueDraft', () => {
+  test('preserves dependency metadata while repairing lint and simulate findings', async () => {
+    const result = await repairIssueDraft({
+      issueText: BROKEN_ISSUE,
+      repoRoot: '/repo',
+      includeSimulation: true,
+      lintReport: {
+        valid: true,
+        readyGateBlocked: false,
+        readyGateStatus: 'pass',
+        readyGateSummary: 'ok',
+        score: 70,
+        errors: [],
+        warnings: [
+          'AllowedFiles should use exact paths or tightly scoped directories: frontend files',
+        ],
+        source: { kind: 'file', path: 'broken.md' },
+        contract: {} as never,
+      },
+      simulationResult: {
+        valid: false,
+        summary: 'simulation failed',
+        failures: [
+          'allowed file scope is too broad for reliable reviewer/auto-fix execution',
+          'validation commands are too generic to confirm issue-specific semantics',
+        ],
+        findings: [
+          {
+            code: 'allowed_files_too_broad',
+            stage: 'reviewer',
+            message: 'allowed file scope is too broad for reliable reviewer/auto-fix execution: frontend files',
+          },
+          {
+            code: 'validation_too_generic',
+            stage: 'reviewer',
+            message: 'validation commands are too generic to confirm issue-specific semantics: 观察一下 issue 看起来是否更清楚',
+          },
+        ],
+        plannerPrompt: 'prompt',
+        plannerOutput: '1. Read the issue\n2. Think about it',
+        plannedSubtasks: ['Read the issue', 'Think about it'],
+        checks: {
+          commitShapedPlan: false,
+          scopedAllowedFiles: false,
+          specificValidation: false,
+        },
+      },
+    }, {
+      buildRepoAuthoringContext: async () => ({
+        candidateValidationCommands: [
+          'bun test apps/agent-daemon/src/issue-repair.test.ts',
+        ],
+        candidateAllowedFiles: [
+          'apps/agent-daemon/src/issue-repair.ts',
+          'apps/agent-daemon/src/issue-repair.test.ts',
+        ],
+        candidateForbiddenFiles: [
+          'apps/agent-daemon/src/dashboard.ts',
+        ],
+        candidateReviewHints: [
+          '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+        ],
+        projectIssueRules: {
+          preferredValidationCommands: [
+            'bun test apps/agent-daemon/src/issue-repair.test.ts',
+          ],
+          preferredAllowedFiles: [
+            'apps/agent-daemon/src/issue-repair.ts',
+            'apps/agent-daemon/src/issue-repair.test.ts',
+          ],
+          forbiddenPaths: [
+            'apps/agent-daemon/src/dashboard.ts',
+          ],
+          reviewHints: [
+            '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+          ],
+        },
+      }),
+      runPlanner: async () => ({
+        responseText: [
+          '1. Add issue-repair.ts and issue-repair.test.ts',
+          '2. Run bun test apps/agent-daemon/src/issue-repair.test.ts',
+        ].join('\n'),
+      }),
+      runAgent: async ({ prompt }) => {
+        expect(prompt).toContain('Project Issue Rules:')
+        expect(prompt).toContain('[allowed_files_too_broad]')
+        expect(prompt).toContain('{ "dependsOn": [50, 51] }')
+
+        return {
+          responseText: REPAIRED_ISSUE,
+        }
+      },
+    })
+
+    expect(result.repairedMarkdown).toContain('{ "dependsOn": [50, 51] }')
+    expect(result.appliedFindingCodes).toEqual([
+      'allowed_files_too_broad',
+      'validation_too_generic',
+    ])
+    expect(result.after.validation.valid).toBe(true)
+    expect(result.after.simulation?.valid).toBe(true)
+    expect(result.success).toBe(true)
+  })
+
+  test('returns blocking findings when the repaired draft is still invalid', async () => {
+    const result = await repairIssueDraft({
+      issueText: BROKEN_ISSUE,
+      repoRoot: '/repo',
+      includeSimulation: false,
+    }, {
+      buildRepoAuthoringContext: async () => ({
+        candidateValidationCommands: [],
+        candidateAllowedFiles: [],
+        candidateForbiddenFiles: [],
+        candidateReviewHints: [],
+        projectIssueRules: {
+          preferredValidationCommands: [],
+          preferredAllowedFiles: [],
+          forbiddenPaths: [],
+          reviewHints: [],
+        },
+      }),
+      runAgent: async () => ({
+        responseText: '## 用户故事\n只有用户故事',
+      }),
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.blockingFindings).toContain('missing ### Dependencies JSON block')
+    const output = JSON.parse(formatIssueRepairResult(result, true))
+    expect(output.success).toBe(false)
+    expect(output.blockingFindings).toContain('missing ### Dependencies JSON block')
+  })
+})

--- a/apps/agent-daemon/src/issue-repair.ts
+++ b/apps/agent-daemon/src/issue-repair.ts
@@ -1,0 +1,381 @@
+import type {
+  BuildRepoAuthoringContextInput,
+  RepoAuthoringContext,
+} from '@agent/shared'
+import {
+  buildIssueLintReport,
+  formatIssueLintReport,
+  type IssueLintReport,
+} from './audit-issue-contracts'
+import { buildRepoAuthoringContext } from './issue-authoring-context'
+import { normalizeCanonicalIssueMarkdown } from './issue-authoring'
+import {
+  parseIssueSimulationDocument,
+  simulateIssueExecutability,
+  type IssueSimulationPlannerRunner,
+  type IssueSimulationResult,
+} from './issue-simulate'
+
+export interface RepairIssueDraftInput {
+  issueText: string
+  repoRoot: string
+  includeSimulation?: boolean
+  lintReport?: IssueLintReport
+  simulationResult?: IssueSimulationResult
+}
+
+export interface RepairIssueDraftResult {
+  success: boolean
+  repairedMarkdown: string
+  appliedFindingCodes: string[]
+  blockingFindings: string[]
+  before: {
+    validation: IssueLintReport
+    simulation?: IssueSimulationResult
+  }
+  after: {
+    validation: IssueLintReport
+    simulation?: IssueSimulationResult
+  }
+  authoringContext: RepoAuthoringContext
+}
+
+export interface IssueRepairAgentResponse {
+  responseText: string
+}
+
+export type IssueRepairAgentRunner = (input: {
+  prompt: string
+  repoRoot: string
+}) => Promise<IssueRepairAgentResponse>
+
+interface RepairIssueDraftDependencies {
+  buildRepoAuthoringContext?: (input: BuildRepoAuthoringContextInput) => Promise<RepoAuthoringContext>
+  runAgent: IssueRepairAgentRunner
+  runPlanner?: IssueSimulationPlannerRunner
+}
+
+export async function repairIssueDraft(
+  input: RepairIssueDraftInput,
+  deps: RepairIssueDraftDependencies,
+): Promise<RepairIssueDraftResult> {
+  const authoringContext = await (deps.buildRepoAuthoringContext ?? buildRepoAuthoringContext)({
+    repoRoot: input.repoRoot,
+    issueText: input.issueText,
+  })
+  const beforeValidation = input.lintReport ?? buildIssueLintReport(input.issueText, {
+    kind: 'file',
+    path: 'stdin',
+  })
+  const beforeSimulation = input.includeSimulation
+    ? await resolveSimulationResult({
+        issueText: input.issueText,
+        repoRoot: input.repoRoot,
+        simulationResult: input.simulationResult,
+        runPlanner: deps.runPlanner,
+      })
+    : undefined
+  const prompt = buildIssueRepairPrompt({
+    issueText: input.issueText,
+    authoringContext,
+    lintReport: beforeValidation,
+    simulationResult: beforeSimulation,
+  })
+  const response = await deps.runAgent({
+    prompt,
+    repoRoot: input.repoRoot,
+  })
+  const repairedMarkdown = normalizeCanonicalIssueMarkdown(response.responseText)
+  const afterValidation = buildIssueLintReport(repairedMarkdown, {
+    kind: 'file',
+    path: 'stdout',
+  })
+  const afterSimulation = input.includeSimulation
+    ? await rerunSimulation({
+        sourceMarkdown: repairedMarkdown,
+        repoRoot: input.repoRoot,
+        runPlanner: deps.runPlanner,
+      })
+    : undefined
+  const blockingFindings = collectBlockingFindings({
+    validation: afterValidation,
+    simulation: afterSimulation,
+  })
+
+  return {
+    success: blockingFindings.length === 0,
+    repairedMarkdown,
+    appliedFindingCodes: collectAppliedFindingCodes({
+      lintReport: beforeValidation,
+      simulationResult: beforeSimulation,
+    }),
+    blockingFindings,
+    before: {
+      validation: beforeValidation,
+      simulation: beforeSimulation,
+    },
+    after: {
+      validation: afterValidation,
+      simulation: afterSimulation,
+    },
+    authoringContext,
+  }
+}
+
+export function buildIssueRepairPrompt(input: {
+  issueText: string
+  authoringContext: RepoAuthoringContext
+  lintReport: IssueLintReport
+  simulationResult?: IssueSimulationResult
+}): string {
+  const candidateAllowedFiles = input.authoringContext.candidateAllowedFiles.length > 0
+    ? input.authoringContext.candidateAllowedFiles.map((value) => `- ${value}`).join('\n')
+    : '- none'
+  const candidateForbiddenFiles = input.authoringContext.candidateForbiddenFiles.length > 0
+    ? input.authoringContext.candidateForbiddenFiles.map((value) => `- ${value}`).join('\n')
+    : '- none'
+  const candidateValidationCommands = input.authoringContext.candidateValidationCommands.length > 0
+    ? input.authoringContext.candidateValidationCommands.map((value) => `- \`${value}\``).join('\n')
+    : '- none'
+  const candidateReviewHints = (input.authoringContext.candidateReviewHints ?? []).length > 0
+    ? (input.authoringContext.candidateReviewHints ?? []).map((value) => `- ${value}`).join('\n')
+    : '- none'
+  const lintErrors = input.lintReport.errors.length > 0
+    ? input.lintReport.errors.map((value) => `- ${value}`).join('\n')
+    : '- none'
+  const lintWarnings = input.lintReport.warnings.length > 0
+    ? input.lintReport.warnings.map((value) => `- ${value}`).join('\n')
+    : '- none'
+  const simulationSection = input.simulationResult
+    ? [
+        `Current simulation summary: ${input.simulationResult.summary}`,
+        `Current simulation failures:\n${input.simulationResult.failures.map((value) => `- ${value}`).join('\n') || '- none'}`,
+        `Current simulation findings:\n${input.simulationResult.findings.map((finding) => `- [${finding.code}] ${finding.message}`).join('\n') || '- none'}`,
+      ].join('\n\n')
+    : 'Current simulation findings:\n- none'
+  const projectIssueRules = formatProjectIssueRules(input.authoringContext)
+
+  return `你正在对一条“接近可执行但仍有 lint / simulate findings”的 issue contract 做最小 repair。
+
+只返回修复后的 markdown 本体，不要输出解释、前言、结尾，也不要包在代码块里。
+输出必须保持 canonical executable contract，并严格保留下面这组 section 顺序：
+
+## 用户故事
+## Context
+### Dependencies
+\`\`\`json
+{"dependsOn":[]}
+\`\`\`
+### Constraints
+### AllowedFiles
+### ForbiddenFiles
+### MustPreserve
+### OutOfScope
+### RequiredSemantics
+### ReviewHints
+### Validation
+## RED 测试
+\`\`\`ts
+throw new Error('red')
+\`\`\`
+## 实现步骤
+## 验收
+
+Repair 要求：
+- 只做最小修正，优先修 findings 指向的问题；不要重写需求、扩大 scope、删除具体约束
+- 如果当前 \`### Dependencies\` fenced JSON 已存在且机器可解析，必须保留它的结构和依赖数字
+- 不要为了“修过 lint”而把具体 \`AllowedFiles\` 宽化成模糊描述
+- 不要把具体 \`Validation\` 命令改成泛泛描述
+- 输出仍然必须是 canonical executable contract markdown
+
+当前 lint errors:
+${lintErrors}
+
+当前 lint warnings:
+${lintWarnings}
+
+${simulationSection}
+
+${projectIssueRules}
+
+Repo-grounded candidate AllowedFiles:
+${candidateAllowedFiles}
+
+Repo-grounded candidate ForbiddenFiles:
+${candidateForbiddenFiles}
+
+Repo-grounded candidate Validation commands:
+${candidateValidationCommands}
+
+Repo-grounded candidate ReviewHints:
+${candidateReviewHints}
+
+当前 issue markdown:
+${input.issueText.trim() || '(empty draft)'}
+`
+}
+
+export function formatIssueRepairResult(
+  result: RepairIssueDraftResult,
+  asJson = false,
+): string {
+  if (asJson) {
+    return JSON.stringify(result, null, 2)
+  }
+
+  return result.repairedMarkdown
+}
+
+function collectAppliedFindingCodes(input: {
+  lintReport: IssueLintReport
+  simulationResult?: IssueSimulationResult
+}): string[] {
+  const lintCodes = [
+    ...input.lintReport.errors.map(deriveLintFindingCode),
+    ...input.lintReport.warnings.map(deriveLintFindingCode),
+  ]
+  const simulationCodes = input.simulationResult?.findings.map((finding) => finding.code) ?? []
+
+  return uniqueStrings([...lintCodes, ...simulationCodes])
+}
+
+function collectBlockingFindings(input: {
+  validation: IssueLintReport
+  simulation?: IssueSimulationResult
+}): string[] {
+  const findings = [...input.validation.errors]
+
+  if (input.simulation && !input.simulation.valid) {
+    findings.push(...input.simulation.failures)
+  }
+
+  return findings
+}
+
+async function resolveSimulationResult(input: {
+  issueText: string
+  repoRoot: string
+  simulationResult?: IssueSimulationResult
+  runPlanner?: IssueSimulationPlannerRunner
+}): Promise<IssueSimulationResult> {
+  if (input.simulationResult) {
+    return input.simulationResult
+  }
+
+  if (!input.runPlanner) {
+    throw new Error('repair simulation requires a planner runner')
+  }
+
+  const document = parseIssueSimulationDocument(input.issueText, 'Issue Draft')
+  return simulateIssueExecutability({
+    issueTitle: document.title,
+    issueBody: document.body,
+    repoRoot: input.repoRoot,
+    runPlanner: input.runPlanner,
+  })
+}
+
+async function rerunSimulation(input: {
+  sourceMarkdown: string
+  repoRoot: string
+  runPlanner?: IssueSimulationPlannerRunner
+}): Promise<IssueSimulationResult> {
+  if (!input.runPlanner) {
+    throw new Error('repair simulation requires a planner runner')
+  }
+
+  const document = parseIssueSimulationDocument(input.sourceMarkdown, 'Repaired Issue Draft')
+  return simulateIssueExecutability({
+    issueTitle: document.title,
+    issueBody: document.body,
+    repoRoot: input.repoRoot,
+    runPlanner: input.runPlanner,
+  })
+}
+
+function deriveLintFindingCode(message: string): string {
+  if (message.startsWith('AllowedFiles should use exact paths or tightly scoped directories:')) {
+    return 'allowed_files_too_broad'
+  }
+
+  if (message.startsWith('Validation should use concrete executable commands instead of generic guidance:')) {
+    return 'validation_too_generic'
+  }
+
+  if (message === 'missing ### Dependencies JSON block') {
+    return 'missing_dependencies_block'
+  }
+
+  if (message === 'missing ## 实现步骤 / Implementation Steps') {
+    return 'missing_implementation_steps'
+  }
+
+  if (message === 'missing ## 验收 / Acceptance') {
+    return 'missing_acceptance'
+  }
+
+  if (message === 'missing ## RED 测试 / RED Tests') {
+    return 'missing_red_tests'
+  }
+
+  if (message === 'missing ### Validation / Validation Commands') {
+    return 'missing_validation_commands'
+  }
+
+  if (message === 'missing executable scope contract (AllowedFiles/ForbiddenFiles/MustPreserve/OutOfScope/RequiredSemantics)') {
+    return 'missing_executable_scope_contract'
+  }
+
+  return message
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+}
+
+function formatProjectIssueRules(authoringContext: RepoAuthoringContext): string {
+  const rules = authoringContext.projectIssueRules ?? {
+    preferredValidationCommands: [],
+    preferredAllowedFiles: [],
+    forbiddenPaths: [],
+    reviewHints: [],
+  }
+
+  if (
+    rules.preferredValidationCommands.length === 0
+    && rules.preferredAllowedFiles.length === 0
+    && rules.forbiddenPaths.length === 0
+    && rules.reviewHints.length === 0
+  ) {
+    return 'Project Issue Rules:\n- none'
+  }
+
+  return [
+    'Project Issue Rules:',
+    rules.preferredAllowedFiles.length > 0
+      ? `Preferred AllowedFiles:\n${rules.preferredAllowedFiles.map((value) => `- ${value}`).join('\n')}`
+      : null,
+    rules.forbiddenPaths.length > 0
+      ? `Forbidden paths:\n${rules.forbiddenPaths.map((value) => `- ${value}`).join('\n')}`
+      : null,
+    rules.preferredValidationCommands.length > 0
+      ? `Preferred Validation commands:\n${rules.preferredValidationCommands.map((value) => `- \`${value}\``).join('\n')}`
+      : null,
+    rules.reviewHints.length > 0
+      ? `Review hints:\n${rules.reviewHints.map((value) => `- ${value}`).join('\n')}`
+      : null,
+  ].filter((value): value is string => value !== null).join('\n\n')
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>()
+  const deduped: string[] = []
+
+  for (const value of values) {
+    const trimmed = value.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    deduped.push(trimmed)
+  }
+
+  return deduped
+}

--- a/apps/agent-daemon/src/issue-simulate.test.ts
+++ b/apps/agent-daemon/src/issue-simulate.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  formatIssueSimulationResult,
+  parseIssueSimulationDocument,
+  simulateIssueExecutability,
+} from './issue-simulate'
+
+describe('simulateIssueExecutability', () => {
+  test('fails when the simulated plan is not commit-shaped and validation is too weak', async () => {
+    const result = await simulateIssueExecutability({
+      issueTitle: '[AL-X] 修复 issue 质量',
+      issueBody: `## 用户故事
+
+作为 维护者，我希望 issue 能被稳定执行，从而减少 daemon 空转。
+
+## Context
+
+### Dependencies
+\`\`\`json
+{"dependsOn":[]}
+\`\`\`
+
+### AllowedFiles
+- apps/agent-daemon/src
+
+### ForbiddenFiles
+- apps/agent-daemon/src/daemon.ts
+
+### MustPreserve
+- ready gate 现有错误语义不变
+
+### OutOfScope
+- runtime evaluator
+
+### RequiredSemantics
+- issue 能被稳定拆分并验证
+
+### ReviewHints
+- 检查任务是否会退化成纯分析
+
+### Validation
+- verify behavior manually
+- \`git diff --stat origin/main...HEAD\`
+
+## RED 测试
+
+\`\`\`ts
+throw new Error('red')
+\`\`\`
+
+## 实现步骤
+
+1. 研究代码
+2. 思考方案
+3. 之后再实现
+
+## 验收
+
+- [ ] issue 可以被执行`,
+      runPlanner: async () => ({
+        responseText: `1. Read the codebase and inspect options
+2. Analyze the issue and propose an approach`,
+      }),
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.failures).toContain(
+      'planning output does not contain commit-shaped subtasks',
+    )
+    expect(result.failures).toContain(
+      'validation commands are too generic to confirm issue-specific semantics',
+    )
+  })
+
+  test('passes when planner output is commit-shaped and contract boundaries are specific', async () => {
+    const result = await simulateIssueExecutability({
+      issueTitle: '[AL-Y] 增加 simulate CLI',
+      issueBody: `## 用户故事
+
+作为 维护者，我希望 simulate CLI 能稳定输出结构化结果，从而在 ready gate 前发现不可执行 issue。
+
+## Context
+
+### Dependencies
+\`\`\`json
+{"dependsOn":[17,18,19]}
+\`\`\`
+
+### AllowedFiles
+- apps/agent-daemon/src/issue-simulate.ts
+- apps/agent-daemon/src/issue-simulate.test.ts
+
+### ForbiddenFiles
+- apps/agent-daemon/src/daemon.ts
+
+### MustPreserve
+- 默认 ready gate 行为不变
+
+### OutOfScope
+- 自动创建 GitHub issue
+
+### RequiredSemantics
+- simulate 输出结构化 failures
+
+### ReviewHints
+- 检查是否保持只读
+
+### Validation
+- \`bun test apps/agent-daemon/src/issue-simulate.test.ts\`
+- \`git diff --stat origin/main...HEAD\`
+
+## RED 测试
+
+\`\`\`ts
+throw new Error('red')
+\`\`\`
+
+## 实现步骤
+
+1. 先补失败测试
+2. 再补最小实现
+3. 最后跑验证
+
+## 验收
+
+- [ ] simulate 可解释失败原因`,
+      runPlanner: async () => ({
+        responseText: `1. Add the failing issue-simulate test coverage
+2. Implement the minimal read-only simulation result checks
+3. Run bun test apps/agent-daemon/src/issue-simulate.test.ts`,
+      }),
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.failures).toEqual([])
+  })
+
+  test('parses local markdown documents and preserves full body when there is no h1 title', () => {
+    expect(parseIssueSimulationDocument('## 用户故事\nbody', 'draft.md')).toEqual({
+      title: 'draft.md',
+      body: '## 用户故事\nbody',
+    })
+  })
+
+  test('formats simulation output as text or json', () => {
+    const result = {
+      valid: false,
+      failures: ['planning output does not contain commit-shaped subtasks'],
+      plannerOutput: '1. Read the code',
+      checks: {
+        commitShapedPlan: false,
+        scopedAllowedFiles: true,
+        specificValidation: true,
+      },
+    }
+
+    expect(formatIssueSimulationResult(result)).toContain('valid=false')
+    expect(JSON.parse(formatIssueSimulationResult(result, true))).toMatchObject({
+      valid: false,
+      failures: ['planning output does not contain commit-shaped subtasks'],
+    })
+  })
+})

--- a/apps/agent-daemon/src/issue-simulate.test.ts
+++ b/apps/agent-daemon/src/issue-simulate.test.ts
@@ -3,6 +3,7 @@ import {
   formatIssueSimulationResult,
   parseIssueSimulationDocument,
   simulateIssueExecutability,
+  type IssueSimulationResult,
 } from './issue-simulate'
 
 describe('simulateIssueExecutability', () => {
@@ -70,6 +71,11 @@ throw new Error('red')
     expect(result.failures).toContain(
       'validation commands are too generic to confirm issue-specific semantics',
     )
+    expect(result.summary).toBe('simulation failed')
+    expect(result.findings.map((finding) => finding.code)).toEqual([
+      'planning_not_commit_shaped',
+      'validation_too_generic',
+    ])
   })
 
   test('passes when planner output is commit-shaped and contract boundaries are specific', async () => {
@@ -133,6 +139,8 @@ throw new Error('red')
 
     expect(result.valid).toBe(true)
     expect(result.failures).toEqual([])
+    expect(result.summary).toBe('simulation passed')
+    expect(result.findings).toEqual([])
   })
 
   test('parses local markdown documents and preserves full body when there is no h1 title', () => {
@@ -143,10 +151,20 @@ throw new Error('red')
   })
 
   test('formats simulation output as text or json', () => {
-    const result = {
+    const result: IssueSimulationResult = {
       valid: false,
+      summary: 'simulation failed',
       failures: ['planning output does not contain commit-shaped subtasks'],
+      findings: [
+        {
+          code: 'planning_not_commit_shaped',
+          stage: 'planner',
+          message: 'planning output does not contain commit-shaped subtasks',
+        },
+      ],
+      plannerPrompt: 'prompt',
       plannerOutput: '1. Read the code',
+      plannedSubtasks: ['Read the code'],
       checks: {
         commitShapedPlan: false,
         scopedAllowedFiles: true,
@@ -155,8 +173,10 @@ throw new Error('red')
     }
 
     expect(formatIssueSimulationResult(result)).toContain('valid=false')
+    expect(formatIssueSimulationResult(result)).toContain('summary=simulation failed')
     expect(JSON.parse(formatIssueSimulationResult(result, true))).toMatchObject({
       valid: false,
+      summary: 'simulation failed',
       failures: ['planning output does not contain commit-shaped subtasks'],
     })
   })

--- a/apps/agent-daemon/src/issue-simulate.ts
+++ b/apps/agent-daemon/src/issue-simulate.ts
@@ -1,0 +1,203 @@
+import { basename } from 'node:path'
+import {
+  buildIssueQualityReport,
+  parseIssueContract,
+} from '@agent/shared'
+
+export interface IssueSimulationPlannerResponse {
+  responseText: string
+}
+
+export type IssueSimulationPlannerRunner = (input: {
+  prompt: string
+  repoRoot: string
+}) => Promise<IssueSimulationPlannerResponse>
+
+export interface SimulateIssueExecutabilityInput {
+  issueTitle: string
+  issueBody: string
+  runPlanner: IssueSimulationPlannerRunner
+  repoRoot?: string
+}
+
+export interface IssueSimulationResult {
+  valid: boolean
+  failures: string[]
+  plannerOutput: string
+  checks: {
+    commitShapedPlan: boolean
+    scopedAllowedFiles: boolean
+    specificValidation: boolean
+  }
+}
+
+export interface ParsedIssueSimulationDocument {
+  title: string
+  body: string
+}
+
+const READ_ONLY_STEP_PATTERNS = [
+  /\bread\b/i,
+  /\binspect\b/i,
+  /\banaly[sz]e\b/i,
+  /\bthink\b/i,
+  /\bconsider\b/i,
+  /\bpropose\b/i,
+  /\bresearch\b/i,
+  /阅读/,
+  /分析/,
+  /思考/,
+  /调研/,
+] as const
+
+const COMMIT_SHAPED_STEP_PATTERNS = [
+  /\b(add|create|implement|fix|update|wire|integrate|refactor|rename|remove|write)\b/i,
+  /\btest\b/i,
+  /\blint\b/i,
+  /\btypecheck\b/i,
+  /新增/,
+  /实现/,
+  /修复/,
+  /更新/,
+  /接入/,
+  /补/,
+  /拆分/,
+] as const
+
+export async function simulateIssueExecutability(
+  input: SimulateIssueExecutabilityInput,
+): Promise<IssueSimulationResult> {
+  const contract = parseIssueContract(input.issueBody)
+  const quality = buildIssueQualityReport(contract)
+  const planner = await input.runPlanner({
+    prompt: buildIssueSimulationPrompt(input.issueTitle, input.issueBody),
+    repoRoot: input.repoRoot ?? process.cwd(),
+  })
+  const plannerOutput = planner.responseText.trim()
+  const plannerSteps = parsePlannerSteps(plannerOutput)
+  const commitShapedPlan = plannerSteps.some(isCommitShapedStep)
+  const scopedAllowedFiles = !quality.warnings.some((warning) => (
+    warning.startsWith('AllowedFiles should use exact paths or tightly scoped directories:')
+  ))
+  const specificValidation = !quality.warnings.some((warning) => (
+    warning.startsWith('Validation should use concrete executable commands instead of generic guidance:')
+  ))
+  const failures: string[] = []
+
+  if (!commitShapedPlan) {
+    failures.push('planning output does not contain commit-shaped subtasks')
+  }
+
+  if (!scopedAllowedFiles) {
+    failures.push('allowed file scope is too broad for reliable reviewer/auto-fix execution')
+  }
+
+  if (!specificValidation) {
+    failures.push('validation commands are too generic to confirm issue-specific semantics')
+  }
+
+  return {
+    valid: failures.length === 0,
+    failures,
+    plannerOutput,
+    checks: {
+      commitShapedPlan,
+      scopedAllowedFiles,
+      specificValidation,
+    },
+  }
+}
+
+export function parseIssueSimulationDocument(
+  markdown: string,
+  fallbackPath: string,
+): ParsedIssueSimulationDocument {
+  const normalized = markdown.trim()
+  const fallbackTitle = basename(fallbackPath)
+  if (!normalized) {
+    return {
+      title: fallbackTitle,
+      body: '',
+    }
+  }
+
+  const lines = normalized.split('\n')
+  const titleLine = lines.find(line => /^#\s+/.test(line.trim()))
+  if (!titleLine) {
+    return {
+      title: fallbackTitle,
+      body: normalized,
+    }
+  }
+
+  const title = titleLine.replace(/^#\s+/, '').trim() || fallbackTitle
+  const titleIndex = lines.indexOf(titleLine)
+  const body = lines
+    .slice(0, titleIndex)
+    .concat(lines.slice(titleIndex + 1))
+    .join('\n')
+    .trim()
+
+  return {
+    title,
+    body,
+  }
+}
+
+export function formatIssueSimulationResult(
+  result: IssueSimulationResult,
+  asJson = false,
+): string {
+  if (asJson) {
+    return JSON.stringify(result, null, 2)
+  }
+
+  return [
+    `valid=${result.valid}`,
+    `checks=commitShapedPlan:${result.checks.commitShapedPlan}, scopedAllowedFiles:${result.checks.scopedAllowedFiles}, specificValidation:${result.checks.specificValidation}`,
+    `failures=${result.failures.join(' | ') || '-'}`,
+    `plannerOutput=${result.plannerOutput || '-'}`,
+  ].join('\n')
+}
+
+function buildIssueSimulationPrompt(
+  issueTitle: string,
+  issueBody: string,
+): string {
+  return `你正在对一条 issue contract 做只读 simulation。
+
+只返回一个有序编号列表，表示 planner 会如何执行这个 issue。不要输出解释，不要输出 JSON。
+要求：
+- 如果 issue 可执行，子任务必须是 commit-shaped coding steps
+- 不要输出纯阅读、纯分析、纯思考型步骤
+- 步骤应该能映射到真实代码修改、测试或验证动作
+
+Issue title:
+${issueTitle}
+
+Issue body:
+${issueBody.trim() || '(empty body)'}
+`
+}
+
+function parsePlannerSteps(responseText: string): string[] {
+  return responseText
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map((line) => line
+      .replace(/^```(?:markdown|md)?\s*/i, '')
+      .replace(/^```$/, '')
+      .replace(/^[-*]\s+/, '')
+      .replace(/^\d+[.)]\s+/, '')
+      .trim())
+    .filter(Boolean)
+}
+
+function isCommitShapedStep(step: string): boolean {
+  if (READ_ONLY_STEP_PATTERNS.some(pattern => pattern.test(step))) {
+    return COMMIT_SHAPED_STEP_PATTERNS.some(pattern => pattern.test(step))
+  }
+
+  return COMMIT_SHAPED_STEP_PATTERNS.some(pattern => pattern.test(step))
+}

--- a/apps/agent-daemon/src/issue-simulate.ts
+++ b/apps/agent-daemon/src/issue-simulate.ts
@@ -8,6 +8,21 @@ export interface IssueSimulationPlannerResponse {
   responseText: string
 }
 
+export type IssueSimulationFindingCode =
+  | 'planning_not_commit_shaped'
+  | 'allowed_files_too_broad'
+  | 'validation_too_generic'
+
+export type IssueSimulationFindingStage =
+  | 'planner'
+  | 'reviewer'
+
+export interface IssueSimulationFinding {
+  code: IssueSimulationFindingCode
+  stage: IssueSimulationFindingStage
+  message: string
+}
+
 export type IssueSimulationPlannerRunner = (input: {
   prompt: string
   repoRoot: string
@@ -22,8 +37,12 @@ export interface SimulateIssueExecutabilityInput {
 
 export interface IssueSimulationResult {
   valid: boolean
+  summary: string
   failures: string[]
+  findings: IssueSimulationFinding[]
+  plannerPrompt: string
   plannerOutput: string
+  plannedSubtasks: string[]
   checks: {
     commitShapedPlan: boolean
     scopedAllowedFiles: boolean
@@ -67,39 +86,66 @@ const COMMIT_SHAPED_STEP_PATTERNS = [
 export async function simulateIssueExecutability(
   input: SimulateIssueExecutabilityInput,
 ): Promise<IssueSimulationResult> {
+  const plannerPrompt = buildIssueSimulationPrompt(input.issueTitle, input.issueBody)
   const contract = parseIssueContract(input.issueBody)
   const quality = buildIssueQualityReport(contract)
   const planner = await input.runPlanner({
-    prompt: buildIssueSimulationPrompt(input.issueTitle, input.issueBody),
+    prompt: plannerPrompt,
     repoRoot: input.repoRoot ?? process.cwd(),
   })
   const plannerOutput = planner.responseText.trim()
   const plannerSteps = parsePlannerSteps(plannerOutput)
   const commitShapedPlan = plannerSteps.some(isCommitShapedStep)
-  const scopedAllowedFiles = !quality.warnings.some((warning) => (
-    warning.startsWith('AllowedFiles should use exact paths or tightly scoped directories:')
-  ))
-  const specificValidation = !quality.warnings.some((warning) => (
-    warning.startsWith('Validation should use concrete executable commands instead of generic guidance:')
-  ))
+  const allowedFilesWarnings = quality.warnings
+    .filter((warning) => warning.startsWith('AllowedFiles should use exact paths or tightly scoped directories:'))
+  const validationWarnings = quality.warnings
+    .filter((warning) => warning.startsWith('Validation should use concrete executable commands instead of generic guidance:'))
+  const scopedAllowedFiles = allowedFilesWarnings.length === 0
+  const specificValidation = validationWarnings.length === 0
   const failures: string[] = []
+  const findings: IssueSimulationFinding[] = []
 
   if (!commitShapedPlan) {
     failures.push('planning output does not contain commit-shaped subtasks')
+    findings.push({
+      code: 'planning_not_commit_shaped',
+      stage: 'planner',
+      message: 'planning output does not contain commit-shaped subtasks',
+    })
   }
 
   if (!scopedAllowedFiles) {
     failures.push('allowed file scope is too broad for reliable reviewer/auto-fix execution')
+    findings.push(...allowedFilesWarnings.map((warning) => ({
+      code: 'allowed_files_too_broad' as const,
+      stage: 'reviewer' as const,
+      message: warning.replace(
+        'AllowedFiles should use exact paths or tightly scoped directories:',
+        'allowed file scope is too broad for reliable reviewer/auto-fix execution:',
+      ).trim(),
+    })))
   }
 
   if (!specificValidation) {
     failures.push('validation commands are too generic to confirm issue-specific semantics')
+    findings.push(...validationWarnings.map((warning) => ({
+      code: 'validation_too_generic' as const,
+      stage: 'reviewer' as const,
+      message: warning.replace(
+        'Validation should use concrete executable commands instead of generic guidance:',
+        'validation commands are too generic to confirm issue-specific semantics:',
+      ).trim(),
+    })))
   }
 
   return {
     valid: failures.length === 0,
+    summary: failures.length === 0 ? 'simulation passed' : 'simulation failed',
     failures,
+    findings,
+    plannerPrompt,
     plannerOutput,
+    plannedSubtasks: plannerSteps,
     checks: {
       commitShapedPlan,
       scopedAllowedFiles,
@@ -154,7 +200,9 @@ export function formatIssueSimulationResult(
 
   return [
     `valid=${result.valid}`,
+    `summary=${result.summary}`,
     `checks=commitShapedPlan:${result.checks.commitShapedPlan}, scopedAllowedFiles:${result.checks.scopedAllowedFiles}, specificValidation:${result.checks.specificValidation}`,
+    `findings=${result.findings.map((finding) => `${finding.code}:${finding.message}`).join(' | ') || '-'}`,
     `failures=${result.failures.join(' | ') || '-'}`,
     `plannerOutput=${result.plannerOutput || '-'}`,
   ].join('\n')

--- a/apps/agent-daemon/src/issue-splitter.test.ts
+++ b/apps/agent-daemon/src/issue-splitter.test.ts
@@ -12,15 +12,27 @@ describe('splitTrackingIssue', () => {
         return () => current++
       })(),
     }, {
-      runAgent: async () => ({
-        responseText: `1. [AL-X] 引入 issue lint
+      runAgent: async ({ prompt }) => {
+        expect(prompt).toContain('Project Issue Rules:')
+        expect(prompt).toContain('优先检查 split 输出是否保持 deterministic')
+
+        return {
+          responseText: `1. [AL-X] 引入 issue lint
 2. [AL-Y] 增加 rewrite CLI
 3. [AL-Z] 增加 simulate`,
-      }),
+        }
+      },
       buildRepoAuthoringContext: async () => ({
         candidateValidationCommands: ['bun run typecheck'],
         candidateAllowedFiles: [],
         candidateForbiddenFiles: ['package.json'],
+        candidateReviewHints: ['优先检查 split 输出是否保持 deterministic'],
+        projectIssueRules: {
+          preferredValidationCommands: ['bun run typecheck'],
+          preferredAllowedFiles: ['apps/agent-daemon/src/audit-issue-contracts.ts'],
+          forbiddenPaths: ['package.json'],
+          reviewHints: ['优先检查 split 输出是否保持 deterministic'],
+        },
       }),
     })
 
@@ -29,6 +41,7 @@ describe('splitTrackingIssue', () => {
     expect(result.children[1]?.body).toContain('"dependsOn":[17]')
     expect(result.children[2]?.body).toContain('"dependsOn":[17,18]')
     expect(result.children.every((child) => child.body.includes('## RED 测试'))).toBe(true)
+    expect(result.children[0]?.body).toContain('优先检查 split 输出是否保持 deterministic')
     expect(result.parentSummary).toContain('#17 [AL-X] 引入 issue lint')
   })
 
@@ -50,6 +63,13 @@ describe('splitTrackingIssue', () => {
         candidateValidationCommands: ['bun run typecheck'],
         candidateAllowedFiles: ['apps/agent-daemon/src/index.ts'],
         candidateForbiddenFiles: ['package.json'],
+        candidateReviewHints: [],
+        projectIssueRules: {
+          preferredValidationCommands: [],
+          preferredAllowedFiles: [],
+          forbiddenPaths: [],
+          reviewHints: [],
+        },
       }),
     })).rejects.toThrow('non-executable child title')
   })

--- a/apps/agent-daemon/src/issue-splitter.test.ts
+++ b/apps/agent-daemon/src/issue-splitter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+import { splitTrackingIssue } from './issue-splitter'
+
+describe('splitTrackingIssue', () => {
+  test('returns ordered child issue contracts with explicit dependsOn arrays', async () => {
+    const result = await splitTrackingIssue({
+      title: '[AL-EPIC] 把 issue 质量能力接入 agent-loop',
+      body: '需要补 issue lint、rewrite、split 和 simulate 四块能力',
+      repoRoot: '/tmp/repo',
+      issueNumberAllocator: (() => {
+        let current = 17
+        return () => current++
+      })(),
+    }, {
+      runAgent: async () => ({
+        responseText: `1. [AL-X] 引入 issue lint
+2. [AL-Y] 增加 rewrite CLI
+3. [AL-Z] 增加 simulate`,
+      }),
+      buildRepoAuthoringContext: async () => ({
+        candidateValidationCommands: ['bun run typecheck'],
+        candidateAllowedFiles: [],
+        candidateForbiddenFiles: ['package.json'],
+      }),
+    })
+
+    expect(result.children).toHaveLength(3)
+    expect(result.children[0]?.body).toContain('"dependsOn":[]')
+    expect(result.children[1]?.body).toContain('"dependsOn":[17]')
+    expect(result.children[2]?.body).toContain('"dependsOn":[17,18]')
+    expect(result.children.every((child) => child.body.includes('## RED 测试'))).toBe(true)
+    expect(result.parentSummary).toContain('#17 [AL-X] 引入 issue lint')
+  })
+
+  test('rejects investigation-only child issues from the split outline', async () => {
+    await expect(splitTrackingIssue({
+      title: '[AL-EPIC] 改进 authoring flow',
+      body: '需要把 child issue 拆干净',
+      repoRoot: '/tmp/repo',
+      issueNumberAllocator: (() => {
+        let current = 30
+        return () => current++
+      })(),
+    }, {
+      runAgent: async () => ({
+        responseText: `1. 调研 ready gate 的失败原因
+2. 增加 rewrite CLI`,
+      }),
+      buildRepoAuthoringContext: async () => ({
+        candidateValidationCommands: ['bun run typecheck'],
+        candidateAllowedFiles: ['apps/agent-daemon/src/index.ts'],
+        candidateForbiddenFiles: ['package.json'],
+      }),
+    })).rejects.toThrow('non-executable child title')
+  })
+})

--- a/apps/agent-daemon/src/issue-splitter.ts
+++ b/apps/agent-daemon/src/issue-splitter.ts
@@ -101,8 +101,12 @@ export async function splitTrackingIssue(
   input: SplitTrackingIssueInput,
   deps: SplitTrackingIssueDependencies,
 ): Promise<SplitTrackingIssueResult> {
+  const parentAuthoringContext = await (deps.buildRepoAuthoringContext ?? buildRepoAuthoringContext)({
+    repoRoot: input.repoRoot,
+    issueText: [input.title, input.body].filter(Boolean).join('\n'),
+  })
   const response = await deps.runAgent({
-    prompt: buildSplitTrackingIssuePrompt(input.title, input.body),
+    prompt: buildSplitTrackingIssuePrompt(input.title, input.body, parentAuthoringContext),
     repoRoot: input.repoRoot,
   })
   const childTitles = parseChildIssueTitles(response.responseText)
@@ -226,7 +230,10 @@ export function formatSplitTrackingIssueResult(
 function buildSplitTrackingIssuePrompt(
   title: string,
   body: string,
+  authoringContext: RepoAuthoringContext,
 ): string {
+  const projectIssueRules = formatProjectIssueRules(authoringContext)
+
   return `你正在把一个 tracking parent issue 拆成 execution-sized child issues。
 
 只返回有序编号列表，每行一条 child issue 标题，不要输出解释，不要输出 markdown section，不要输出 dependsOn JSON。
@@ -238,6 +245,8 @@ function buildSplitTrackingIssuePrompt(
 
 Tracking parent title:
 ${title}
+
+${projectIssueRules}
 
 Tracking parent body:
 ${body.trim() || '(empty body)'}
@@ -318,6 +327,11 @@ function buildChildIssueBody(input: {
   const outOfScope = input.laterTitles.length > 0
     ? input.laterTitles.map(title => `后续 child issue: ${title}`)
     : ['自动创建 GitHub issue / label / assignee']
+  const reviewHints = uniqueStrings([
+    ...(input.authoringContext.candidateReviewHints ?? []),
+    '优先检查本 child issue 是否偷混入后续 sibling 工作',
+    '优先检查变更文件是否仍落在 `AllowedFiles` 边界内',
+  ])
 
   return `## 用户故事
 
@@ -352,8 +366,7 @@ ${outOfScope.map(value => `- ${value}`).join('\n')}
 - \`AllowedFiles\`、\`Validation\` 与本切片实际实现路径保持一致
 
 ### ReviewHints
-- 优先检查本 child issue 是否偷混入后续 sibling 工作
-- 优先检查变更文件是否仍落在 \`AllowedFiles\` 边界内
+${reviewHints.map(value => `- ${value}`).join('\n')}
 
 ### Validation
 ${validationCommands.map(value => `- \`${value}\``).join('\n')}
@@ -456,4 +469,37 @@ function buildSlugFallbackFiles(title: string): string[] {
 
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))]
+}
+
+function formatProjectIssueRules(authoringContext: RepoAuthoringContext): string {
+  const rules = authoringContext.projectIssueRules ?? {
+    preferredValidationCommands: [],
+    preferredAllowedFiles: [],
+    forbiddenPaths: [],
+    reviewHints: [],
+  }
+  if (
+    rules.preferredValidationCommands.length === 0
+    && rules.preferredAllowedFiles.length === 0
+    && rules.forbiddenPaths.length === 0
+    && rules.reviewHints.length === 0
+  ) {
+    return ''
+  }
+
+  return [
+    'Project Issue Rules:',
+    rules.preferredAllowedFiles.length > 0
+      ? `Preferred AllowedFiles:\n${rules.preferredAllowedFiles.map((value) => `- ${value}`).join('\n')}`
+      : null,
+    rules.forbiddenPaths.length > 0
+      ? `Forbidden paths:\n${rules.forbiddenPaths.map((value) => `- ${value}`).join('\n')}`
+      : null,
+    rules.preferredValidationCommands.length > 0
+      ? `Preferred Validation commands:\n${rules.preferredValidationCommands.map((value) => `- \`${value}\``).join('\n')}`
+      : null,
+    rules.reviewHints.length > 0
+      ? `Review hints:\n${rules.reviewHints.map((value) => `- ${value}`).join('\n')}`
+      : null,
+  ].filter((value): value is string => value !== null).join('\n\n')
 }

--- a/apps/agent-daemon/src/issue-splitter.ts
+++ b/apps/agent-daemon/src/issue-splitter.ts
@@ -1,0 +1,459 @@
+import { basename } from 'node:path'
+import {
+  buildIssueLintReport,
+  formatIssueLintReport,
+  type IssueLintReport,
+} from './audit-issue-contracts'
+import { buildRepoAuthoringContext } from './issue-authoring-context'
+import type {
+  BuildRepoAuthoringContextInput,
+  RepoAuthoringContext,
+} from '@agent/shared'
+import type { IssueAuthoringAgentRunner } from './issue-authoring'
+
+export interface SplitTrackingIssueInput {
+  title: string
+  body: string
+  repoRoot: string
+  issueNumberAllocator: () => number
+}
+
+export interface SplitTrackingIssueChild {
+  issueNumber: number
+  title: string
+  body: string
+  validation: IssueLintReport
+  authoringContext: RepoAuthoringContext
+}
+
+export interface SplitTrackingIssueResult {
+  parentSummary: string
+  children: SplitTrackingIssueChild[]
+}
+
+export interface TrackingIssueDraftDocument {
+  title: string
+  body: string
+}
+
+interface SplitTrackingIssueDependencies {
+  buildRepoAuthoringContext?: (input: BuildRepoAuthoringContextInput) => Promise<RepoAuthoringContext>
+  runAgent: IssueAuthoringAgentRunner
+}
+
+const INVESTIGATION_ONLY_TITLE_PATTERNS = [
+  /\binvestigat(?:e|ion)\b/i,
+  /\bresearch\b/i,
+  /\bspike\b/i,
+  /\banalys(?:e|is)\b/i,
+  /调研/,
+  /调查/,
+  /研究/,
+] as const
+
+const CHILD_FILE_HINTS = [
+  {
+    patterns: [/\blint\b/i, /质量/, /\baudit\b/i],
+    files: [
+      'apps/agent-daemon/src/audit-issue-contracts.ts',
+      'apps/agent-daemon/src/audit-issue-contracts.test.ts',
+      'apps/agent-daemon/src/index.ts',
+      'apps/agent-daemon/src/index.test.ts',
+    ],
+  },
+  {
+    patterns: [/\brewrite\b/i, /重写/],
+    files: [
+      'apps/agent-daemon/src/issue-authoring.ts',
+      'apps/agent-daemon/src/issue-authoring.test.ts',
+      'apps/agent-daemon/src/index.ts',
+      'apps/agent-daemon/src/index.test.ts',
+    ],
+  },
+  {
+    patterns: [/\bsplit\b/i, /拆/, /dependson/i, /依赖图/],
+    files: [
+      'apps/agent-daemon/src/issue-splitter.ts',
+      'apps/agent-daemon/src/issue-splitter.test.ts',
+      'apps/agent-daemon/src/index.ts',
+      'apps/agent-daemon/src/index.test.ts',
+    ],
+  },
+  {
+    patterns: [/\bsimulate\b/i, /模拟/],
+    files: [
+      'apps/agent-daemon/src/issue-simulate.ts',
+      'apps/agent-daemon/src/issue-simulate.test.ts',
+      'apps/agent-daemon/src/index.ts',
+      'apps/agent-daemon/src/index.test.ts',
+    ],
+  },
+  {
+    patterns: [/\bcontext\b/i, /上下文/, /grounded/i],
+    files: [
+      'apps/agent-daemon/src/issue-authoring-context.ts',
+      'apps/agent-daemon/src/issue-authoring-context.test.ts',
+    ],
+  },
+] as const
+
+export async function splitTrackingIssue(
+  input: SplitTrackingIssueInput,
+  deps: SplitTrackingIssueDependencies,
+): Promise<SplitTrackingIssueResult> {
+  const response = await deps.runAgent({
+    prompt: buildSplitTrackingIssuePrompt(input.title, input.body),
+    repoRoot: input.repoRoot,
+  })
+  const childTitles = parseChildIssueTitles(response.responseText)
+
+  if (childTitles.length < 2) {
+    throw new Error('Split output must contain at least two execution-sized child issues')
+  }
+
+  const seen = new Set<number>()
+  const childNumbers = childTitles.map(() => {
+    const issueNumber = input.issueNumberAllocator()
+    if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+      throw new Error(`Issue number allocator returned an invalid issue number: ${issueNumber}`)
+    }
+    if (seen.has(issueNumber)) {
+      throw new Error(`Issue number allocator returned a duplicate issue number: ${issueNumber}`)
+    }
+    seen.add(issueNumber)
+    return issueNumber
+  })
+
+  const children: SplitTrackingIssueChild[] = []
+
+  for (const [index, childTitle] of childTitles.entries()) {
+    const authoringContext = await (deps.buildRepoAuthoringContext ?? buildRepoAuthoringContext)({
+      repoRoot: input.repoRoot,
+      issueText: [input.title, input.body, childTitle].filter(Boolean).join('\n'),
+    })
+    const issueNumber = childNumbers[index]!
+    const dependsOn = childNumbers.slice(0, index)
+    const laterTitles = childTitles.slice(index + 1)
+    const body = buildChildIssueBody({
+      parentTitle: input.title,
+      childTitle,
+      issueNumber,
+      dependsOn,
+      authoringContext,
+      laterTitles,
+    })
+    const validation = buildIssueLintReport(body, {
+      kind: 'file',
+      path: `child-${issueNumber}.md`,
+    }, childTitle)
+
+    if (!validation.valid) {
+      throw new Error(
+        `Split child issue #${issueNumber} failed local validation:\n${formatIssueLintReport(validation)}`,
+      )
+    }
+
+    children.push({
+      issueNumber,
+      title: childTitle,
+      body,
+      validation,
+      authoringContext,
+    })
+  }
+
+  return {
+    parentSummary: buildParentSummary({
+      parentTitle: input.title,
+      childTitles,
+      childNumbers,
+    }),
+    children,
+  }
+}
+
+export function parseTrackingIssueDocument(
+  markdown: string,
+  fallbackTitle = 'Tracking Issue Draft',
+): TrackingIssueDraftDocument {
+  const normalized = markdown.trim()
+  if (!normalized) {
+    return {
+      title: fallbackTitle,
+      body: '',
+    }
+  }
+
+  const lines = normalized.split('\n')
+  const headingIndex = lines.findIndex(line => /^#\s+/.test(line.trim()))
+
+  if (headingIndex >= 0) {
+    const title = lines[headingIndex]!.replace(/^#\s+/, '').trim() || fallbackTitle
+    const body = lines
+      .slice(0, headingIndex)
+      .concat(lines.slice(headingIndex + 1))
+      .join('\n')
+      .trim()
+    return {
+      title,
+      body,
+    }
+  }
+
+  const firstNonEmpty = lines.find(line => line.trim().length > 0)?.trim() ?? fallbackTitle
+  const remaining = lines.slice(lines.findIndex(line => line.trim().length > 0) + 1).join('\n').trim()
+
+  return {
+    title: firstNonEmpty,
+    body: remaining,
+  }
+}
+
+export function formatSplitTrackingIssueResult(
+  result: SplitTrackingIssueResult,
+): string {
+  return [
+    result.parentSummary,
+    ...result.children.flatMap((child) => [
+      '',
+      `## Child Issue #${child.issueNumber}: ${child.title}`,
+      '',
+      child.body,
+    ]),
+  ].join('\n')
+}
+
+function buildSplitTrackingIssuePrompt(
+  title: string,
+  body: string,
+): string {
+  return `你正在把一个 tracking parent issue 拆成 execution-sized child issues。
+
+只返回有序编号列表，每行一条 child issue 标题，不要输出解释，不要输出 markdown section，不要输出 dependsOn JSON。
+要求：
+- child issue 必须是 code-producing slices
+- 不能输出 investigation-only / research-only / analysis-only task
+- 顺序必须符合执行依赖关系
+- 标题要足够具体，能自然落成 canonical executable contract
+
+Tracking parent title:
+${title}
+
+Tracking parent body:
+${body.trim() || '(empty body)'}
+`
+}
+
+function parseChildIssueTitles(responseText: string): string[] {
+  const titles = responseText
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(stripOutlinePrefix)
+    .filter(Boolean)
+    .map(title => title.replace(/^\[[^\]]+\]\s*/, (prefix) => prefix.trimEnd() + ' ').trim())
+
+  const deduped: string[] = []
+  const seen = new Set<string>()
+  for (const title of titles) {
+    const normalized = title.toLowerCase()
+    if (seen.has(normalized)) continue
+    if (INVESTIGATION_ONLY_TITLE_PATTERNS.some(pattern => pattern.test(title))) {
+      throw new Error(`Split output contains a non-executable child title: ${title}`)
+    }
+    deduped.push(title)
+    seen.add(normalized)
+  }
+
+  return deduped
+}
+
+function stripOutlinePrefix(line: string): string {
+  return line
+    .replace(/^```(?:markdown|md)?\s*/i, '')
+    .replace(/^```$/, '')
+    .replace(/^[-*]\s+/, '')
+    .replace(/^\d+[.)]\s+/, '')
+    .trim()
+}
+
+function buildParentSummary(input: {
+  parentTitle: string
+  childTitles: string[]
+  childNumbers: number[]
+}): string {
+  return [
+    '## Tracking Parent Summary',
+    '',
+    `- Parent: ${input.parentTitle}`,
+    '- Parent role: tracking-only; do not move it into `agent:ready`',
+    `- Child count: ${input.childTitles.length}`,
+    '- Suggested creation order:',
+    ...input.childTitles.map((title, index) => {
+      const dependencies = input.childNumbers
+        .slice(0, index)
+        .map(number => `#${number}`)
+        .join(', ')
+      return `${index + 1}. #${input.childNumbers[index]} ${title}${dependencies ? ` | 依赖 issue: ${dependencies}` : ' | 依赖 issue: none'}`
+    }),
+  ].join('\n')
+}
+
+function buildChildIssueBody(input: {
+  parentTitle: string
+  childTitle: string
+  issueNumber: number
+  dependsOn: number[]
+  authoringContext: RepoAuthoringContext
+  laterTitles: string[]
+}): string {
+  const allowedFiles = resolveAllowedFiles(input.childTitle, input.authoringContext)
+  const forbiddenFiles = resolveForbiddenFiles(
+    input.childTitle,
+    input.laterTitles,
+    allowedFiles,
+    input.authoringContext,
+  )
+  const validationCommands = resolveValidationCommands(input.authoringContext)
+  const outOfScope = input.laterTitles.length > 0
+    ? input.laterTitles.map(title => `后续 child issue: ${title}`)
+    : ['自动创建 GitHub issue / label / assignee']
+
+  return `## 用户故事
+
+作为 \`agent-loop\` 维护者，我希望完成 ${input.childTitle}，从而把 \`${input.parentTitle}\` 拆成可进入 ready pool 的 execution-sized child issue。
+
+## Context
+
+### Dependencies
+\`\`\`json
+{"dependsOn":[${input.dependsOn.join(',')}]}
+\`\`\`
+
+### Constraints
+- 只完成 \`${input.childTitle}\` 这一条 execution-sized 切片
+- 不要把 sibling child issue 的后续工作提前混入本次实现
+
+### AllowedFiles
+${allowedFiles.map(value => `- ${value}`).join('\n')}
+
+### ForbiddenFiles
+${forbiddenFiles.map(value => `- ${value}`).join('\n')}
+
+### MustPreserve
+- tracking parent 仍然保持 tracking-only，不进入 \`agent:ready\`
+- 已完成或前序 child issue 的 contract 结构与依赖顺序不回归
+
+### OutOfScope
+${outOfScope.map(value => `- ${value}`).join('\n')}
+
+### RequiredSemantics
+- 产出与 \`${input.childTitle}\` 对齐的最小代码切片，而不是 investigation-only 结果
+- \`AllowedFiles\`、\`Validation\` 与本切片实际实现路径保持一致
+
+### ReviewHints
+- 优先检查本 child issue 是否偷混入后续 sibling 工作
+- 优先检查变更文件是否仍落在 \`AllowedFiles\` 边界内
+
+### Validation
+${validationCommands.map(value => `- \`${value}\``).join('\n')}
+
+## RED 测试
+
+\`\`\`ts
+throw new Error(${JSON.stringify(`red: ${input.childTitle}`)})
+\`\`\`
+
+## 实现步骤
+
+1. 先补 RED 测试
+2. 再做最小实现
+3. 最后跑 Validation 并收紧 scope
+
+## 验收
+
+- [ ] 只修改 \`AllowedFiles\` 内文件
+- [ ] \`MustPreserve\` 行为未回归
+- [ ] \`OutOfScope\` 内容未混入
+- [ ] RED 测试转绿
+- [ ] 完成 \`Validation\` 中要求的验证`
+}
+
+function resolveAllowedFiles(
+  childTitle: string,
+  authoringContext: RepoAuthoringContext,
+): string[] {
+  const contextCandidates = authoringContext.candidateAllowedFiles.slice(0, 4)
+  const hintedFiles = collectHintedFiles(childTitle)
+
+  return uniqueStrings([
+    ...hintedFiles,
+    ...contextCandidates,
+    ...(contextCandidates.length === 0 && hintedFiles.length === 0
+      ? buildSlugFallbackFiles(childTitle)
+      : []),
+  ]).slice(0, 4)
+}
+
+function resolveForbiddenFiles(
+  childTitle: string,
+  laterTitles: string[],
+  allowedFiles: string[],
+  authoringContext: RepoAuthoringContext,
+): string[] {
+  const forbidden = uniqueStrings([
+    ...authoringContext.candidateForbiddenFiles,
+    ...laterTitles.flatMap(title => collectHintedFiles(title)),
+    ...collectNonMatchingHintFiles(childTitle),
+  ]).filter(file => !allowedFiles.includes(file))
+
+  if (forbidden.length > 0) {
+    return forbidden.slice(0, 4)
+  }
+
+  return [
+    'package.json',
+    'tsconfig.json',
+  ].filter(file => !allowedFiles.includes(file))
+}
+
+function resolveValidationCommands(
+  authoringContext: RepoAuthoringContext,
+): string[] {
+  const commands = uniqueStrings([
+    ...authoringContext.candidateValidationCommands.slice(0, 2),
+    'git diff --stat origin/main...HEAD',
+  ])
+
+  return commands
+}
+
+function collectHintedFiles(title: string): string[] {
+  return CHILD_FILE_HINTS
+    .filter(entry => entry.patterns.some(pattern => pattern.test(title)))
+    .flatMap(entry => entry.files)
+}
+
+function collectNonMatchingHintFiles(title: string): string[] {
+  return CHILD_FILE_HINTS
+    .filter(entry => !entry.patterns.some(pattern => pattern.test(title)))
+    .flatMap(entry => entry.files)
+}
+
+function buildSlugFallbackFiles(title: string): string[] {
+  const slug = title
+    .replace(/^\[[^\]]+\]\s*/, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    || basename(title).toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'child-issue'
+
+  return [
+    `apps/agent-daemon/src/${slug}.ts`,
+    `apps/agent-daemon/src/${slug}.test.ts`,
+  ]
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))]
+}

--- a/apps/agent-daemon/src/local-implementation.test.ts
+++ b/apps/agent-daemon/src/local-implementation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildLocalImplementationIndex,
+  parseLocalImplementationRecords,
+} from './local-implementation'
+
+describe('parseLocalImplementationRecords', () => {
+  test('extracts issue-linked implementation commits from conventional subjects', () => {
+    const records = parseLocalImplementationRecords([
+      'Fix #70 add bootstrap scorecard taxonomy report',
+      '',
+      '\u001e',
+      'feat(#53): add issue repair cli',
+      '',
+      '\u001e',
+      'docs: mention roadmap only',
+      '',
+      '\u001e',
+    ].join('\n'))
+
+    expect(records).toEqual([
+      {
+        issueNumber: 70,
+        latestCommitHeadline: 'Fix #70 add bootstrap scorecard taxonomy report',
+        commitCount: 1,
+      },
+      {
+        issueNumber: 53,
+        latestCommitHeadline: 'feat(#53): add issue repair cli',
+        commitCount: 1,
+      },
+    ])
+  })
+
+  test('keeps the newest headline and counts repeated implementations for the same issue', () => {
+    const records = parseLocalImplementationRecords([
+      'fix(#61): gate approved PR merges on check status',
+      '',
+      '\u001e',
+      'feat(#61): first pass at checks gate',
+      '',
+      '\u001e',
+    ].join('\n'))
+
+    expect(records).toEqual([
+      {
+        issueNumber: 61,
+        latestCommitHeadline: 'fix(#61): gate approved PR merges on check status',
+        commitCount: 2,
+      },
+    ])
+  })
+})
+
+describe('buildLocalImplementationIndex', () => {
+  test('returns an empty index when git log cannot be read', () => {
+    expect(buildLocalImplementationIndex('/definitely/not/a/repo')).toEqual(new Map())
+  })
+})

--- a/apps/agent-daemon/src/local-implementation.ts
+++ b/apps/agent-daemon/src/local-implementation.ts
@@ -1,0 +1,95 @@
+import { execFileSync } from 'node:child_process'
+
+export interface LocalImplementationRecord {
+  issueNumber: number
+  latestCommitHeadline: string
+  commitCount: number
+}
+
+const IMPLEMENTATION_REFERENCE_PATTERNS = [
+  /\b[a-z][a-z0-9-]*\(#(\d+)\)/gi,
+  /\bfix #(\d+)\b/gi,
+]
+
+export function parseLocalImplementationRecords(
+  gitLogOutput: string,
+): LocalImplementationRecord[] {
+  const records = new Map<number, LocalImplementationRecord>()
+
+  for (const rawEntry of gitLogOutput.split('\u001e')) {
+    const entry = rawEntry.trim()
+    if (!entry) {
+      continue
+    }
+
+    const lines = entry
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+    const latestCommitHeadline = lines[0] ?? '(unknown commit)'
+    const issueNumbers = extractImplementedIssueNumbers(entry)
+
+    for (const issueNumber of issueNumbers) {
+      const existing = records.get(issueNumber)
+      if (existing) {
+        existing.commitCount += 1
+        continue
+      }
+
+      records.set(issueNumber, {
+        issueNumber,
+        latestCommitHeadline,
+        commitCount: 1,
+      })
+    }
+  }
+
+  return [...records.values()]
+}
+
+export function buildLocalImplementationIndex(
+  repoRoot = process.cwd(),
+  maxCommits = 400,
+): Map<number, LocalImplementationRecord> {
+  try {
+    const gitLogOutput = execFileSync('git', [
+      '-C',
+      repoRoot,
+      'log',
+      '--format=%s%n%b%x1e',
+      '-n',
+      String(maxCommits),
+    ], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+
+    return new Map(
+      parseLocalImplementationRecords(gitLogOutput).map((record) => [record.issueNumber, record]),
+    )
+  } catch {
+    return new Map()
+  }
+}
+
+function extractImplementedIssueNumbers(message: string): Set<number> {
+  const issueNumbers = new Set<number>()
+
+  for (const pattern of IMPLEMENTATION_REFERENCE_PATTERNS) {
+    pattern.lastIndex = 0
+
+    for (const match of message.matchAll(pattern)) {
+      const rawIssueNumber = match[1]
+      if (!rawIssueNumber) {
+        continue
+      }
+
+      const issueNumber = Number.parseInt(rawIssueNumber, 10)
+      if (Number.isSafeInteger(issueNumber)) {
+        issueNumbers.add(issueNumber)
+      }
+    }
+  }
+
+  return issueNumbers
+}

--- a/apps/agent-daemon/src/metrics.test.ts
+++ b/apps/agent-daemon/src/metrics.test.ts
@@ -23,6 +23,7 @@ import {
   setBlockedIssueResumeAgeSeconds,
   setBlockedIssueResumeEscalations,
   setBlockedIssueResumeEscalationAgeSeconds,
+  setIssueOpsSummaryMetrics,
   setLastTransientLoopErrorAgeSeconds,
   setNextPollDelaySeconds,
   setPendingWakeRequests,
@@ -69,6 +70,21 @@ describe('metrics', () => {
       expect(metrics).toContain('result="no_issues"')
       expect(metrics).toContain('result="skipped_concurrency"')
       expect(metrics).toContain('result="error"')
+    })
+  })
+
+  describe('issue ops summary gauges', () => {
+    test('sets repo-level issue contract quality gauges', async () => {
+      setIssueOpsSummaryMetrics({
+        invalidReadyIssueCount: 1,
+        lowScoreIssueCount: 2,
+        warningIssueCount: 1,
+      })
+
+      const metrics = await getMetrics()
+      expect(metrics).toContain('agent_loop_issue_contract_invalid_ready 1')
+      expect(metrics).toContain('agent_loop_issue_contract_warning_issues 1')
+      expect(metrics).toContain('agent_loop_issue_contract_low_score_issues 2')
     })
   })
 

--- a/apps/agent-daemon/src/metrics.test.ts
+++ b/apps/agent-daemon/src/metrics.test.ts
@@ -14,6 +14,7 @@ import {
   recordWorkerIdleTimeout,
   recordQueuedWakeRequest,
   recordHandledWakeRequest,
+  recordPrLineageEvent,
   recordPrCreated,
   setActiveWorktrees,
   setActivePrReviews,
@@ -25,6 +26,7 @@ import {
   setLastTransientLoopErrorAgeSeconds,
   setNextPollDelaySeconds,
   setPendingWakeRequests,
+  setPrLineageWarningSnapshot,
   setAutoUpgradeSnapshot,
   setInFlightIssueProcesses,
   setInFlightPrReviews,
@@ -131,6 +133,17 @@ describe('metrics', () => {
   })
 
   describe('review and merge metrics', () => {
+    test('records lineage counters for blocked terminal reuse and superseded PRs', async () => {
+      recordPrLineageEvent('terminal_reuse_blocked')
+      recordPrLineageEvent('superseded_lineage')
+
+      const metrics = await getMetrics()
+
+      expect(metrics).toContain('agent_loop_pr_lineage_events_total')
+      expect(metrics).toContain('kind="terminal_reuse_blocked"')
+      expect(metrics).toContain('kind="superseded_lineage"')
+    })
+
     test('increments pr_reviews_total counter with stage and outcome labels', async () => {
       recordPrReviewOutcome('initial', 'approved')
       recordPrReviewOutcome('post_fix', 'rejected')
@@ -266,6 +279,13 @@ describe('metrics', () => {
     test('tracks active PR reviews and in-flight task gauges', async () => {
       setActivePrReviews(2)
       setActiveLeases(3)
+      setPrLineageWarningSnapshot({
+        multi_active_lineage: 1,
+        terminal_reuse_blocked: 1,
+        superseded_lineage: 1,
+        missing_metadata: 1,
+        lineage_mismatch_blocked: 0,
+      })
       setBlockedIssueResumes(1)
       setBlockedIssueResumeAgeSeconds(45)
       setBlockedIssueResumeEscalations(1)
@@ -283,6 +303,11 @@ describe('metrics', () => {
       const metrics = await getMetrics()
       expect(metrics).toContain('agent_loop_active_pr_reviews')
       expect(metrics).toContain('agent_loop_active_leases')
+      expect(metrics).toContain('agent_loop_pr_lineage_warnings')
+      expect(metrics).toContain('kind="multi_active_lineage"')
+      expect(metrics).toContain('kind="terminal_reuse_blocked"')
+      expect(metrics).toContain('kind="superseded_lineage"')
+      expect(metrics).toContain('kind="missing_metadata"')
       expect(metrics).toContain('agent_loop_blocked_issue_resumes')
       expect(metrics).toContain('agent_loop_blocked_issue_resume_age_seconds')
       expect(metrics).toContain('agent_loop_blocked_issue_resume_escalations')

--- a/apps/agent-daemon/src/metrics.ts
+++ b/apps/agent-daemon/src/metrics.ts
@@ -34,6 +34,8 @@
  * - agent_loop_auto_upgrade_no_changes: Gauge of automatic self-upgrades that found no revision change
  * - agent_loop_auto_upgrade_last_attempt_age_seconds: Gauge of the last automatic self-upgrade attempt age
  * - agent_loop_auto_upgrade_last_success_age_seconds: Gauge of the last successful automatic self-upgrade age
+ * - agent_loop_pr_lineage_events_total: Counter of observed PR lineage anomalies and transitions (labels: kind)
+ * - agent_loop_pr_lineage_warnings: Gauge of currently tracked PR lineage warnings by kind
  * - agent_loop_blocked_issue_resumes: Gauge of failed issue resumes currently blocked by linked PR state
  * - agent_loop_blocked_issue_resume_age_seconds: Gauge of the oldest blocked failed-issue resume age
  * - agent_loop_poll_duration_seconds: Histogram of poll cycle durations
@@ -122,6 +124,12 @@ export type PrReviewStage = 'initial' | 'post_fix' | 'merge_refresh'
 export type PrReviewOutcome = 'approved' | 'rejected' | 'invalid_output' | 'execution_failed'
 export type WakeRequestKind = 'now' | 'issue' | 'pr'
 export type WakeRequestOutcome = 'queued' | 'started_work' | 'no_match' | 'allow_fallback'
+export type PrLineageEventKind =
+  | 'multi_active_lineage'
+  | 'terminal_reuse_blocked'
+  | 'superseded_lineage'
+  | 'missing_metadata'
+  | 'lineage_mismatch_blocked'
 
 /**
  * Total number of automated PR reviews performed by the daemon.
@@ -267,6 +275,18 @@ export const wakeRequestsTotal = new Counter({
   name: 'agent_loop_wake_requests_total',
   help: 'Total number of wake requests queued and handled by the daemon',
   labelNames: ['kind', 'outcome'] as const,
+  registers: [registry],
+})
+
+/**
+ * Total number of PR lineage anomalies or transitions observed by the daemon.
+ * Labels:
+ *   - kind: lineage event kind
+ */
+export const prLineageEventsTotal = new Counter({
+  name: 'agent_loop_pr_lineage_events_total',
+  help: 'Total number of PR lineage anomalies or transitions observed by the daemon',
+  labelNames: ['kind'] as const,
   registers: [registry],
 })
 
@@ -508,6 +528,16 @@ export const autoUpgradeLastSuccessAgeSeconds = new Gauge({
   registers: [registry],
 })
 
+/**
+ * Current number of tracked PR lineage warnings by kind.
+ */
+export const prLineageWarnings = new Gauge({
+  name: 'agent_loop_pr_lineage_warnings',
+  help: 'Current number of tracked PR lineage warnings by kind',
+  labelNames: ['kind'] as const,
+  registers: [registry],
+})
+
 // ─── Histograms ────────────────────────────────────────────────────────────────
 
 /**
@@ -739,6 +769,13 @@ export function recordHandledWakeRequest(
 }
 
 /**
+ * Record a PR lineage observability event.
+ */
+export function recordPrLineageEvent(kind: PrLineageEventKind): void {
+  prLineageEventsTotal.inc({ kind })
+}
+
+/**
  * Update active worktrees gauge.
  */
 export function setActiveWorktrees(count: number): void {
@@ -920,6 +957,26 @@ export function setAutoUpgradeSnapshot(
   autoUpgradeNoChanges.set(state.noChangeCount)
   autoUpgradeLastAttemptAgeSeconds.set(computeIsoAgeSeconds(state.lastAttemptAt, nowMs))
   autoUpgradeLastSuccessAgeSeconds.set(computeIsoAgeSeconds(state.lastSuccessAt, nowMs))
+}
+
+/**
+ * Update tracked PR lineage warning gauges by kind.
+ */
+export function setPrLineageWarningSnapshot(
+  counts: Partial<Record<PrLineageEventKind, number>>,
+): void {
+  const orderedKinds: PrLineageEventKind[] = [
+    'multi_active_lineage',
+    'terminal_reuse_blocked',
+    'superseded_lineage',
+    'missing_metadata',
+    'lineage_mismatch_blocked',
+  ]
+
+  prLineageWarnings.reset()
+  for (const kind of orderedKinds) {
+    prLineageWarnings.labels({ kind }).set(counts[kind] ?? 0)
+  }
 }
 
 /**

--- a/apps/agent-daemon/src/metrics.ts
+++ b/apps/agent-daemon/src/metrics.ts
@@ -38,6 +38,9 @@
  * - agent_loop_pr_lineage_warnings: Gauge of currently tracked PR lineage warnings by kind
  * - agent_loop_blocked_issue_resumes: Gauge of failed issue resumes currently blocked by linked PR state
  * - agent_loop_blocked_issue_resume_age_seconds: Gauge of the oldest blocked failed-issue resume age
+ * - agent_loop_issue_contract_invalid_ready: Gauge of ready issues blocked by hard executable-contract validation
+ * - agent_loop_issue_contract_low_score_issues: Gauge of open issues below the low-score contract threshold
+ * - agent_loop_issue_contract_warning_issues: Gauge of open issues with contract warnings
  * - agent_loop_poll_duration_seconds: Histogram of poll cycle durations
  * - agent_loop_issue_processing_duration_seconds: Histogram of issue processing durations
  * - agent_loop_agent_execution_duration_seconds: Histogram of agent execution durations
@@ -59,6 +62,7 @@ import type {
   GitHubApiOutcome,
   GitHubApiTransport,
 } from '@agent/shared'
+import type { IssueOpsSummary } from './audit-issue-contracts'
 
 export const METRICS_PORT_DEFAULT = 9090
 export const METRICS_PATH = '/metrics'
@@ -453,6 +457,33 @@ export const blockedIssueResumeEscalations = new Gauge({
 export const blockedIssueResumeEscalationAgeSeconds = new Gauge({
   name: 'agent_loop_blocked_issue_resume_escalation_age_seconds',
   help: 'Age in seconds of the oldest GitHub escalation comment for a blocked failed issue resume',
+  registers: [registry],
+})
+
+/**
+ * Current number of ready issues that would fail hard executable-contract validation.
+ */
+export const invalidReadyIssueContracts = new Gauge({
+  name: 'agent_loop_issue_contract_invalid_ready',
+  help: 'Current number of ready issues that would fail hard executable-contract validation',
+  registers: [registry],
+})
+
+/**
+ * Current number of open managed issues whose contract quality score is below the low-score threshold.
+ */
+export const lowScoreIssueContracts = new Gauge({
+  name: 'agent_loop_issue_contract_low_score_issues',
+  help: 'Current number of open managed issues whose contract quality score is below the low-score threshold',
+  registers: [registry],
+})
+
+/**
+ * Current number of open managed issues whose contract still has warnings.
+ */
+export const warningIssueContracts = new Gauge({
+  name: 'agent_loop_issue_contract_warning_issues',
+  help: 'Current number of open managed issues whose contract still has warnings',
   registers: [registry],
 })
 
@@ -928,6 +959,15 @@ export function setBlockedIssueResumeEscalations(count: number): void {
  */
 export function setBlockedIssueResumeEscalationAgeSeconds(ageSeconds: number): void {
   blockedIssueResumeEscalationAgeSeconds.set(ageSeconds)
+}
+
+/**
+ * Update repo-level issue contract quality gauges.
+ */
+export function setIssueOpsSummaryMetrics(summary: IssueOpsSummary): void {
+  invalidReadyIssueContracts.set(summary.invalidReadyIssueCount)
+  lowScoreIssueContracts.set(summary.lowScoreIssueCount)
+  warningIssueContracts.set(summary.warningIssueCount)
 }
 
 /**

--- a/apps/agent-daemon/src/pr-lineage-preflight.test.ts
+++ b/apps/agent-daemon/src/pr-lineage-preflight.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  collectPrLineagePreflightActualState,
+  evaluatePrLineagePreflight,
+  isCommitAncestorInWorktree,
+} from './pr-lineage-preflight'
+
+describe('evaluatePrLineagePreflight', () => {
+  test('fails when the branch was rebuilt onto an unexpected base branch', async () => {
+    const result = evaluatePrLineagePreflight({
+      expected: {
+        issueNumber: 37,
+        headBranch: 'agent/37-rebuild/codex-dev',
+        baseBranch: 'master',
+        baseSha: '11fc78e',
+      },
+      actual: {
+        headBranch: 'agent/37-rebuild/codex-dev',
+        baseBranch: 'agent/36/codex-dev',
+        baseSha: '0176283',
+        changedFiles: [
+          'apps/agent-daemon/src/issue-authoring-context.ts',
+        ],
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures).toContain(
+      'base branch mismatch: expected master but found agent/36/codex-dev',
+    )
+    expect(result.failures).toContain(
+      'base sha mismatch: expected 11fc78e but found 0176283',
+    )
+  })
+
+  test('fails when the diff is polluted outside the expected lineage scope', () => {
+    const result = evaluatePrLineagePreflight({
+      expected: {
+        issueNumber: 37,
+        headBranch: 'agent/37/codex-dev',
+        baseBranch: 'master',
+        baseSha: '11fc78e',
+        allowedChangedFiles: [
+          'apps/agent-daemon/src/daemon.ts',
+        ],
+      },
+      actual: {
+        headBranch: 'agent/37/codex-dev',
+        baseBranch: 'master',
+        baseSha: '11fc78e',
+        changedFiles: [
+          'apps/agent-daemon/src/daemon.ts',
+          'apps/agent-daemon/src/issue-authoring-context.ts',
+        ],
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures).toContain(
+      'unexpected changed files outside lineage scope: apps/agent-daemon/src/issue-authoring-context.ts',
+    )
+  })
+})
+
+describe('collectPrLineagePreflightActualState', () => {
+  test('reads the current branch, merge-base, and changed file set from a worktree', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'pr-lineage-preflight-'))
+    const remoteDir = join(tempDir, 'remote.git')
+    const repoDir = join(tempDir, 'repo')
+    const branch = 'agent/37/codex-dev'
+
+    try {
+      mkdirSync(remoteDir, { recursive: true })
+      mkdirSync(repoDir, { recursive: true })
+
+      await Bun.$`git -C ${remoteDir} init --bare`.quiet()
+      await Bun.$`git -C ${repoDir} init -b master`.quiet()
+      await Bun.$`git -C ${repoDir} config user.name test`.quiet()
+      await Bun.$`git -C ${repoDir} config user.email test@example.com`.quiet()
+      await Bun.$`git -C ${repoDir} remote add origin ${remoteDir}`.quiet()
+
+      writeFileSync(join(repoDir, 'README.md'), 'base\n', 'utf-8')
+      await Bun.$`git -C ${repoDir} add README.md`.quiet()
+      await Bun.$`git -C ${repoDir} commit -m "base"`.quiet()
+      await Bun.$`git -C ${repoDir} push -u origin master`.quiet()
+
+      await Bun.$`git -C ${repoDir} checkout -b ${branch}`.quiet()
+      mkdirSync(join(repoDir, 'apps', 'agent-daemon', 'src'), { recursive: true })
+      writeFileSync(join(repoDir, 'apps', 'agent-daemon', 'src', 'daemon.ts'), 'export const updated = true\n', 'utf-8')
+      await Bun.$`git -C ${repoDir} add apps/agent-daemon/src/daemon.ts`.quiet()
+      await Bun.$`git -C ${repoDir} commit -m "feature"`.quiet()
+
+      const actual = await collectPrLineagePreflightActualState({
+        worktreePath: repoDir,
+        expectedBaseBranch: 'master',
+      })
+      const baseSha = (await Bun.$`git -C ${repoDir} rev-parse origin/master`.quiet().text()).trim()
+
+      expect(actual).toEqual({
+        headBranch: branch,
+        baseBranch: null,
+        baseSha,
+        changedFiles: ['apps/agent-daemon/src/daemon.ts'],
+      })
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('treats forward rebases as descendant base-sha evolution', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'pr-lineage-preflight-ancestor-'))
+    const remoteDir = join(tempDir, 'remote.git')
+    const repoDir = join(tempDir, 'repo')
+    const branch = 'agent/37/codex-dev'
+
+    try {
+      mkdirSync(remoteDir, { recursive: true })
+      mkdirSync(repoDir, { recursive: true })
+
+      await Bun.$`git -C ${remoteDir} init --bare`.quiet()
+      await Bun.$`git -C ${repoDir} init -b master`.quiet()
+      await Bun.$`git -C ${repoDir} config user.name test`.quiet()
+      await Bun.$`git -C ${repoDir} config user.email test@example.com`.quiet()
+      await Bun.$`git -C ${repoDir} remote add origin ${remoteDir}`.quiet()
+
+      writeFileSync(join(repoDir, 'README.md'), 'base\n', 'utf-8')
+      await Bun.$`git -C ${repoDir} add README.md`.quiet()
+      await Bun.$`git -C ${repoDir} commit -m "base"`.quiet()
+      await Bun.$`git -C ${repoDir} push -u origin master`.quiet()
+
+      const originalBaseSha = (await Bun.$`git -C ${repoDir} rev-parse HEAD`.quiet().text()).trim()
+
+      writeFileSync(join(repoDir, 'README.md'), 'base\nnext\n', 'utf-8')
+      await Bun.$`git -C ${repoDir} add README.md`.quiet()
+      await Bun.$`git -C ${repoDir} commit -m "base-2"`.quiet()
+      await Bun.$`git -C ${repoDir} push origin master`.quiet()
+
+      const advancedBaseSha = (await Bun.$`git -C ${repoDir} rev-parse HEAD`.quiet().text()).trim()
+
+      await Bun.$`git -C ${repoDir} checkout -b ${branch} ${advancedBaseSha}`.quiet()
+
+      expect(await isCommitAncestorInWorktree(repoDir, originalBaseSha, advancedBaseSha)).toBe(true)
+      expect(await isCommitAncestorInWorktree(repoDir, advancedBaseSha, originalBaseSha)).toBe(false)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/agent-daemon/src/pr-lineage-preflight.ts
+++ b/apps/agent-daemon/src/pr-lineage-preflight.ts
@@ -1,0 +1,236 @@
+interface GitCommandResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+export interface PrLineagePreflightExpected {
+  issueNumber: number
+  headBranch: string
+  baseBranch: string
+  baseSha: string
+  allowedChangedFiles?: string[]
+}
+
+export interface PrLineagePreflightActual {
+  headBranch: string
+  baseBranch: string | null
+  baseSha: string
+  changedFiles: string[]
+}
+
+export type PrLineagePreflightFailureCode =
+  | 'head_branch_mismatch'
+  | 'base_branch_mismatch'
+  | 'base_sha_mismatch'
+  | 'unexpected_changed_files'
+
+export interface PrLineagePreflightFailure {
+  code: PrLineagePreflightFailureCode
+  message: string
+  expected: string | string[] | null
+  actual: string | string[] | null
+}
+
+export interface PrLineagePreflightResult {
+  ok: boolean
+  failures: string[]
+  details: PrLineagePreflightFailure[]
+  expected: PrLineagePreflightExpected
+  actual: PrLineagePreflightActual
+}
+
+export interface CollectPrLineagePreflightActualStateInput {
+  worktreePath: string
+  expectedBaseBranch: string
+  actualHeadBranch?: string | null
+  actualBaseBranch?: string | null
+  runGit?: (
+    worktreePath: string,
+    args: string[],
+  ) => Promise<GitCommandResult>
+}
+
+export class PrLineagePreflightError extends Error {
+  readonly stage: string
+  readonly result: PrLineagePreflightResult
+
+  constructor(stage: string, result: PrLineagePreflightResult) {
+    super(`PR lineage preflight failed before ${stage}: ${result.failures.join('; ')}`)
+    this.name = 'PrLineagePreflightError'
+    this.stage = stage
+    this.result = result
+  }
+}
+
+export function evaluatePrLineagePreflight(input: {
+  expected: PrLineagePreflightExpected
+  actual: PrLineagePreflightActual
+}): PrLineagePreflightResult {
+  const details: PrLineagePreflightFailure[] = []
+
+  const addFailure = (
+    code: PrLineagePreflightFailureCode,
+    message: string,
+    expected: string | string[] | null,
+    actual: string | string[] | null,
+  ): void => {
+    details.push({
+      code,
+      message,
+      expected,
+      actual,
+    })
+  }
+
+  if (input.actual.headBranch !== input.expected.headBranch) {
+    addFailure(
+      'head_branch_mismatch',
+      `head branch mismatch: expected ${input.expected.headBranch} but found ${input.actual.headBranch}`,
+      input.expected.headBranch,
+      input.actual.headBranch,
+    )
+  }
+
+  if (
+    input.actual.baseBranch !== null
+    && input.actual.baseBranch !== input.expected.baseBranch
+  ) {
+    addFailure(
+      'base_branch_mismatch',
+      `base branch mismatch: expected ${input.expected.baseBranch} but found ${input.actual.baseBranch}`,
+      input.expected.baseBranch,
+      input.actual.baseBranch,
+    )
+  }
+
+  if (input.actual.baseSha !== input.expected.baseSha) {
+    addFailure(
+      'base_sha_mismatch',
+      `base sha mismatch: expected ${input.expected.baseSha} but found ${input.actual.baseSha}`,
+      input.expected.baseSha,
+      input.actual.baseSha,
+    )
+  }
+
+  const allowedChangedFiles = new Set(input.expected.allowedChangedFiles ?? [])
+  if (allowedChangedFiles.size > 0) {
+    const unexpectedChangedFiles = input.actual.changedFiles
+      .filter(file => !allowedChangedFiles.has(file))
+      .sort((left, right) => left.localeCompare(right))
+
+    if (unexpectedChangedFiles.length > 0) {
+      addFailure(
+        'unexpected_changed_files',
+        `unexpected changed files outside lineage scope: ${unexpectedChangedFiles.join(', ')}`,
+        [...allowedChangedFiles].sort((left, right) => left.localeCompare(right)),
+        unexpectedChangedFiles,
+      )
+    }
+  }
+
+  return {
+    ok: details.length === 0,
+    failures: details.map(detail => detail.message),
+    details,
+    expected: input.expected,
+    actual: input.actual,
+  }
+}
+
+export async function collectPrLineagePreflightActualState(
+  input: CollectPrLineagePreflightActualStateInput,
+): Promise<PrLineagePreflightActual> {
+  const gitRunner = input.runGit ?? runGit
+  const fetchBase = await gitRunner(input.worktreePath, ['fetch', 'origin', input.expectedBaseBranch])
+  if (fetchBase.exitCode !== 0) {
+    throw new Error(
+      fetchBase.stderr
+        || fetchBase.stdout
+        || `Failed to fetch origin/${input.expectedBaseBranch} for PR lineage preflight`,
+    )
+  }
+
+  const headBranch = input.actualHeadBranch ?? await resolveCurrentHeadBranch(input.worktreePath, gitRunner)
+  const mergeBase = await gitRunner(input.worktreePath, ['merge-base', 'HEAD', `origin/${input.expectedBaseBranch}`])
+  if (mergeBase.exitCode !== 0) {
+    throw new Error(
+      mergeBase.stderr
+        || mergeBase.stdout
+        || `Failed to resolve merge-base against origin/${input.expectedBaseBranch} for PR lineage preflight`,
+    )
+  }
+
+  const changedFilesResult = await gitRunner(
+    input.worktreePath,
+    ['diff', '--name-only', `origin/${input.expectedBaseBranch}...HEAD`],
+  )
+  if (changedFilesResult.exitCode !== 0) {
+    throw new Error(
+      changedFilesResult.stderr
+        || changedFilesResult.stdout
+        || `Failed to list changed files against origin/${input.expectedBaseBranch} for PR lineage preflight`,
+    )
+  }
+
+  return {
+    headBranch,
+    baseBranch: input.actualBaseBranch ?? null,
+    baseSha: mergeBase.stdout.trim(),
+    changedFiles: changedFilesResult.stdout
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .sort((left, right) => left.localeCompare(right)),
+  }
+}
+
+export async function isCommitAncestorInWorktree(
+  worktreePath: string,
+  ancestorSha: string,
+  descendantSha: string,
+  gitRunner: CollectPrLineagePreflightActualStateInput['runGit'] = runGit,
+): Promise<boolean> {
+  const result = await gitRunner(worktreePath, ['merge-base', '--is-ancestor', ancestorSha, descendantSha])
+  if (result.exitCode === 0) return true
+  if (result.exitCode === 1) return false
+  throw new Error(
+    result.stderr
+      || result.stdout
+      || `Failed to compare commit ancestry for ${ancestorSha} -> ${descendantSha}`,
+  )
+}
+
+async function resolveCurrentHeadBranch(
+  worktreePath: string,
+  gitRunner: NonNullable<CollectPrLineagePreflightActualStateInput['runGit']>,
+): Promise<string> {
+  const branchResult = await gitRunner(worktreePath, ['symbolic-ref', '--quiet', '--short', 'HEAD'])
+  if (branchResult.exitCode !== 0) {
+    return 'HEAD'
+  }
+
+  return branchResult.stdout.trim() || 'HEAD'
+}
+
+async function runGit(
+  worktreePath: string,
+  args: string[],
+): Promise<GitCommandResult> {
+  const proc = Bun.spawn(['git', '-C', worktreePath, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  const exitCode = await proc.exited
+
+  return {
+    exitCode,
+    stdout,
+    stderr,
+  }
+}

--- a/apps/agent-daemon/src/pr-lineage.test.ts
+++ b/apps/agent-daemon/src/pr-lineage.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildPrLineageMetadata,
+  parsePrLineageMetadata,
+  PrLineageMetadataParseError,
+  renderPrLineageMetadataComment,
+} from './pr-lineage'
+
+describe('pr lineage metadata', () => {
+  test('round-trips a deterministic fingerprint without runtime-only fields', () => {
+    const metadata = buildPrLineageMetadata({
+      issueNumber: 37,
+      headBranch: 'agent/37-rebuild/codex-dev',
+      baseBranch: 'master',
+      baseSha: '11fc78e',
+      attempt: 2,
+    })
+
+    const parsed = parsePrLineageMetadata(renderPrLineageMetadataComment(metadata))
+
+    expect(parsed).toEqual(metadata)
+    expect(metadata.fingerprint).toBe(buildPrLineageMetadata({
+      issueNumber: 37,
+      headBranch: 'agent/37-rebuild/codex-dev',
+      baseBranch: 'master',
+      baseSha: '11fc78e',
+      attempt: 2,
+    }).fingerprint)
+    expect(JSON.stringify(metadata)).not.toContain('/tmp/')
+    expect(JSON.stringify(metadata)).not.toContain('"timestamp"')
+  })
+
+  test('throws a structured error when required fields are missing', () => {
+    expect(() => parsePrLineageMetadata(
+      '<!-- agent-loop:pr-lineage {"version":1,"issue":37} -->',
+    )).toThrow(PrLineageMetadataParseError)
+
+    try {
+      parsePrLineageMetadata('<!-- agent-loop:pr-lineage {"version":1,"issue":37} -->')
+      throw new Error('expected parser to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(PrLineageMetadataParseError)
+      expect((error as PrLineageMetadataParseError).code).toBe('missing_required_fields')
+    }
+  })
+
+  test('throws a structured error when the fingerprint is tampered', () => {
+    expect(() => parsePrLineageMetadata(
+      '<!-- agent-loop:pr-lineage {"version":1,"issue":37,"headBranch":"agent/37-rebuild/codex-dev","baseBranch":"master","baseSha":"11fc78e","attempt":2,"fingerprint":"tampered"} -->',
+    )).toThrow(PrLineageMetadataParseError)
+
+    try {
+      parsePrLineageMetadata(
+        '<!-- agent-loop:pr-lineage {"version":1,"issue":37,"headBranch":"agent/37-rebuild/codex-dev","baseBranch":"master","baseSha":"11fc78e","attempt":2,"fingerprint":"tampered"} -->',
+      )
+      throw new Error('expected parser to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(PrLineageMetadataParseError)
+      expect((error as PrLineageMetadataParseError).code).toBe('fingerprint_mismatch')
+    }
+  })
+})

--- a/apps/agent-daemon/src/pr-lineage.test.ts
+++ b/apps/agent-daemon/src/pr-lineage.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  buildReplacementBranchName,
+  buildSupersededPrComment,
   buildPrLineageMetadata,
+  choosePrLifecycleAction,
+  inferPrAttemptFromBranch,
   parsePrLineageMetadata,
   PrLineageMetadataParseError,
   renderPrLineageMetadataComment,
@@ -58,5 +62,129 @@ describe('pr lineage metadata', () => {
       expect(error).toBeInstanceOf(PrLineageMetadataParseError)
       expect((error as PrLineageMetadataParseError).code).toBe('fingerprint_mismatch')
     }
+  })
+
+  test('infers replacement attempts from rebuild branch names', () => {
+    expect(inferPrAttemptFromBranch('agent/37/codex-dev')).toBe(1)
+    expect(inferPrAttemptFromBranch('agent/37-rebuild/codex-dev')).toBe(2)
+    expect(inferPrAttemptFromBranch('agent/37-rebuild-2/codex-dev')).toBe(3)
+  })
+
+  test('builds deterministic replacement branch names', () => {
+    expect(buildReplacementBranchName('agent/37/codex-dev', 2)).toBe('agent/37-rebuild/codex-dev')
+    expect(buildReplacementBranchName('agent/37-rebuild/codex-dev', 3)).toBe('agent/37-rebuild-2/codex-dev')
+  })
+
+  test('requests a replacement PR when the only matching lineage is closed', () => {
+    const decision = choosePrLifecycleAction({
+      issueNumber: 37,
+      headBranch: 'agent/37/codex-dev',
+      baseBranch: 'master',
+      baseSha: '11fc78e',
+    }, [
+      {
+        number: 45,
+        prUrl: 'https://example.test/pr/45',
+        prState: 'closed',
+        headRefName: 'agent/37/codex-dev',
+        baseRefName: 'master',
+        body: renderPrLineageMetadataComment(buildPrLineageMetadata({
+          issueNumber: 37,
+          headBranch: 'agent/37/codex-dev',
+          baseBranch: 'master',
+          baseSha: '0176283',
+          attempt: 1,
+        })),
+      },
+    ])
+
+    expect(decision).toEqual({
+      kind: 'replacement-needed',
+      supersedesPrNumber: 45,
+      supersedesPrState: 'closed',
+      replacementBranch: 'agent/37-rebuild/codex-dev',
+      replacementAttempt: 2,
+      reason: 'terminal-closed',
+    })
+  })
+
+  test('reuses the matching open lineage when metadata fingerprint matches', () => {
+    const metadata = buildPrLineageMetadata({
+      issueNumber: 37,
+      headBranch: 'agent/37-rebuild/codex-dev',
+      baseBranch: 'master',
+      baseSha: '11fc78e',
+      attempt: 2,
+    })
+    const decision = choosePrLifecycleAction({
+      issueNumber: 37,
+      headBranch: 'agent/37-rebuild/codex-dev',
+      baseBranch: 'master',
+      baseSha: '11fc78e',
+    }, [
+      {
+        number: 91,
+        prUrl: 'https://example.test/pr/91',
+        prState: 'open',
+        headRefName: 'agent/37-rebuild/codex-dev',
+        baseRefName: 'master',
+        body: renderPrLineageMetadataComment(metadata),
+      },
+    ])
+
+    expect(decision).toEqual({
+      kind: 'reuse-open-lineage',
+      prNumber: 91,
+      prUrl: 'https://example.test/pr/91',
+      branch: 'agent/37-rebuild/codex-dev',
+      attempt: 2,
+    })
+  })
+
+  test('marks an open mismatched lineage for replacement', () => {
+    const decision = choosePrLifecycleAction({
+      issueNumber: 37,
+      headBranch: 'agent/37-rebuild/codex-dev',
+      baseBranch: 'master',
+      baseSha: '11fc78e',
+    }, [
+      {
+        number: 91,
+        prUrl: 'https://example.test/pr/91',
+        prState: 'open',
+        headRefName: 'agent/37-rebuild/codex-dev',
+        baseRefName: 'agent/36/codex-dev',
+        body: renderPrLineageMetadataComment(buildPrLineageMetadata({
+          issueNumber: 37,
+          headBranch: 'agent/37-rebuild/codex-dev',
+          baseBranch: 'master',
+          baseSha: '0176283',
+          attempt: 2,
+        })),
+      },
+    ])
+
+    expect(decision).toEqual({
+      kind: 'replacement-needed',
+      supersedesPrNumber: 91,
+      supersedesPrState: 'open',
+      replacementBranch: 'agent/37-rebuild-2/codex-dev',
+      replacementAttempt: 3,
+      reason: 'lineage-mismatch',
+    })
+  })
+
+  test('renders a structured supersede comment for audit trails', () => {
+    const comment = buildSupersededPrComment({
+      previousPrNumber: 45,
+      replacementPrNumber: 91,
+      replacementBranch: 'agent/37-rebuild/codex-dev',
+      replacementAttempt: 2,
+      reason: 'terminal-closed',
+    })
+
+    expect(comment).toContain('<!-- agent-loop:pr-superseded')
+    expect(comment).toContain('This PR has been superseded by #91.')
+    expect(comment).toContain('Replacement branch: `agent/37-rebuild/codex-dev`')
   })
 })

--- a/apps/agent-daemon/src/pr-lineage.ts
+++ b/apps/agent-daemon/src/pr-lineage.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import type { PrLineageMetadata } from '@agent/shared'
+import type { BranchPullRequestRecord, PrLineageMetadata } from '@agent/shared'
 
 const PR_LINEAGE_COMMENT_PREFIX = '<!-- agent-loop:pr-lineage '
 
@@ -27,6 +27,42 @@ export class PrLineageMetadataParseError extends Error {
   }
 }
 
+export interface ChoosePrLifecycleActionInput {
+  issueNumber: number
+  headBranch: string
+  baseBranch: string
+  baseSha: string
+}
+
+export type PrLifecycleAction =
+  | {
+      kind: 'create-new-pr'
+      branch: string
+      attempt: number
+    }
+  | {
+      kind: 'reuse-open-lineage'
+      prNumber: number
+      prUrl: string
+      branch: string
+      attempt: number
+    }
+  | {
+      kind: 'replacement-needed'
+      supersedesPrNumber: number
+      supersedesPrState: 'open' | 'closed'
+      replacementBranch: string
+      replacementAttempt: number
+      reason: 'lineage-mismatch' | 'terminal-closed'
+    }
+  | {
+      kind: 'terminal-merged'
+      prNumber: number
+      prUrl: string
+      branch: string
+      attempt: number
+    }
+
 export function buildPrLineageMetadata(input: BuildPrLineageMetadataInput): PrLineageMetadata {
   const fingerprintInput = JSON.stringify({
     issue: input.issueNumber,
@@ -45,6 +81,33 @@ export function buildPrLineageMetadata(input: BuildPrLineageMetadataInput): PrLi
     attempt: input.attempt,
     fingerprint: createHash('sha256').update(fingerprintInput).digest('hex'),
   }
+}
+
+export function inferPrAttemptFromBranch(branch: string): number {
+  const rebuildMatch = branch.match(/^agent\/\d+-rebuild(?:-(\d+))?\/.+$/)
+  if (!rebuildMatch) return 1
+  const rebuildIndex = Number.parseInt(rebuildMatch[1] ?? '1', 10)
+  return Number.isFinite(rebuildIndex) ? rebuildIndex + 1 : 2
+}
+
+export function buildReplacementBranchName(
+  branch: string,
+  attempt: number,
+): string {
+  const match = branch.match(/^agent\/(\d+)(?:-rebuild(?:-\d+)?)?\/(.+)$/)
+  if (!match?.[1] || !match[2]) {
+    return `${branch}-rebuild-${attempt}`
+  }
+
+  if (attempt <= 1) {
+    return `agent/${match[1]}/${match[2]}`
+  }
+
+  if (attempt === 2) {
+    return `agent/${match[1]}-rebuild/${match[2]}`
+  }
+
+  return `agent/${match[1]}-rebuild-${attempt - 1}/${match[2]}`
 }
 
 export function renderPrLineageMetadataComment(metadata: PrLineageMetadata): string {
@@ -115,4 +178,112 @@ export function parsePrLineageMetadata(body: string): PrLineageMetadata {
   }
 
   return expected
+}
+
+function tryParsePrLineageMetadata(body: string | null): PrLineageMetadata | null {
+  if (!body) return null
+
+  try {
+    return parsePrLineageMetadata(body)
+  } catch {
+    return null
+  }
+}
+
+export function choosePrLifecycleAction(
+  input: ChoosePrLifecycleActionInput,
+  pullRequests: BranchPullRequestRecord[],
+): PrLifecycleAction {
+  const expectedAttempt = inferPrAttemptFromBranch(input.headBranch)
+  const expectedMetadata = buildPrLineageMetadata({
+    issueNumber: input.issueNumber,
+    headBranch: input.headBranch,
+    baseBranch: input.baseBranch,
+    baseSha: input.baseSha,
+    attempt: expectedAttempt,
+  })
+  const parsedPullRequests = pullRequests
+    .map((pullRequest) => ({
+      ...pullRequest,
+      metadata: tryParsePrLineageMetadata(pullRequest.body),
+    }))
+    .sort((left, right) => right.number - left.number)
+
+  if (parsedPullRequests.length === 0) {
+    return {
+      kind: 'create-new-pr',
+      branch: input.headBranch,
+      attempt: expectedAttempt,
+    }
+  }
+
+  const exactOpenLineage = parsedPullRequests.find((pullRequest) => (
+    pullRequest.prState === 'open'
+    && pullRequest.headRefName === input.headBranch
+    && pullRequest.metadata?.fingerprint === expectedMetadata.fingerprint
+  )) ?? null
+  if (exactOpenLineage) {
+    return {
+      kind: 'reuse-open-lineage',
+      prNumber: exactOpenLineage.number,
+      prUrl: exactOpenLineage.prUrl ?? '',
+      branch: input.headBranch,
+      attempt: exactOpenLineage.metadata?.attempt ?? expectedAttempt,
+    }
+  }
+
+  const maxAttempt = parsedPullRequests.reduce((highest, pullRequest) => {
+    return Math.max(highest, pullRequest.metadata?.attempt ?? 1)
+  }, expectedAttempt)
+
+  const openMismatch = parsedPullRequests.find((pullRequest) => pullRequest.prState === 'open') ?? null
+  if (openMismatch) {
+    return {
+      kind: 'replacement-needed',
+      supersedesPrNumber: openMismatch.number,
+      supersedesPrState: 'open',
+      replacementBranch: buildReplacementBranchName(input.headBranch, maxAttempt + 1),
+      replacementAttempt: maxAttempt + 1,
+      reason: 'lineage-mismatch',
+    }
+  }
+
+  const latestTerminal = parsedPullRequests[0] ?? null
+  if (latestTerminal?.prState === 'closed') {
+    return {
+      kind: 'replacement-needed',
+      supersedesPrNumber: latestTerminal.number,
+      supersedesPrState: 'closed',
+      replacementBranch: buildReplacementBranchName(input.headBranch, maxAttempt + 1),
+      replacementAttempt: maxAttempt + 1,
+      reason: 'terminal-closed',
+    }
+  }
+
+  return {
+    kind: 'terminal-merged',
+    prNumber: latestTerminal?.number ?? 0,
+    prUrl: latestTerminal?.prUrl ?? '',
+    branch: input.headBranch,
+    attempt: maxAttempt,
+  }
+}
+
+export function buildSupersededPrComment(input: {
+  previousPrNumber: number
+  replacementPrNumber: number
+  replacementBranch: string
+  replacementAttempt: number
+  reason: 'lineage-mismatch' | 'terminal-closed'
+}): string {
+  return [
+    `<!-- agent-loop:pr-superseded {"previousPr":${input.previousPrNumber},"replacementPr":${input.replacementPrNumber},"replacementBranch":"${input.replacementBranch}","replacementAttempt":${input.replacementAttempt},"reason":"${input.reason}"} -->`,
+    '## PR Superseded',
+    '',
+    `This PR has been superseded by #${input.replacementPrNumber}.`,
+    '',
+    `- Replacement branch: \`${input.replacementBranch}\``,
+    `- Replacement attempt: ${input.replacementAttempt}`,
+    `- Reason: ${input.reason}`,
+  ].join('\n')
 }

--- a/apps/agent-daemon/src/pr-lineage.ts
+++ b/apps/agent-daemon/src/pr-lineage.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'node:crypto'
+import type { PrLineageMetadata } from '@agent/shared'
+
+const PR_LINEAGE_COMMENT_PREFIX = '<!-- agent-loop:pr-lineage '
+
+export interface BuildPrLineageMetadataInput {
+  issueNumber: number
+  headBranch: string
+  baseBranch: string
+  baseSha: string
+  attempt: number
+}
+
+export type PrLineageMetadataParseErrorCode =
+  | 'metadata_comment_missing'
+  | 'invalid_json'
+  | 'missing_required_fields'
+  | 'fingerprint_mismatch'
+
+export class PrLineageMetadataParseError extends Error {
+  readonly code: PrLineageMetadataParseErrorCode
+
+  constructor(code: PrLineageMetadataParseErrorCode, message: string) {
+    super(message)
+    this.name = 'PrLineageMetadataParseError'
+    this.code = code
+  }
+}
+
+export function buildPrLineageMetadata(input: BuildPrLineageMetadataInput): PrLineageMetadata {
+  const fingerprintInput = JSON.stringify({
+    issue: input.issueNumber,
+    headBranch: input.headBranch,
+    baseBranch: input.baseBranch,
+    baseSha: input.baseSha,
+    attempt: input.attempt,
+  })
+
+  return {
+    version: 1,
+    issue: input.issueNumber,
+    headBranch: input.headBranch,
+    baseBranch: input.baseBranch,
+    baseSha: input.baseSha,
+    attempt: input.attempt,
+    fingerprint: createHash('sha256').update(fingerprintInput).digest('hex'),
+  }
+}
+
+export function renderPrLineageMetadataComment(metadata: PrLineageMetadata): string {
+  return `${PR_LINEAGE_COMMENT_PREFIX}${JSON.stringify(metadata)} -->`
+}
+
+export function parsePrLineageMetadata(body: string): PrLineageMetadata {
+  const match = body.match(/<!-- agent-loop:pr-lineage (\{.*?\}) -->/s)
+  if (!match?.[1]) {
+    throw new PrLineageMetadataParseError(
+      'metadata_comment_missing',
+      'PR lineage metadata comment is missing',
+    )
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(match[1])
+  } catch {
+    throw new PrLineageMetadataParseError(
+      'invalid_json',
+      'PR lineage metadata comment contains invalid JSON',
+    )
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new PrLineageMetadataParseError(
+      'missing_required_fields',
+      'PR lineage metadata must be a JSON object',
+    )
+  }
+
+  const candidate = parsed as Partial<PrLineageMetadata>
+  if (
+    candidate.version !== 1
+    || typeof candidate.issue !== 'number'
+    || typeof candidate.headBranch !== 'string'
+    || candidate.headBranch.length === 0
+    || typeof candidate.baseBranch !== 'string'
+    || candidate.baseBranch.length === 0
+    || typeof candidate.baseSha !== 'string'
+    || candidate.baseSha.length === 0
+    || typeof candidate.attempt !== 'number'
+    || !Number.isInteger(candidate.attempt)
+    || candidate.attempt < 1
+    || typeof candidate.fingerprint !== 'string'
+    || candidate.fingerprint.length === 0
+  ) {
+    throw new PrLineageMetadataParseError(
+      'missing_required_fields',
+      'PR lineage metadata is missing one or more required fields',
+    )
+  }
+
+  const expected = buildPrLineageMetadata({
+    issueNumber: candidate.issue,
+    headBranch: candidate.headBranch,
+    baseBranch: candidate.baseBranch,
+    baseSha: candidate.baseSha,
+    attempt: candidate.attempt,
+  })
+
+  if (candidate.fingerprint !== expected.fingerprint) {
+    throw new PrLineageMetadataParseError(
+      'fingerprint_mismatch',
+      'PR lineage metadata fingerprint does not match its required fields',
+    )
+  }
+
+  return expected
+}

--- a/apps/agent-daemon/src/pr-reporter.test.ts
+++ b/apps/agent-daemon/src/pr-reporter.test.ts
@@ -232,6 +232,7 @@ describe('createOrFindPr', () => {
         pushBranch: async () => {
           pushCalls += 1
         },
+        runPrLineagePreflight: async () => {},
         prepareReplacementBranch: async (_worktreePath, branch) => {
           preparedBranch = branch
         },
@@ -296,6 +297,7 @@ describe('createOrFindPr', () => {
         pushBranch: async () => {
           pushCalls += 1
         },
+        runPrLineagePreflight: async () => {},
         createPr: async () => {
           createCalls += 1
           return { number: 99, url: 'https://example.test/pr/99' }
@@ -335,6 +337,7 @@ describe('createOrFindPr', () => {
       {
         listBranchPullRequests: async () => [],
         pushBranch: async () => {},
+        runPrLineagePreflight: async () => {},
         resolvePrLineageContext: async () => ({
           baseBranch: 'master',
           baseSha: '11fc78e',
@@ -410,6 +413,7 @@ describe('createOrFindPr', () => {
           baseBranch: 'master',
           baseSha: '11fc78e',
         }),
+        runPrLineagePreflight: async () => {},
         prepareReplacementBranch: async () => {},
         pushBranch: async () => {},
         commentOnPr: async () => {},
@@ -430,5 +434,39 @@ describe('createOrFindPr', () => {
       'agent/37/codex-dev',
       'agent/37-rebuild/codex-dev',
     ])
+  })
+
+  test('fails fast when PR creation preflight reports polluted lineage state', async () => {
+    let pushCalls = 0
+    let createCalls = 0
+
+    await expect(createOrFindPr(
+      '/tmp/agent-loop-preflight-block',
+      'agent/37/codex-dev',
+      37,
+      'block polluted lineage push',
+      TEST_CONFIG,
+      console,
+      {
+        listBranchPullRequests: async () => [],
+        resolvePrLineageContext: async () => ({
+          baseBranch: 'master',
+          baseSha: '11fc78e',
+        }),
+        runPrLineagePreflight: async () => {
+          throw new Error('PR lineage preflight failed before PR creation: base sha mismatch: expected 11fc78e but found 0176283')
+        },
+        pushBranch: async () => {
+          pushCalls += 1
+        },
+        createPr: async () => {
+          createCalls += 1
+          return { number: 99, url: 'https://example.test/pr/99' }
+        },
+      },
+    )).rejects.toThrow('PR lineage preflight failed before PR creation')
+
+    expect(pushCalls).toBe(0)
+    expect(createCalls).toBe(0)
   })
 })

--- a/apps/agent-daemon/src/pr-reporter.test.ts
+++ b/apps/agent-daemon/src/pr-reporter.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { AgentConfig, PrLineageMetadata } from '@agent/shared'
 import { createOrFindPr, hasReusableOpenPr, isRetryableManagedBranchPushFailure, pushBranch } from './pr-reporter'
+import { buildPrLineageMetadata, renderPrLineageMetadataComment } from './pr-lineage'
 
 const TEST_CONFIG: AgentConfig = {
   machineId: 'codex-dev',
@@ -196,9 +197,11 @@ describe('createOrFindPr', () => {
     expect(hasReusableOpenPr({ prNumber: null, prState: null })).toBe(false)
   })
 
-  test('returns a terminal replacement-needed result for closed PR matches', async () => {
+  test('creates a replacement PR when the latest matching lineage is closed', async () => {
     let pushCalls = 0
     let createCalls = 0
+    let preparedBranch = ''
+    const supersedeComments: Array<{ prNumber: number; body: string }> = []
 
     const result = await createOrFindPr(
       '/tmp/agent-loop-terminal-pr',
@@ -208,35 +211,67 @@ describe('createOrFindPr', () => {
       TEST_CONFIG,
       console,
       {
-        checkPrExists: async () => ({
-          prNumber: 45,
-          prUrl: 'https://example.test/pr/45',
-          prState: 'closed',
+        listBranchPullRequests: async (requestedBranch) => {
+          if (requestedBranch === 'agent/37/codex-dev') {
+            return [{
+              number: 45,
+              prUrl: 'https://example.test/pr/45',
+              prState: 'closed',
+              headRefName: 'agent/37/codex-dev',
+              baseRefName: 'master',
+              body: '<!-- agent-loop:pr-lineage {"version":1,"issue":37,"headBranch":"agent/37/codex-dev","baseBranch":"master","baseSha":"0176283","attempt":1,"fingerprint":"old"} -->',
+            }]
+          }
+
+          return []
+        },
+        resolvePrLineageContext: async () => ({
+          baseBranch: 'master',
+          baseSha: '11fc78e',
         }),
         pushBranch: async () => {
           pushCalls += 1
         },
-        createPr: async () => {
+        prepareReplacementBranch: async (_worktreePath, branch) => {
+          preparedBranch = branch
+        },
+        commentOnPr: async (prNumber, body) => {
+          supersedeComments.push({ prNumber, body })
+        },
+        closePullRequest: async () => {},
+        createPr: async (replacementBranch, _issueNumber, _issueTitle, body) => {
           createCalls += 1
+          expect(replacementBranch).toBe('agent/37-rebuild/codex-dev')
+          expect(body).toContain('"attempt":2')
           return { number: 99, url: 'https://example.test/pr/99' }
         },
       },
     )
 
     expect(result).toEqual({
-      kind: 'terminal',
-      prNumber: 45,
-      prUrl: 'https://example.test/pr/45',
-      prState: 'closed',
-      replacementNeeded: true,
+      kind: 'created',
+      prNumber: 99,
+      prUrl: 'https://example.test/pr/99',
+      branch: 'agent/37-rebuild/codex-dev',
     })
-    expect(pushCalls).toBe(0)
-    expect(createCalls).toBe(0)
+    expect(preparedBranch).toBe('agent/37-rebuild/codex-dev')
+    expect(pushCalls).toBe(1)
+    expect(createCalls).toBe(1)
+    expect(supersedeComments).toHaveLength(1)
+    expect(supersedeComments[0]?.prNumber).toBe(45)
+    expect(supersedeComments[0]?.body).toContain('This PR has been superseded by #99.')
   })
 
   test('keeps the open PR idempotent path intact', async () => {
     let pushCalls = 0
     let createCalls = 0
+    const lineageMetadata = buildPrLineageMetadata({
+      issueNumber: 37,
+      headBranch: 'agent/37/codex-dev',
+      baseBranch: 'master',
+      baseSha: '11fc78e',
+      attempt: 1,
+    })
 
     const result = await createOrFindPr(
       '/tmp/agent-loop-open-pr',
@@ -246,10 +281,17 @@ describe('createOrFindPr', () => {
       TEST_CONFIG,
       console,
       {
-        checkPrExists: async () => ({
-          prNumber: 78,
+        listBranchPullRequests: async () => [{
+          number: 78,
           prUrl: 'https://example.test/pr/78',
           prState: 'open',
+          headRefName: 'agent/37/codex-dev',
+          baseRefName: 'master',
+          body: renderPrLineageMetadataComment(lineageMetadata),
+        }],
+        resolvePrLineageContext: async () => ({
+          baseBranch: 'master',
+          baseSha: '11fc78e',
         }),
         pushBranch: async () => {
           pushCalls += 1
@@ -265,6 +307,7 @@ describe('createOrFindPr', () => {
       kind: 'reused',
       prNumber: 78,
       prUrl: 'https://example.test/pr/78',
+      branch: 'agent/37/codex-dev',
     })
     expect(pushCalls).toBe(1)
     expect(createCalls).toBe(0)
@@ -290,13 +333,12 @@ describe('createOrFindPr', () => {
       TEST_CONFIG,
       console,
       {
-        checkPrExists: async () => ({
-          prNumber: null,
-          prUrl: null,
-          prState: null,
-        }),
+        listBranchPullRequests: async () => [],
         pushBranch: async () => {},
-        resolvePrLineageMetadata: async () => lineageMetadata,
+        resolvePrLineageContext: async () => ({
+          baseBranch: 'master',
+          baseSha: '11fc78e',
+        }),
         createPr: async (_branch, _issueNumber, _issueTitle, body) => {
           capturedBody = body
           return { number: 91, url: 'https://example.test/pr/91' }
@@ -308,12 +350,85 @@ describe('createOrFindPr', () => {
       kind: 'created',
       prNumber: 91,
       prUrl: 'https://example.test/pr/91',
+      branch: 'agent/37/codex-dev',
     })
     expect(capturedBody).toContain('## Summary')
     expect(capturedBody).toContain('Fixes #37')
-    expect(capturedBody).toContain('<!-- agent-loop:pr-lineage {"version":1,"issue":37,"headBranch":"agent/37/codex-dev","baseBranch":"master","baseSha":"11fc78e","attempt":1,"fingerprint":"lineage-fingerprint"} -->')
+    expect(capturedBody).toContain(`<!-- agent-loop:pr-lineage ${JSON.stringify(buildPrLineageMetadata({
+      issueNumber: 37,
+      headBranch: 'agent/37/codex-dev',
+      baseBranch: 'master',
+      baseSha: '11fc78e',
+      attempt: 1,
+    }))} -->`)
     expect(capturedBody).toContain('## Metadata')
     expect(capturedBody).toContain('"generated_by": "agent-loop"')
     expect(capturedBody).toContain('## Test Plan')
+  })
+
+  test('reuses an existing open replacement lineage after switching branches', async () => {
+    const seenBranches: string[] = []
+    const replacementMetadata = buildPrLineageMetadata({
+      issueNumber: 37,
+      headBranch: 'agent/37-rebuild/codex-dev',
+      baseBranch: 'master',
+      baseSha: '11fc78e',
+      attempt: 2,
+    })
+
+    const result = await createOrFindPr(
+      '/tmp/agent-loop-replacement-reuse',
+      'agent/37/codex-dev',
+      37,
+      'reuse replacement lineage',
+      TEST_CONFIG,
+      console,
+      {
+        listBranchPullRequests: async (requestedBranch) => {
+          seenBranches.push(requestedBranch)
+          if (requestedBranch === 'agent/37/codex-dev') {
+            return [{
+              number: 45,
+              prUrl: 'https://example.test/pr/45',
+              prState: 'closed',
+              headRefName: 'agent/37/codex-dev',
+              baseRefName: 'master',
+              body: '<!-- agent-loop:pr-lineage {"version":1,"issue":37,"headBranch":"agent/37/codex-dev","baseBranch":"master","baseSha":"0176283","attempt":1,"fingerprint":"old"} -->',
+            }]
+          }
+
+          return [{
+            number: 91,
+            prUrl: 'https://example.test/pr/91',
+            prState: 'open',
+            headRefName: 'agent/37-rebuild/codex-dev',
+            baseRefName: 'master',
+            body: renderPrLineageMetadataComment(replacementMetadata),
+          }]
+        },
+        resolvePrLineageContext: async () => ({
+          baseBranch: 'master',
+          baseSha: '11fc78e',
+        }),
+        prepareReplacementBranch: async () => {},
+        pushBranch: async () => {},
+        commentOnPr: async () => {},
+        closePullRequest: async () => {},
+        createPr: async () => {
+          throw new Error('createPr should not run when replacement PR already exists')
+        },
+      },
+    )
+
+    expect(result).toEqual({
+      kind: 'reused',
+      prNumber: 91,
+      prUrl: 'https://example.test/pr/91',
+      branch: 'agent/37-rebuild/codex-dev',
+    })
+    expect(seenBranches).toEqual([
+      'agent/37/codex-dev',
+      'agent/37-rebuild/codex-dev',
+    ])
   })
 })

--- a/apps/agent-daemon/src/pr-reporter.test.ts
+++ b/apps/agent-daemon/src/pr-reporter.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import type { AgentConfig } from '@agent/shared'
+import type { AgentConfig, PrLineageMetadata } from '@agent/shared'
 import { createOrFindPr, hasReusableOpenPr, isRetryableManagedBranchPushFailure, pushBranch } from './pr-reporter'
 
 const TEST_CONFIG: AgentConfig = {
@@ -268,5 +268,52 @@ describe('createOrFindPr', () => {
     })
     expect(pushCalls).toBe(1)
     expect(createCalls).toBe(0)
+  })
+
+  test('writes deterministic lineage metadata into newly created PR bodies', async () => {
+    let capturedBody = ''
+    const lineageMetadata: PrLineageMetadata = {
+      version: 1,
+      issue: 37,
+      headBranch: 'agent/37/codex-dev',
+      baseBranch: 'master',
+      baseSha: '11fc78e',
+      attempt: 1,
+      fingerprint: 'lineage-fingerprint',
+    }
+
+    const result = await createOrFindPr(
+      '/tmp/agent-loop-create-pr',
+      'agent/37/codex-dev',
+      37,
+      'record lineage metadata',
+      TEST_CONFIG,
+      console,
+      {
+        checkPrExists: async () => ({
+          prNumber: null,
+          prUrl: null,
+          prState: null,
+        }),
+        pushBranch: async () => {},
+        resolvePrLineageMetadata: async () => lineageMetadata,
+        createPr: async (_branch, _issueNumber, _issueTitle, body) => {
+          capturedBody = body
+          return { number: 91, url: 'https://example.test/pr/91' }
+        },
+      },
+    )
+
+    expect(result).toEqual({
+      kind: 'created',
+      prNumber: 91,
+      prUrl: 'https://example.test/pr/91',
+    })
+    expect(capturedBody).toContain('## Summary')
+    expect(capturedBody).toContain('Fixes #37')
+    expect(capturedBody).toContain('<!-- agent-loop:pr-lineage {"version":1,"issue":37,"headBranch":"agent/37/codex-dev","baseBranch":"master","baseSha":"11fc78e","attempt":1,"fingerprint":"lineage-fingerprint"} -->')
+    expect(capturedBody).toContain('## Metadata')
+    expect(capturedBody).toContain('"generated_by": "agent-loop"')
+    expect(capturedBody).toContain('## Test Plan')
   })
 })

--- a/apps/agent-daemon/src/pr-reporter.test.ts
+++ b/apps/agent-daemon/src/pr-reporter.test.ts
@@ -2,7 +2,52 @@ import { describe, expect, test } from 'bun:test'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { isRetryableManagedBranchPushFailure, pushBranch } from './pr-reporter'
+import type { AgentConfig } from '@agent/shared'
+import { createOrFindPr, hasReusableOpenPr, isRetryableManagedBranchPushFailure, pushBranch } from './pr-reporter'
+
+const TEST_CONFIG: AgentConfig = {
+  machineId: 'codex-dev',
+  repo: 'JamesWuHK/agent-loop',
+  pat: 'test-token',
+  pollIntervalMs: 60_000,
+  idlePollIntervalMs: 300_000,
+  concurrency: 1,
+  requestedConcurrency: 1,
+  concurrencyPolicy: {
+    requested: 1,
+    effective: 1,
+    repoCap: null,
+    profileCap: null,
+    projectCap: null,
+  },
+  scheduling: {
+    concurrencyByRepo: {},
+    concurrencyByProfile: {},
+  },
+  recovery: {
+    heartbeatIntervalMs: 30_000,
+    leaseTtlMs: 60_000,
+    workerIdleTimeoutMs: 300_000,
+    leaseAdoptionBackoffMs: 5_000,
+    leaseNoProgressTimeoutMs: 360_000,
+  },
+  worktreesBase: '/tmp/worktrees',
+  project: {
+    profile: 'desktop-vite',
+  },
+  agent: {
+    primary: 'codex',
+    fallback: 'claude',
+    claudePath: 'claude',
+    codexPath: 'codex',
+    timeoutMs: 60_000,
+  },
+  git: {
+    defaultBranch: 'master',
+    authorName: 'agent-loop',
+    authorEmail: 'agent-loop@local',
+  },
+}
 
 async function runGit(
   worktreePath: string,
@@ -140,5 +185,88 @@ describe('pr reporter push recovery', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true })
     }
+  })
+})
+
+describe('createOrFindPr', () => {
+  test('treats only open PR checks as reusable', () => {
+    expect(hasReusableOpenPr({ prNumber: 81, prState: 'open' })).toBe(true)
+    expect(hasReusableOpenPr({ prNumber: 81, prState: 'closed' })).toBe(false)
+    expect(hasReusableOpenPr({ prNumber: 81, prState: 'merged' })).toBe(false)
+    expect(hasReusableOpenPr({ prNumber: null, prState: null })).toBe(false)
+  })
+
+  test('returns a terminal replacement-needed result for closed PR matches', async () => {
+    let pushCalls = 0
+    let createCalls = 0
+
+    const result = await createOrFindPr(
+      '/tmp/agent-loop-terminal-pr',
+      'agent/37/codex-dev',
+      37,
+      'repair terminal PR reuse',
+      TEST_CONFIG,
+      console,
+      {
+        checkPrExists: async () => ({
+          prNumber: 45,
+          prUrl: 'https://example.test/pr/45',
+          prState: 'closed',
+        }),
+        pushBranch: async () => {
+          pushCalls += 1
+        },
+        createPr: async () => {
+          createCalls += 1
+          return { number: 99, url: 'https://example.test/pr/99' }
+        },
+      },
+    )
+
+    expect(result).toEqual({
+      kind: 'terminal',
+      prNumber: 45,
+      prUrl: 'https://example.test/pr/45',
+      prState: 'closed',
+      replacementNeeded: true,
+    })
+    expect(pushCalls).toBe(0)
+    expect(createCalls).toBe(0)
+  })
+
+  test('keeps the open PR idempotent path intact', async () => {
+    let pushCalls = 0
+    let createCalls = 0
+
+    const result = await createOrFindPr(
+      '/tmp/agent-loop-open-pr',
+      'agent/37/codex-dev',
+      37,
+      'repair terminal PR reuse',
+      TEST_CONFIG,
+      console,
+      {
+        checkPrExists: async () => ({
+          prNumber: 78,
+          prUrl: 'https://example.test/pr/78',
+          prState: 'open',
+        }),
+        pushBranch: async () => {
+          pushCalls += 1
+        },
+        createPr: async () => {
+          createCalls += 1
+          return { number: 99, url: 'https://example.test/pr/99' }
+        },
+      },
+    )
+
+    expect(result).toEqual({
+      kind: 'reused',
+      prNumber: 78,
+      prUrl: 'https://example.test/pr/78',
+    })
+    expect(pushCalls).toBe(1)
+    expect(createCalls).toBe(0)
   })
 })

--- a/apps/agent-daemon/src/pr-reporter.ts
+++ b/apps/agent-daemon/src/pr-reporter.ts
@@ -1,11 +1,17 @@
 import type { AgentConfig, BranchPullRequestRecord, PrCheckResult, PrLineageMetadata } from '@agent/shared'
 import { checkPrExists, closePullRequest, commentOnPr, createPr, listBranchPullRequests } from '@agent/shared'
+import { parseIssueContract } from '@agent/shared'
 import {
   buildPrLineageMetadata,
   buildSupersededPrComment,
   choosePrLifecycleAction,
   renderPrLineageMetadataComment,
 } from './pr-lineage'
+import {
+  PrLineagePreflightError,
+  collectPrLineagePreflightActualState,
+  evaluatePrLineagePreflight,
+} from './pr-lineage-preflight'
 
 interface GitCommandResult {
   exitCode: number
@@ -41,6 +47,14 @@ interface CreateOrFindPrDependencies {
   commentOnPr?: typeof commentOnPr
   closePullRequest?: typeof closePullRequest
   prepareReplacementBranch?: typeof prepareReplacementBranch
+  runPrLineagePreflight?: (input: {
+    worktreePath: string
+    branch: string
+    issueNumber: number
+    issueBody?: string
+    lineageContext: ResolvedPrLineageContext
+    strictBaseSha: boolean
+  }) => Promise<void>
 }
 
 export type CreateOrFindPrResult =
@@ -305,6 +319,35 @@ async function markSupersededPullRequest(
   }
 }
 
+async function runCreateOrFindPrLineagePreflight(input: {
+  worktreePath: string
+  branch: string
+  issueNumber: number
+  issueBody?: string
+  lineageContext: ResolvedPrLineageContext
+  strictBaseSha: boolean
+}): Promise<void> {
+  const actual = await collectPrLineagePreflightActualState({
+    worktreePath: input.worktreePath,
+    expectedBaseBranch: input.lineageContext.baseBranch,
+  })
+  const contract = parseIssueContract(input.issueBody ?? '')
+  const result = evaluatePrLineagePreflight({
+    expected: {
+      issueNumber: input.issueNumber,
+      headBranch: input.branch,
+      baseBranch: input.lineageContext.baseBranch,
+      baseSha: input.strictBaseSha ? input.lineageContext.baseSha : actual.baseSha,
+      allowedChangedFiles: contract.allowedFiles,
+    },
+    actual,
+  })
+
+  if (!result.ok) {
+    throw new PrLineagePreflightError('PR creation', result)
+  }
+}
+
 /**
  * Create a PR for the given branch (idempotent).
  * Checks if PR already exists before creating.
@@ -317,12 +360,14 @@ export async function createOrFindPr(
   config: AgentConfig,
   logger = console,
   dependencies: CreateOrFindPrDependencies = {},
+  issueBody?: string,
 ): Promise<CreateOrFindPrResult> {
   const createPullRequest = dependencies.createPr ?? createPr
   const pushManagedBranch = dependencies.pushBranch ?? pushBranch
   const resolveLineageContext = dependencies.resolvePrLineageContext ?? resolvePrLineageContext
   const listBranchPrs = dependencies.listBranchPullRequests ?? listBranchPullRequests
   const switchToReplacementBranch = dependencies.prepareReplacementBranch ?? prepareReplacementBranch
+  const runLineagePreflight = dependencies.runPrLineagePreflight ?? runCreateOrFindPrLineagePreflight
 
   const lineageContext = await resolveLineageContext(worktreePath, config)
   let currentBranch = branch
@@ -354,6 +399,14 @@ export async function createOrFindPr(
     }
 
     if (lifecycle.kind === 'reuse-open-lineage') {
+      await runLineagePreflight({
+        worktreePath,
+        branch: currentBranch,
+        issueNumber,
+        issueBody,
+        lineageContext,
+        strictBaseSha: true,
+      })
       await pushManagedBranch(worktreePath, currentBranch, logger)
       for (const target of supersedeTargets) {
         await markSupersededPullRequest(target.pullRequest, {
@@ -367,6 +420,14 @@ export async function createOrFindPr(
     }
 
     if (lifecycle.kind === 'create-new-pr') {
+      await runLineagePreflight({
+        worktreePath,
+        branch: currentBranch,
+        issueNumber,
+        issueBody,
+        lineageContext,
+        strictBaseSha: supersedeTargets.length > 0 || candidates.length > 0,
+      })
       await pushManagedBranch(worktreePath, currentBranch, logger)
       const lineageMetadata = await resolvePrLineageMetadata(
         currentBranch,

--- a/apps/agent-daemon/src/pr-reporter.ts
+++ b/apps/agent-daemon/src/pr-reporter.ts
@@ -1,5 +1,6 @@
-import type { AgentConfig, PrCheckResult } from '@agent/shared'
+import type { AgentConfig, PrCheckResult, PrLineageMetadata } from '@agent/shared'
 import { checkPrExists, createPr } from '@agent/shared'
+import { buildPrLineageMetadata, renderPrLineageMetadataComment } from './pr-lineage'
 
 interface GitCommandResult {
   exitCode: number
@@ -31,6 +32,7 @@ interface CreateOrFindPrDependencies {
   checkPrExists?: typeof checkPrExists
   createPr?: typeof createPr
   pushBranch?: typeof pushBranch
+  resolvePrLineageMetadata?: typeof resolvePrLineageMetadata
 }
 
 export type CreateOrFindPrResult =
@@ -180,6 +182,8 @@ const PR_BODY_TEMPLATE = (issueNumber: number, machineId: string) => `
 
 Fixes #${issueNumber}
 
+${renderPrLineageMetadataCommentPlaceholder}
+
 ## Metadata
 
 \`\`\`json
@@ -195,6 +199,43 @@ Fixes #${issueNumber}
 - [ ] tested locally
 - [ ] CI passes
 `.trim()
+
+const renderPrLineageMetadataCommentPlaceholder = '__AGENT_LOOP_PR_LINEAGE_METADATA__'
+
+function buildPrBody(
+  issueNumber: number,
+  machineId: string,
+  lineageMetadata: PrLineageMetadata,
+): string {
+  return PR_BODY_TEMPLATE(issueNumber, machineId)
+    .replace(renderPrLineageMetadataCommentPlaceholder, renderPrLineageMetadataComment(lineageMetadata))
+}
+
+async function resolvePrLineageMetadata(
+  worktreePath: string,
+  branch: string,
+  issueNumber: number,
+  config: AgentConfig,
+  gitRunner: PushBranchDependencies['runGit'] = runGit,
+): Promise<PrLineageMetadata> {
+  const fetchBase = await gitRunner(worktreePath, ['fetch', 'origin', config.git.defaultBranch])
+  if (fetchBase.exitCode !== 0) {
+    throw new Error(fetchBase.stderr || fetchBase.stdout || `Failed to fetch origin/${config.git.defaultBranch}`)
+  }
+
+  const baseSha = await gitRunner(worktreePath, ['rev-parse', `origin/${config.git.defaultBranch}`])
+  if (baseSha.exitCode !== 0) {
+    throw new Error(baseSha.stderr || baseSha.stdout || `Failed to resolve origin/${config.git.defaultBranch}`)
+  }
+
+  return buildPrLineageMetadata({
+    issueNumber,
+    headBranch: branch,
+    baseBranch: config.git.defaultBranch,
+    baseSha: baseSha.stdout.trim(),
+    attempt: 1,
+  })
+}
 
 /**
  * Create a PR for the given branch (idempotent).
@@ -212,6 +253,7 @@ export async function createOrFindPr(
   const checkExistingPr = dependencies.checkPrExists ?? checkPrExists
   const createPullRequest = dependencies.createPr ?? createPr
   const pushManagedBranch = dependencies.pushBranch ?? pushBranch
+  const resolveMetadata = dependencies.resolvePrLineageMetadata ?? resolvePrLineageMetadata
 
   // Check idempotency: PR might already exist
   const existing = await checkExistingPr(branch, config)
@@ -250,7 +292,8 @@ export async function createOrFindPr(
   // Push branch first if not pushed yet
   await pushManagedBranch(worktreePath, branch, logger)
 
-  const body = PR_BODY_TEMPLATE(issueNumber, config.machineId)
+  const lineageMetadata = await resolveMetadata(worktreePath, branch, issueNumber, config)
+  const body = buildPrBody(issueNumber, config.machineId, lineageMetadata)
   const pr = await createPullRequest(branch, issueNumber, issueTitle, body, config)
 
   logger.log(`[pr] created PR #${pr.number}: ${pr.url}`)

--- a/apps/agent-daemon/src/pr-reporter.ts
+++ b/apps/agent-daemon/src/pr-reporter.ts
@@ -1,6 +1,11 @@
-import type { AgentConfig, PrCheckResult, PrLineageMetadata } from '@agent/shared'
-import { checkPrExists, createPr } from '@agent/shared'
-import { buildPrLineageMetadata, renderPrLineageMetadataComment } from './pr-lineage'
+import type { AgentConfig, BranchPullRequestRecord, PrCheckResult, PrLineageMetadata } from '@agent/shared'
+import { checkPrExists, closePullRequest, commentOnPr, createPr, listBranchPullRequests } from '@agent/shared'
+import {
+  buildPrLineageMetadata,
+  buildSupersededPrComment,
+  choosePrLifecycleAction,
+  renderPrLineageMetadataComment,
+} from './pr-lineage'
 
 interface GitCommandResult {
   exitCode: number
@@ -29,10 +34,13 @@ interface ManagedBranchPushPlan {
 }
 
 interface CreateOrFindPrDependencies {
-  checkPrExists?: typeof checkPrExists
   createPr?: typeof createPr
   pushBranch?: typeof pushBranch
-  resolvePrLineageMetadata?: typeof resolvePrLineageMetadata
+  resolvePrLineageContext?: typeof resolvePrLineageContext
+  listBranchPullRequests?: typeof listBranchPullRequests
+  commentOnPr?: typeof commentOnPr
+  closePullRequest?: typeof closePullRequest
+  prepareReplacementBranch?: typeof prepareReplacementBranch
 }
 
 export type CreateOrFindPrResult =
@@ -40,6 +48,7 @@ export type CreateOrFindPrResult =
       kind: 'reused' | 'created'
       prNumber: number
       prUrl: string
+      branch: string
     }
   | {
       kind: 'terminal'
@@ -47,6 +56,7 @@ export type CreateOrFindPrResult =
       prUrl: string
       prState: 'closed' | 'merged'
       replacementNeeded: true
+      branch: string
     }
 
 export function hasReusableOpenPr(
@@ -212,12 +222,30 @@ function buildPrBody(
 }
 
 async function resolvePrLineageMetadata(
-  worktreePath: string,
   branch: string,
   issueNumber: number,
+  context: ResolvedPrLineageContext,
+  attempt: number,
+): Promise<PrLineageMetadata> {
+  return buildPrLineageMetadata({
+    issueNumber,
+    headBranch: branch,
+    baseBranch: context.baseBranch,
+    baseSha: context.baseSha,
+    attempt,
+  })
+}
+
+interface ResolvedPrLineageContext {
+  baseBranch: string
+  baseSha: string
+}
+
+async function resolvePrLineageContext(
+  worktreePath: string,
   config: AgentConfig,
   gitRunner: PushBranchDependencies['runGit'] = runGit,
-): Promise<PrLineageMetadata> {
+): Promise<ResolvedPrLineageContext> {
   const fetchBase = await gitRunner(worktreePath, ['fetch', 'origin', config.git.defaultBranch])
   if (fetchBase.exitCode !== 0) {
     throw new Error(fetchBase.stderr || fetchBase.stdout || `Failed to fetch origin/${config.git.defaultBranch}`)
@@ -228,13 +256,53 @@ async function resolvePrLineageMetadata(
     throw new Error(baseSha.stderr || baseSha.stdout || `Failed to resolve origin/${config.git.defaultBranch}`)
   }
 
-  return buildPrLineageMetadata({
-    issueNumber,
-    headBranch: branch,
+  return {
     baseBranch: config.git.defaultBranch,
     baseSha: baseSha.stdout.trim(),
-    attempt: 1,
-  })
+  }
+}
+
+async function prepareReplacementBranch(
+  worktreePath: string,
+  replacementBranch: string,
+  gitRunner: PushBranchDependencies['runGit'] = runGit,
+): Promise<void> {
+  const currentBranch = await gitRunner(worktreePath, ['symbolic-ref', '--quiet', '--short', 'HEAD'])
+  if (currentBranch.exitCode === 0 && currentBranch.stdout.trim() === replacementBranch) {
+    return
+  }
+
+  const checkout = await gitRunner(worktreePath, ['checkout', '-B', replacementBranch])
+  if (checkout.exitCode !== 0) {
+    throw new Error(checkout.stderr || checkout.stdout || `Failed to switch worktree to ${replacementBranch}`)
+  }
+}
+
+async function markSupersededPullRequest(
+  pullRequest: BranchPullRequestRecord,
+  replacement: {
+    prNumber: number
+    branch: string
+    attempt: number
+  },
+  reason: 'lineage-mismatch' | 'terminal-closed',
+  config: AgentConfig,
+  dependencies: Pick<CreateOrFindPrDependencies, 'commentOnPr' | 'closePullRequest'> = {},
+): Promise<void> {
+  const comment = dependencies.commentOnPr ?? commentOnPr
+  const close = dependencies.closePullRequest ?? closePullRequest
+
+  await comment(pullRequest.number, buildSupersededPrComment({
+    previousPrNumber: pullRequest.number,
+    replacementPrNumber: replacement.prNumber,
+    replacementBranch: replacement.branch,
+    replacementAttempt: replacement.attempt,
+    reason,
+  }), config)
+
+  if (pullRequest.prState === 'open') {
+    await close(pullRequest.number, config)
+  }
 }
 
 /**
@@ -250,52 +318,94 @@ export async function createOrFindPr(
   logger = console,
   dependencies: CreateOrFindPrDependencies = {},
 ): Promise<CreateOrFindPrResult> {
-  const checkExistingPr = dependencies.checkPrExists ?? checkPrExists
   const createPullRequest = dependencies.createPr ?? createPr
   const pushManagedBranch = dependencies.pushBranch ?? pushBranch
-  const resolveMetadata = dependencies.resolvePrLineageMetadata ?? resolvePrLineageMetadata
+  const resolveLineageContext = dependencies.resolvePrLineageContext ?? resolvePrLineageContext
+  const listBranchPrs = dependencies.listBranchPullRequests ?? listBranchPullRequests
+  const switchToReplacementBranch = dependencies.prepareReplacementBranch ?? prepareReplacementBranch
 
-  // Check idempotency: PR might already exist
-  const existing = await checkExistingPr(branch, config)
+  const lineageContext = await resolveLineageContext(worktreePath, config)
+  let currentBranch = branch
+  const supersedeTargets: Array<{
+    pullRequest: BranchPullRequestRecord
+    reason: 'lineage-mismatch' | 'terminal-closed'
+    replacementAttempt: number
+  }> = []
 
-  if (hasReusableOpenPr(existing)) {
-    const url = existing.prUrl ?? ''
-    await pushManagedBranch(worktreePath, branch, logger)
-    logger.log(`[pr] PR already exists: #${existing.prNumber} (${url})`)
-    return { kind: 'reused', prNumber: existing.prNumber, prUrl: url }
-  }
+  for (let guard = 0; guard < 5; guard += 1) {
+    const candidates = await listBranchPrs(currentBranch, config)
+    const lifecycle = choosePrLifecycleAction({
+      issueNumber,
+      headBranch: currentBranch,
+      baseBranch: lineageContext.baseBranch,
+      baseSha: lineageContext.baseSha,
+    }, candidates)
 
-  if (existing.prNumber !== null && existing.prState === 'merged') {
-    const url = existing.prUrl ?? ''
-    logger.warn(`[pr] PR #${existing.prNumber} is merged; replacement PR is required before continuing`)
-    return {
-      kind: 'terminal',
-      prNumber: existing.prNumber,
-      prUrl: url,
-      prState: 'merged',
-      replacementNeeded: true,
+    if (lifecycle.kind === 'terminal-merged') {
+      logger.warn(`[pr] PR #${lifecycle.prNumber} is merged; replacement PR is not created automatically`)
+      return {
+        kind: 'terminal',
+        prNumber: lifecycle.prNumber,
+        prUrl: lifecycle.prUrl,
+        prState: 'merged',
+        replacementNeeded: true,
+        branch: currentBranch,
+      }
     }
-  }
 
-  if (existing.prNumber !== null && existing.prState === 'closed') {
-    logger.warn(`[pr] PR #${existing.prNumber} is closed; replacement PR is required before continuing`)
-    const url = existing.prUrl ?? ''
-    return {
-      kind: 'terminal',
-      prNumber: existing.prNumber,
-      prUrl: url,
-      prState: 'closed',
-      replacementNeeded: true,
+    if (lifecycle.kind === 'reuse-open-lineage') {
+      await pushManagedBranch(worktreePath, currentBranch, logger)
+      for (const target of supersedeTargets) {
+        await markSupersededPullRequest(target.pullRequest, {
+          prNumber: lifecycle.prNumber,
+          branch: currentBranch,
+          attempt: target.replacementAttempt,
+        }, target.reason, config, dependencies)
+      }
+      logger.log(`[pr] PR already exists: #${lifecycle.prNumber} (${lifecycle.prUrl})`)
+      return { kind: 'reused', prNumber: lifecycle.prNumber, prUrl: lifecycle.prUrl, branch: currentBranch }
     }
+
+    if (lifecycle.kind === 'create-new-pr') {
+      await pushManagedBranch(worktreePath, currentBranch, logger)
+      const lineageMetadata = await resolvePrLineageMetadata(
+        currentBranch,
+        issueNumber,
+        lineageContext,
+        lifecycle.attempt,
+      )
+      const body = buildPrBody(issueNumber, config.machineId, lineageMetadata)
+      const pr = await createPullRequest(currentBranch, issueNumber, issueTitle, body, config)
+
+      for (const target of supersedeTargets) {
+        await markSupersededPullRequest(target.pullRequest, {
+          prNumber: pr.number,
+          branch: currentBranch,
+          attempt: target.replacementAttempt,
+        }, target.reason, config, dependencies)
+      }
+
+      logger.log(`[pr] created PR #${pr.number}: ${pr.url}`)
+      return { kind: 'created', prNumber: pr.number, prUrl: pr.url, branch: currentBranch }
+    }
+
+    const supersededPullRequest = candidates.find((candidate) => candidate.number === lifecycle.supersedesPrNumber)
+    if (!supersededPullRequest) {
+      throw new Error(`Replacement target PR #${lifecycle.supersedesPrNumber} was not found for ${currentBranch}`)
+    }
+
+    supersedeTargets.push({
+      pullRequest: supersededPullRequest,
+      reason: lifecycle.reason,
+      replacementAttempt: lifecycle.replacementAttempt,
+    })
+
+    logger.warn(
+      `[pr] ${currentBranch} requires replacement after ${lifecycle.reason} on PR #${lifecycle.supersedesPrNumber}; switching to ${lifecycle.replacementBranch}`,
+    )
+    await switchToReplacementBranch(worktreePath, lifecycle.replacementBranch)
+    currentBranch = lifecycle.replacementBranch
   }
 
-  // Push branch first if not pushed yet
-  await pushManagedBranch(worktreePath, branch, logger)
-
-  const lineageMetadata = await resolveMetadata(worktreePath, branch, issueNumber, config)
-  const body = buildPrBody(issueNumber, config.machineId, lineageMetadata)
-  const pr = await createPullRequest(branch, issueNumber, issueTitle, body, config)
-
-  logger.log(`[pr] created PR #${pr.number}: ${pr.url}`)
-  return { kind: 'created', prNumber: pr.number, prUrl: pr.url }
+  throw new Error(`Failed to resolve an active PR lineage for issue #${issueNumber}`)
 }

--- a/apps/agent-daemon/src/pr-reporter.ts
+++ b/apps/agent-daemon/src/pr-reporter.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig } from '@agent/shared'
+import type { AgentConfig, PrCheckResult } from '@agent/shared'
 import { checkPrExists, createPr } from '@agent/shared'
 
 interface GitCommandResult {
@@ -25,6 +25,32 @@ const MAX_PUSH_ATTEMPTS = 3
 interface ManagedBranchPushPlan {
   pushArgs: string[] | null
   detachedHead: boolean
+}
+
+interface CreateOrFindPrDependencies {
+  checkPrExists?: typeof checkPrExists
+  createPr?: typeof createPr
+  pushBranch?: typeof pushBranch
+}
+
+export type CreateOrFindPrResult =
+  | {
+      kind: 'reused' | 'created'
+      prNumber: number
+      prUrl: string
+    }
+  | {
+      kind: 'terminal'
+      prNumber: number
+      prUrl: string
+      prState: 'closed' | 'merged'
+      replacementNeeded: true
+    }
+
+export function hasReusableOpenPr(
+  prCheck: Pick<PrCheckResult, 'prNumber' | 'prState'>,
+): prCheck is Pick<PrCheckResult, 'prState'> & { prNumber: number; prState: 'open' } {
+  return prCheck.prNumber !== null && prCheck.prState === 'open'
 }
 
 export async function pushBranch(
@@ -181,35 +207,52 @@ export async function createOrFindPr(
   issueTitle: string,
   config: AgentConfig,
   logger = console,
-): Promise<{ prNumber: number; prUrl: string }> {
-  // Check idempotency: PR might already exist
-  const existing = await checkPrExists(branch, config)
+  dependencies: CreateOrFindPrDependencies = {},
+): Promise<CreateOrFindPrResult> {
+  const checkExistingPr = dependencies.checkPrExists ?? checkPrExists
+  const createPullRequest = dependencies.createPr ?? createPr
+  const pushManagedBranch = dependencies.pushBranch ?? pushBranch
 
-  if (existing.prNumber !== null && existing.prState === 'open') {
+  // Check idempotency: PR might already exist
+  const existing = await checkExistingPr(branch, config)
+
+  if (hasReusableOpenPr(existing)) {
     const url = existing.prUrl ?? ''
-    await pushBranch(worktreePath, branch, logger)
+    await pushManagedBranch(worktreePath, branch, logger)
     logger.log(`[pr] PR already exists: #${existing.prNumber} (${url})`)
-    return { prNumber: existing.prNumber, prUrl: url }
+    return { kind: 'reused', prNumber: existing.prNumber, prUrl: url }
   }
 
   if (existing.prNumber !== null && existing.prState === 'merged') {
     const url = existing.prUrl ?? ''
-    logger.log(`[pr] PR already merged: #${existing.prNumber}`)
-    return { prNumber: existing.prNumber, prUrl: url }
+    logger.warn(`[pr] PR #${existing.prNumber} is merged; replacement PR is required before continuing`)
+    return {
+      kind: 'terminal',
+      prNumber: existing.prNumber,
+      prUrl: url,
+      prState: 'merged',
+      replacementNeeded: true,
+    }
   }
 
   if (existing.prNumber !== null && existing.prState === 'closed') {
-    logger.warn(`[pr] PR was closed, not creating new PR`)
+    logger.warn(`[pr] PR #${existing.prNumber} is closed; replacement PR is required before continuing`)
     const url = existing.prUrl ?? ''
-    return { prNumber: existing.prNumber, prUrl: url }
+    return {
+      kind: 'terminal',
+      prNumber: existing.prNumber,
+      prUrl: url,
+      prState: 'closed',
+      replacementNeeded: true,
+    }
   }
 
   // Push branch first if not pushed yet
-  await pushBranch(worktreePath, branch, logger)
+  await pushManagedBranch(worktreePath, branch, logger)
 
   const body = PR_BODY_TEMPLATE(issueNumber, config.machineId)
-  const pr = await createPr(branch, issueNumber, issueTitle, body, config)
+  const pr = await createPullRequest(branch, issueNumber, issueTitle, body, config)
 
   logger.log(`[pr] created PR #${pr.number}: ${pr.url}`)
-  return { prNumber: pr.number, prUrl: pr.url }
+  return { kind: 'created', prNumber: pr.number, prUrl: pr.url }
 }

--- a/apps/agent-daemon/src/pr-reviewer.test.ts
+++ b/apps/agent-daemon/src/pr-reviewer.test.ts
@@ -351,6 +351,7 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
         attempt: 1,
         approved: false,
         canMerge: false,
+        action: 'retrying',
         headRefOid: 'abc123',
       },
       feedback: {
@@ -392,17 +393,55 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
     })
   })
 
-  test('allows standalone review to resume from a valid structured human-needed comment', () => {
+  test('reuses the latest structured review feedback when the latest comment is retrying and the PR head sha is unchanged', () => {
+    const issueBody = `## 用户故事
+- keep retry semantics stable`
     const comments = [
       {
-        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":1,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
-<!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":"First blocker","findings":[{"severity":"high","file":"apps/desktop/src/pages/MainPage.tsx","summary":"retry success regressed","mustFix":["restore success-list semantics"],"mustNotDo":["do not add selection state"],"validation":["bun --cwd apps/desktop test src/pages/MainPage.test.tsx"],"scopeRationale":"issue #76 requires preserving success semantics"}]} -->
-## Automated review found blocking issues — starting one auto-fix retry`,
+        body: buildPrReviewComment(
+          84,
+          {
+            approved: false,
+            canMerge: false,
+            reason: 'Second blocker',
+            findings: [{
+              severity: 'high',
+              file: 'apps/desktop/src/pages/MainPage.tsx',
+              summary: 'retry success regressed',
+              mustFix: ['restore success-list semantics'],
+              mustNotDo: ['do not add selection state'],
+              validation: ['bun --cwd apps/desktop test src/pages/MainPage.test.tsx'],
+              scopeRationale: 'issue #76 requires preserving success semantics',
+            }],
+          },
+          2,
+          'retrying',
+          'abc123',
+          issueBody,
+        ),
       },
     ]
 
     expect(canResumeAutomatedPrReview(comments, 3)).toBe(true)
-    expect(getNextAutomatedPrReviewAttempt(comments)).toBe(2)
+    expect(getReusableAutomatedPrReviewFeedback(comments, 'abc123', 3)).toEqual({
+      attempt: 2,
+      feedback: {
+        approved: false,
+        canMerge: false,
+        reason: 'Second blocker',
+        findings: [
+          {
+            severity: 'high',
+            file: 'apps/desktop/src/pages/MainPage.tsx',
+            summary: 'retry success regressed',
+            mustFix: ['restore success-list semantics'],
+            mustNotDo: ['do not add selection state'],
+            validation: ['bun --cwd apps/desktop test src/pages/MainPage.test.tsx'],
+            scopeRationale: 'issue #76 requires preserving success semantics',
+          },
+        ],
+      },
+    })
   })
 
   test('does not resume standalone review when the latest automated comment lacks valid structured feedback', () => {
@@ -517,34 +556,38 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
     expect(shouldRestartAutomatedPrReviewOnIssueUpdate(comments, '2026-04-05T08:10:01.000Z')).toBe(false)
   })
 
-  test('reuses the latest structured review feedback when the PR head sha is unchanged', () => {
+  test('does not reuse structured feedback from a terminal human-needed comment on an unchanged head', () => {
+    const issueBody = `## 用户故事
+- keep terminal human-needed terminal`
     const comments = [
       {
-        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":2,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
-<!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":"Second blocker","findings":[{"severity":"high","file":"apps/desktop/src/pages/MainPage.tsx","summary":"retry success regressed","mustFix":["restore success-list semantics"],"mustNotDo":["do not add selection state"],"validation":["bun --cwd apps/desktop test src/pages/MainPage.test.tsx"],"scopeRationale":"issue #76 requires preserving success semantics"}]} -->
-## Automated review still failing — human intervention required`,
+        body: buildPrReviewComment(
+          84,
+          {
+            approved: false,
+            canMerge: false,
+            reason: 'Final blocker',
+            findings: [{
+              severity: 'high',
+              file: 'apps/desktop/src/pages/MainPage.tsx',
+              summary: 'manual fix required',
+              mustFix: ['wait for a human or a new head commit before retrying'],
+              mustNotDo: ['do not auto-fix again on the same head'],
+              validation: ['bun test apps/agent-daemon/src/pr-reviewer.test.ts'],
+              scopeRationale: 'terminal human-needed should not be resurrected by recovery on unchanged head',
+            }],
+          },
+          2,
+          'human-needed',
+          'abc123',
+          issueBody,
+        ),
       },
     ]
 
-    expect(getReusableAutomatedPrReviewFeedback(comments, 'abc123', 3)).toEqual({
-      attempt: 2,
-      feedback: {
-        approved: false,
-        canMerge: false,
-        reason: 'Second blocker',
-        findings: [
-          {
-            severity: 'high',
-            file: 'apps/desktop/src/pages/MainPage.tsx',
-            summary: 'retry success regressed',
-            mustFix: ['restore success-list semantics'],
-            mustNotDo: ['do not add selection state'],
-            validation: ['bun --cwd apps/desktop test src/pages/MainPage.test.tsx'],
-            scopeRationale: 'issue #76 requires preserving success semantics',
-          },
-        ],
-      },
-    })
+    expect(canResumeAutomatedPrReview(comments, 3)).toBe(false)
+    expect(canResumeHumanNeededPrReview(comments, 3, 'abc123', issueBody)).toBe(false)
+    expect(getReusableAutomatedPrReviewFeedback(comments, 'abc123', 3)).toBeNull()
     expect(getReusableAutomatedPrReviewFeedback(comments, 'def456', 3)).toBeNull()
   })
 

--- a/apps/agent-daemon/src/pr-reviewer.ts
+++ b/apps/agent-daemon/src/pr-reviewer.ts
@@ -59,6 +59,7 @@ interface AutomatedPrReviewMetadata {
   attempt: number
   approved: boolean
   canMerge: boolean
+  action?: 'approved' | 'retrying' | 'human-needed'
   headRefOid?: string
   issueContractFingerprint?: string
 }
@@ -437,6 +438,7 @@ export function buildPrReviewComment(
     attempt,
     approved: review.approved,
     canMerge: review.canMerge,
+    action,
     ...(headRefOid ? { headRefOid } : {}),
     ...(issueContractFingerprint ? { issueContractFingerprint } : {}),
   }
@@ -559,6 +561,8 @@ export function canResumeAutomatedPrReview(
   if (!latest) return false
 
   return (
+    latest.metadata.action === 'retrying'
+    &&
     latest.metadata.approved === false
     && latest.metadata.canMerge === false
     && latest.feedback !== null
@@ -636,6 +640,7 @@ export function getReusableAutomatedPrReviewFeedback(
   const latest = extractLatestAutomatedPrReviewState(comments)
   if (!latest) return null
   if (latest.feedback === null) return null
+  if (latest.metadata.action !== 'retrying') return null
   if (latest.metadata.approved || latest.metadata.canMerge) return null
   if (latest.metadata.attempt >= maxAttempt) return null
   if (!latest.metadata.headRefOid || latest.metadata.headRefOid !== currentHeadRefOid) return null
@@ -829,6 +834,10 @@ function extractAutomatedPrReviewMetadata(body: string): AutomatedPrReviewMetada
       attempt,
       approved: parsed.approved === true,
       canMerge: parsed.canMerge === true,
+      action: inferAutomatedPrReviewAction(
+        typeof parsed.action === 'string' ? parsed.action : null,
+        body,
+      ),
       headRefOid: typeof parsed.headRefOid === 'string' && parsed.headRefOid.trim().length > 0
         ? parsed.headRefOid.trim()
         : undefined,
@@ -840,6 +849,38 @@ function extractAutomatedPrReviewMetadata(body: string): AutomatedPrReviewMetada
   } catch {
     return null
   }
+}
+
+function inferAutomatedPrReviewAction(
+  explicitAction: string | null,
+  body: string,
+): 'approved' | 'retrying' | 'human-needed' | undefined {
+  if (explicitAction === 'approved' || explicitAction === 'retrying' || explicitAction === 'human-needed') {
+    return explicitAction
+  }
+
+  if (
+    body.includes('## Automated review found blocking issues — starting one auto-fix retry')
+    || body.includes('Next step: daemon will attempt one automatic fix on the same branch.')
+  ) {
+    return 'retrying'
+  }
+
+  if (
+    body.includes('## Automated review still failing — human intervention required')
+    || body.includes('Next step: stopping automation and leaving the worktree/branch for a human.')
+  ) {
+    return 'human-needed'
+  }
+
+  if (
+    body.includes('## Automated review approved')
+    || body.includes('Next step: ready to merge.')
+  ) {
+    return 'approved'
+  }
+
+  return undefined
 }
 
 function buildIssueContractFingerprint(body: string | null | undefined): string | null {

--- a/apps/agent-daemon/src/process-tree.ts
+++ b/apps/agent-daemon/src/process-tree.ts
@@ -1,0 +1,28 @@
+export const DETACH_PROCESS_GROUP = process.platform !== 'win32'
+
+interface KillableProcess {
+  pid: number
+  kill(signal?: NodeJS.Signals | number): void
+}
+
+export function killProcessTree(
+  proc: KillableProcess | null | undefined,
+  signal: NodeJS.Signals | number = 'SIGKILL',
+): void {
+  if (!proc) return
+
+  if (DETACH_PROCESS_GROUP && Number.isInteger(proc.pid) && proc.pid > 0) {
+    try {
+      process.kill(-proc.pid, signal)
+      return
+    } catch {
+      // Fall through to a direct kill when process-group signaling is unavailable.
+    }
+  }
+
+  try {
+    proc.kill(signal)
+  } catch {
+    // Ignore already-exited processes.
+  }
+}

--- a/apps/agent-daemon/src/ready-gate.test.ts
+++ b/apps/agent-daemon/src/ready-gate.test.ts
@@ -3,7 +3,11 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { ISSUE_LABELS } from '@agent/shared'
-import { buildReadyGateFailureComment, evaluateReadyGate } from './ready-gate'
+import {
+  buildReadyGateFailureComment,
+  evaluateReadyGate,
+  evaluateReadyGateWithSimulation,
+} from './ready-gate'
 
 describe('ready-gate', () => {
   test('skips issues that are not in agent:ready', () => {
@@ -90,6 +94,188 @@ describe('ready-gate', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true })
     }
+  })
+
+  test('keeps default ready gate evaluation unchanged without simulation', () => {
+    const issue = {
+      number: 63,
+      title: '[AL-10] simulate default gate remains static',
+      body: [
+        '## 用户故事',
+        '作为维护者，我希望默认 ready gate 保持静态校验兼容。',
+        '',
+        '## Context',
+        '### Dependencies',
+        '```json',
+        '{ "dependsOn": [62] }',
+        '```',
+        '### AllowedFiles',
+        '- apps/agent-daemon/src/ready-gate.ts',
+        '### ForbiddenFiles',
+        '- apps/agent-daemon/src/daemon.ts',
+        '### MustPreserve',
+        '- 默认 ready gate 行为不变',
+        '### OutOfScope',
+        '- runtime evaluator',
+        '### RequiredSemantics',
+        '- ready gate 继续只看静态 contract',
+        '### Validation',
+        '- bun test apps/agent-daemon/src/ready-gate.test.ts',
+        '',
+        '## RED 测试',
+        '```ts',
+        'throw new Error("red")',
+        '```',
+        '',
+        '## 实现步骤',
+        '1. 补 gate 测试',
+        '',
+        '## 验收',
+        '- 默认模式不受 simulate 影响',
+      ].join('\n'),
+      state: 'open' as const,
+      labels: [ISSUE_LABELS.READY],
+    }
+
+    expect(evaluateReadyGate(issue)).toEqual({
+      shouldEnforce: true,
+      valid: true,
+      errors: [],
+    })
+  })
+
+  test('blocks ready issues when opt-in simulation fails a planner executability check', async () => {
+    const result = await evaluateReadyGateWithSimulation({
+      number: 64,
+      title: '[AL-10] simulate blocks planner-only issue',
+      body: [
+        '## 用户故事',
+        '作为维护者，我希望 simulate 能拦住静态通过但实际不可执行的 issue。',
+        '',
+        '## Context',
+        '### Dependencies',
+        '```json',
+        '{ "dependsOn": [63] }',
+        '```',
+        '### AllowedFiles',
+        '- apps/agent-daemon/src/issue-simulate.ts',
+        '### ForbiddenFiles',
+        '- apps/agent-daemon/src/daemon.ts',
+        '### MustPreserve',
+        '- 只读 simulation 不写远端',
+        '### OutOfScope',
+        '- 自动 rewrite issue body',
+        '### RequiredSemantics',
+        '- simulate 暴露 planner failures',
+        '### Validation',
+        '- bun test apps/agent-daemon/src/issue-simulate.test.ts',
+        '',
+        '## RED 测试',
+        '```ts',
+        'throw new Error("red")',
+        '```',
+        '',
+        '## 实现步骤',
+        '1. 用 simulation 评估 executability',
+        '',
+        '## 验收',
+        '- simulation 失败时阻塞 ready gate',
+      ].join('\n'),
+      state: 'open',
+      labels: [ISSUE_LABELS.READY],
+    }, {
+      simulate: {
+        enabled: true,
+        runPlanner: async () => ({
+          responseText: '1. Read the codebase and analyze the issue\n2. Propose an approach',
+        }),
+      },
+    })
+
+    expect(result.shouldEnforce).toBe(true)
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain(
+      'planning output does not contain commit-shaped subtasks',
+    )
+    expect(result.simulation).toMatchObject({
+      valid: false,
+      checks: {
+        commitShapedPlan: false,
+        scopedAllowedFiles: true,
+        specificValidation: true,
+      },
+    })
+  })
+
+  test('preserves success when opt-in simulation passes', async () => {
+    const result = await evaluateReadyGateWithSimulation({
+      number: 65,
+      title: '[AL-10] simulate accepts executable issue',
+      body: [
+        '## 用户故事',
+        '作为维护者，我希望 simulate 通过时 ready gate 继续放行。',
+        '',
+        '## Context',
+        '### Dependencies',
+        '```json',
+        '{ "dependsOn": [64] }',
+        '```',
+        '### AllowedFiles',
+        '- apps/agent-daemon/src/index.ts',
+        '- apps/agent-daemon/src/index.test.ts',
+        '### ForbiddenFiles',
+        '- apps/agent-daemon/src/daemon.ts',
+        '### MustPreserve',
+        '- 默认 ready gate 行为不回归',
+        '### OutOfScope',
+        '- runtime browser evaluator',
+        '### RequiredSemantics',
+        '- simulate 输出结构化检查结果',
+        '### Validation',
+        '- bun test apps/agent-daemon/src/index.test.ts',
+        '- bun run typecheck',
+        '',
+        '## RED 测试',
+        '```ts',
+        'throw new Error("red")',
+        '```',
+        '',
+        '## 实现步骤',
+        '1. 新增 simulate CLI',
+        '2. 补 index tests',
+        '3. 跑 typecheck',
+        '',
+        '## 验收',
+        '- simulation valid=true',
+      ].join('\n'),
+      state: 'open',
+      labels: [ISSUE_LABELS.READY],
+    }, {
+      simulate: {
+        enabled: true,
+        runPlanner: async () => ({
+          responseText: [
+            '1. Add the simulate CLI entry in apps/agent-daemon/src/index.ts',
+            '2. Write index tests covering file and issue inputs',
+            '3. Run bun test apps/agent-daemon/src/index.test.ts and bun run typecheck',
+          ].join('\n'),
+        }),
+      },
+    })
+
+    expect(result).toMatchObject({
+      shouldEnforce: true,
+      valid: true,
+      errors: [],
+      simulation: {
+        valid: true,
+        checks: {
+          commitShapedPlan: true,
+          scopedAllowedFiles: true,
+          specificValidation: true,
+        },
+      },
+    })
   })
 
   test('accepts ready issues when validation points at a new file that is explicitly allowed', () => {

--- a/apps/agent-daemon/src/ready-gate.ts
+++ b/apps/agent-daemon/src/ready-gate.ts
@@ -2,6 +2,12 @@ import { parseIssueContract, validateIssueContract, ISSUE_LABELS, buildGhEnv, co
 import { existsSync } from 'node:fs'
 import { isAbsolute, posix, resolve } from 'node:path'
 import { loadConfig, type CliArgs } from './config'
+import {
+  simulateIssueExecutability,
+  type IssueSimulationPlannerRunner,
+  type IssueSimulationResult,
+} from './issue-simulate'
+import { runConfiguredAgent } from './cli-agent'
 
 interface ReadyGateIssueSnapshot {
   number: number
@@ -15,10 +21,18 @@ export interface ReadyGateEvaluation {
   shouldEnforce: boolean
   valid: boolean
   errors: string[]
+  simulation?: IssueSimulationResult
 }
 
 interface ReadyGateOptions {
   repoRoot?: string
+}
+
+interface ReadyGateSimulationOptions extends ReadyGateOptions {
+  simulate?: {
+    enabled: boolean
+    runPlanner: IssueSimulationPlannerRunner
+  }
 }
 
 function normalizeContractPath(value: string): string {
@@ -154,6 +168,37 @@ export function evaluateReadyGate(
   }
 }
 
+export async function evaluateReadyGateWithSimulation(
+  issue: ReadyGateIssueSnapshot,
+  options: ReadyGateSimulationOptions = {},
+): Promise<ReadyGateEvaluation> {
+  const base = evaluateReadyGate(issue, options)
+  if (!options.simulate?.enabled || !base.shouldEnforce || !base.valid) {
+    return base
+  }
+
+  const simulation = await simulateIssueExecutability({
+    issueTitle: issue.title,
+    issueBody: issue.body,
+    repoRoot: options.repoRoot,
+    runPlanner: options.simulate.runPlanner,
+  })
+
+  if (simulation.valid) {
+    return {
+      ...base,
+      simulation,
+    }
+  }
+
+  return {
+    shouldEnforce: true,
+    valid: false,
+    errors: [...base.errors, ...simulation.failures],
+    simulation,
+  }
+}
+
 export function buildReadyGateFailureComment(issueNumber: number, errors: string[]): string {
   return `<!-- agent-loop:ready-gate {"issue":${issueNumber},"valid":false} -->
 ## agent:ready gate blocked
@@ -240,9 +285,39 @@ export async function enforceReadyGate(
   issueNumber: number,
   config: AgentConfig,
   logger = console,
+  options: {
+    simulate?: boolean
+    repoRoot?: string
+    runPlanner?: IssueSimulationPlannerRunner
+  } = {},
 ): Promise<ReadyGateEvaluation> {
   const issue = await fetchIssueSnapshot(issueNumber, config)
-  const evaluation = evaluateReadyGate(issue, { repoRoot: process.cwd() })
+  const evaluation = await evaluateReadyGateWithSimulation(issue, {
+    repoRoot: options.repoRoot ?? process.cwd(),
+    simulate: options.simulate
+      ? {
+          enabled: true,
+          runPlanner: options.runPlanner ?? (async ({ prompt, repoRoot }) => {
+            const result = await runConfiguredAgent({
+              prompt,
+              worktreePath: repoRoot,
+              timeoutMs: config.agent.timeoutMs,
+              config,
+              logger,
+              allowWrites: false,
+            })
+
+            if (!result.ok) {
+              throw new Error(result.stderr || result.stdout || 'ready-gate simulation planner failed')
+            }
+
+            return {
+              responseText: result.responseText,
+            }
+          }),
+        }
+      : undefined,
+  })
 
   if (!evaluation.shouldEnforce) {
     logger.log(`[ready-gate] issue #${issueNumber} does not currently require enforcement`)
@@ -260,9 +335,10 @@ export async function enforceReadyGate(
   return evaluation
 }
 
-function parseArgs(argv: string[]): CliArgs & { issueNumber: number } {
+function parseArgs(argv: string[]): CliArgs & { issueNumber: number; simulate: boolean } {
   let issueNumber: number | null = null
   let repo: string | undefined
+  let simulate = false
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index]
@@ -277,6 +353,10 @@ function parseArgs(argv: string[]): CliArgs & { issueNumber: number } {
       repo = argv[index + 1]
       index++
     }
+
+    if (arg === '--simulate') {
+      simulate = true
+    }
   }
 
   if (!Number.isInteger(issueNumber) || issueNumber === null || issueNumber <= 0) {
@@ -286,13 +366,16 @@ function parseArgs(argv: string[]): CliArgs & { issueNumber: number } {
   return {
     issueNumber,
     repo,
+    simulate,
   }
 }
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2))
   const config = loadConfig({ repo: args.repo })
-  const evaluation = await enforceReadyGate(args.issueNumber, config)
+  const evaluation = await enforceReadyGate(args.issueNumber, config, console, {
+    simulate: args.simulate,
+  })
 
   if (evaluation.shouldEnforce && !evaluation.valid) {
     process.exitCode = 1

--- a/apps/agent-daemon/src/replay-eval.test.ts
+++ b/apps/agent-daemon/src/replay-eval.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  evaluateBootstrapScenarioFixtureDirectory,
+  evaluateBootstrapScenarioSuite,
   evaluateReplayFixtureDirectory,
   evaluateReplayFixtures,
 } from './replay-eval'
@@ -108,12 +112,139 @@ throw new Error('fixture red test body')
 
     expect(report.ok).toBe(true)
     expect(report.summary).toMatchObject({
-      totalCases: 2,
-      passedCases: 2,
+      totalCases: 6,
+      passedCases: 6,
       failedCases: 0,
-      claimable: 1,
-      blocked: 1,
+      claimable: 3,
+      blocked: 3,
       invalid: 1,
     })
+  })
+})
+
+describe('evaluateBootstrapScenarioSuite', () => {
+  test('fails when any required self-bootstrap case is missing or red', () => {
+    const report = evaluateBootstrapScenarioSuite({
+      suite: 'self-bootstrap-v0.2',
+      cases: [
+        { name: 'self-bootstrap-happy-path', ok: true },
+        { name: 'self-bootstrap-closed-pr-recreate', ok: true },
+        { name: 'self-bootstrap-checks-pending', ok: false },
+      ],
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.failedCases).toEqual([
+      'self-bootstrap-checks-pending',
+      'self-bootstrap-checks-fail',
+    ])
+    expect(report.summary).toEqual({
+      requiredCases: 4,
+      presentCases: 3,
+      passedCases: 2,
+      failedCases: 2,
+    })
+  })
+
+  test('loads the fixed self-bootstrap scenario suite from disk', () => {
+    const report = evaluateBootstrapScenarioFixtureDirectory(join(import.meta.dir, 'fixtures', 'replay'))
+
+    expect(report.ok).toBe(true)
+    expect(report.cases.map((fixture) => fixture.name)).toEqual([
+      'self-bootstrap-happy-path',
+      'self-bootstrap-closed-pr-recreate',
+      'self-bootstrap-checks-pending',
+      'self-bootstrap-checks-fail',
+    ])
+    expect(report.failedCases).toEqual([])
+    expect(report.summary).toEqual({
+      requiredCases: 4,
+      presentCases: 4,
+      passedCases: 4,
+      failedCases: 0,
+    })
+  })
+
+  test('isolates the fixed suite from unrelated replay fixtures', () => {
+    const fixturesDir = mkdtempSync(join(tmpdir(), 'bootstrap-suite-fixtures-'))
+
+    try {
+      for (const fixtureName of [
+        'self-bootstrap-happy-path',
+        'self-bootstrap-closed-pr-recreate',
+        'self-bootstrap-checks-pending',
+        'self-bootstrap-checks-fail',
+      ]) {
+        writeFileSync(
+          join(fixturesDir, `${fixtureName}.json`),
+          readFileSync(join(import.meta.dir, 'fixtures', 'replay', `${fixtureName}.json`), 'utf-8'),
+          'utf-8',
+        )
+      }
+
+      writeFileSync(
+        join(fixturesDir, 'zzz-unrelated-broken.json'),
+        JSON.stringify({
+          name: 'zzz-unrelated-broken',
+          openIssues: 'not-an-array',
+          issueComments: [],
+          openPullRequests: [],
+          expected: {
+            claimable: 0,
+            blocked: 0,
+            invalid: 0,
+          },
+        }, null, 2),
+        'utf-8',
+      )
+
+      const report = evaluateBootstrapScenarioFixtureDirectory(fixturesDir)
+
+      expect(report.ok).toBe(true)
+      expect(report.cases.map((fixture) => fixture.name)).toEqual([
+        'self-bootstrap-happy-path',
+        'self-bootstrap-closed-pr-recreate',
+        'self-bootstrap-checks-pending',
+        'self-bootstrap-checks-fail',
+      ])
+      expect(report.failedCases).toEqual([])
+    } finally {
+      rmSync(fixturesDir, { recursive: true, force: true })
+    }
+  })
+
+  test('reports missing required fixtures without loading unrelated files', () => {
+    const fixturesDir = mkdtempSync(join(tmpdir(), 'bootstrap-suite-missing-'))
+
+    try {
+      mkdirSync(fixturesDir, { recursive: true })
+      writeFileSync(
+        join(fixturesDir, 'self-bootstrap-happy-path.json'),
+        readFileSync(join(import.meta.dir, 'fixtures', 'replay', 'self-bootstrap-happy-path.json'), 'utf-8'),
+        'utf-8',
+      )
+      writeFileSync(
+        join(fixturesDir, 'self-bootstrap-closed-pr-recreate.json'),
+        readFileSync(join(import.meta.dir, 'fixtures', 'replay', 'self-bootstrap-closed-pr-recreate.json'), 'utf-8'),
+        'utf-8',
+      )
+      writeFileSync(
+        join(fixturesDir, 'self-bootstrap-checks-pending.json'),
+        readFileSync(join(import.meta.dir, 'fixtures', 'replay', 'self-bootstrap-checks-pending.json'), 'utf-8'),
+        'utf-8',
+      )
+
+      const report = evaluateBootstrapScenarioFixtureDirectory(fixturesDir)
+
+      expect(report.ok).toBe(false)
+      expect(report.failedCases).toEqual(['self-bootstrap-checks-fail'])
+      expect(report.cases[3]).toMatchObject({
+        name: 'self-bootstrap-checks-fail',
+        ok: false,
+        present: false,
+      })
+    } finally {
+      rmSync(fixturesDir, { recursive: true, force: true })
+    }
   })
 })

--- a/apps/agent-daemon/src/replay-eval.ts
+++ b/apps/agent-daemon/src/replay-eval.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { readdirSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 import {
   applyDependencyClaimability,
@@ -79,6 +79,37 @@ export interface ReplayFixtureReport {
 }
 
 const DEFAULT_FIXTURES_DIR = 'apps/agent-daemon/src/fixtures/replay'
+export const DEFAULT_BOOTSTRAP_SCENARIO_SUITE = 'self-bootstrap-v0.2'
+export const REQUIRED_BOOTSTRAP_SCENARIO_CASES = [
+  'self-bootstrap-happy-path',
+  'self-bootstrap-closed-pr-recreate',
+  'self-bootstrap-checks-pending',
+  'self-bootstrap-checks-fail',
+] as const
+
+export interface BootstrapScenarioSuiteCaseReport {
+  name: string
+  ok: boolean
+  present: boolean
+  mismatches: string[]
+  actual: ReplayFixtureSummary | null
+  expected: ReplayFixtureSummary | null
+}
+
+export interface BootstrapScenarioSuiteReportSummary {
+  requiredCases: number
+  presentCases: number
+  passedCases: number
+  failedCases: number
+}
+
+export interface BootstrapScenarioSuiteReport {
+  suite: string
+  ok: boolean
+  cases: BootstrapScenarioSuiteCaseReport[]
+  failedCases: string[]
+  summary: BootstrapScenarioSuiteReportSummary
+}
 
 export function evaluateReplayFixtures(fixtures: ReplayFixtureCase[]): ReplayFixtureReport {
   const caseResults = fixtures.map(evaluateReplayFixtureCase)
@@ -101,6 +132,75 @@ export function evaluateReplayFixtureDirectory(fixturesDir: string): ReplayFixtu
   return evaluateReplayFixtures(loadReplayFixtures(fixturesDir))
 }
 
+export function evaluateBootstrapScenarioSuite(input: {
+  suite?: string
+  cases: Array<{
+    name: string
+    ok: boolean
+    present?: boolean
+    mismatches?: string[]
+    actual?: ReplayFixtureSummary | null
+    expected?: ReplayFixtureSummary | null
+  }>
+}): BootstrapScenarioSuiteReport {
+  const reportedCases = new Map(input.cases.map((fixture) => [fixture.name, fixture]))
+  const cases = REQUIRED_BOOTSTRAP_SCENARIO_CASES.map<BootstrapScenarioSuiteCaseReport>((name) => {
+    const reportedCase = reportedCases.get(name)
+    if (!reportedCase) {
+      return {
+        name,
+        ok: false,
+        present: false,
+        mismatches: ['required self-bootstrap scenario is missing'],
+        actual: null,
+        expected: null,
+      }
+    }
+
+    return {
+      name,
+      ok: reportedCase.ok,
+      present: reportedCase.present ?? true,
+      mismatches: [...(reportedCase.mismatches ?? [])],
+      actual: reportedCase.actual ?? null,
+      expected: reportedCase.expected ?? null,
+    }
+  })
+  const failedCases = cases.filter((fixture) => !fixture.ok).map((fixture) => fixture.name)
+
+  return {
+    suite: input.suite ?? DEFAULT_BOOTSTRAP_SCENARIO_SUITE,
+    ok: failedCases.length === 0,
+    cases,
+    failedCases,
+    summary: {
+      requiredCases: REQUIRED_BOOTSTRAP_SCENARIO_CASES.length,
+      presentCases: cases.filter((fixture) => fixture.present).length,
+      passedCases: cases.filter((fixture) => fixture.ok).length,
+      failedCases: failedCases.length,
+    },
+  }
+}
+
+export function evaluateBootstrapScenarioFixtureDirectory(
+  fixturesDir: string,
+): BootstrapScenarioSuiteReport {
+  return evaluateBootstrapScenarioSuite({
+    suite: DEFAULT_BOOTSTRAP_SCENARIO_SUITE,
+    cases: REQUIRED_BOOTSTRAP_SCENARIO_CASES.flatMap((name) => {
+      const fixture = loadReplayFixtureByName(fixturesDir, name)
+      if (fixture === null) {
+        return []
+      }
+
+      return [{
+        ...evaluateReplayFixtureCase(fixture),
+        present: true,
+      }]
+    }),
+  })
+}
+
 export function loadReplayFixtures(fixturesDir: string): ReplayFixtureCase[] {
   const resolvedDir = resolve(fixturesDir)
   const fixtureFiles = readdirSync(resolvedDir)
@@ -109,9 +209,22 @@ export function loadReplayFixtures(fixturesDir: string): ReplayFixtureCase[] {
 
   return fixtureFiles.map((entry) => {
     const filePath = join(resolvedDir, entry)
-    const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as Partial<ReplayFixtureCase>
-    return normalizeReplayFixture(parsed, basename(entry, '.json'))
+    return loadReplayFixtureFile(filePath)
   })
+}
+
+function loadReplayFixtureByName(fixturesDir: string, fixtureName: string): ReplayFixtureCase | null {
+  const filePath = join(resolve(fixturesDir), `${fixtureName}.json`)
+  if (!existsSync(filePath)) {
+    return null
+  }
+
+  return loadReplayFixtureFile(filePath)
+}
+
+function loadReplayFixtureFile(filePath: string): ReplayFixtureCase {
+  const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as Partial<ReplayFixtureCase>
+  return normalizeReplayFixture(parsed, basename(filePath, '.json'))
 }
 
 export function formatReplayFixtureReport(report: ReplayFixtureReport): string {
@@ -132,6 +245,38 @@ export function formatReplayFixtureReport(report: ReplayFixtureReport): string {
   )
 
   return lines.join('\n')
+}
+
+export function formatBootstrapScenarioSuiteReport(
+  report: BootstrapScenarioSuiteReport,
+): string {
+  return [
+    'Bootstrap Scenarios',
+    `suite=${report.suite}`,
+    `ok=${report.ok}`,
+    'cases:',
+    ...report.cases.map((fixture) => {
+      const status = fixture.ok ? 'ok' : fixture.present ? 'failed' : 'missing'
+      const mismatchSuffix = fixture.mismatches.length > 0
+        ? ` mismatches=${fixture.mismatches.join(' | ')}`
+        : ''
+      return `- ${fixture.name}: ${status}${mismatchSuffix}`
+    }),
+    `failedCases=${report.failedCases.join(',') || '-'}`,
+    `summary: required=${report.summary.requiredCases} present=${report.summary.presentCases} passed=${report.summary.passedCases} failed=${report.summary.failedCases}`,
+  ].join('\n')
+}
+
+export function formatBootstrapScenarioSuiteReportJson(
+  report: BootstrapScenarioSuiteReport,
+): string {
+  return JSON.stringify(report, null, 2)
+}
+
+export function resolveBootstrapScenarioSuiteExitCode(
+  report: Pick<BootstrapScenarioSuiteReport, 'ok'>,
+): number {
+  return report.ok ? 0 : 1
 }
 
 function evaluateReplayFixtureCase(fixture: ReplayFixtureCase): ReplayFixtureCaseResult {

--- a/apps/agent-daemon/src/status.test.ts
+++ b/apps/agent-daemon/src/status.test.ts
@@ -12,6 +12,7 @@ import {
   formatStatusReport,
   parsePrometheusSamples,
   summarizeDaemonMetrics,
+  summarizePrLineageWarnings,
 } from './status'
 
 const baseHealth: DaemonStatus & {
@@ -69,6 +70,28 @@ const baseHealth: DaemonStatus & {
     latestCommitAt: '2026-04-05T08:09:40.000Z',
     safeToUpgradeNow: false,
     message: 'channel master is newer: local v0.1.0, latest v0.1.1',
+  },
+  prLineage: {
+    warningCount: 1,
+    warningCounts: {
+      multiActiveLineage: 1,
+      terminalReuseBlocked: 1,
+      supersededLineage: 1,
+      missingMetadata: 0,
+      lineageMismatchBlocked: 0,
+    },
+    warnings: [
+      {
+        issueNumber: 37,
+        branch: 'agent/37-rebuild/codex-dev',
+        activePrNumbers: [78, 91],
+        supersededPrNumbers: [45],
+        terminalReuseBlockedPrNumbers: [45],
+        missingMetadataPrNumbers: [],
+        lineageMismatchBlockedPrNumbers: [],
+        updatedAt: '2026-04-05T08:09:50.000Z',
+      },
+    ],
   },
   endpoints: {
     health: {
@@ -243,6 +266,14 @@ agent_loop_review_auto_fixes_total{outcome="committed"} 2
 agent_loop_review_auto_fixes_total{outcome="push_failed"} 1
 agent_loop_pr_merge_recovery_total{outcome="merged_initial"} 1
 agent_loop_pr_merge_recovery_total{outcome="refresh_push_failed"} 1
+agent_loop_pr_lineage_events_total{kind="multi_active_lineage"} 1
+agent_loop_pr_lineage_events_total{kind="terminal_reuse_blocked"} 1
+agent_loop_pr_lineage_events_total{kind="superseded_lineage"} 1
+agent_loop_pr_lineage_warnings{kind="multi_active_lineage"} 1
+agent_loop_pr_lineage_warnings{kind="terminal_reuse_blocked"} 1
+agent_loop_pr_lineage_warnings{kind="superseded_lineage"} 1
+agent_loop_pr_lineage_warnings{kind="missing_metadata"} 0
+agent_loop_pr_lineage_warnings{kind="lineage_mismatch_blocked"} 0
 agent_loop_recovery_actions_total{kind="issue-process-idle-timeout",outcome="recoverable"} 2
 agent_loop_transient_loop_errors_total{kind="startup-recovery"} 1
 agent_loop_transient_loop_errors_total{kind="poll-cycle"} 1
@@ -379,6 +410,18 @@ describe('status helpers', () => {
         merged_initial: 1,
         refresh_push_failed: 1,
       },
+      prLineageEvents: {
+        multi_active_lineage: 1,
+        terminal_reuse_blocked: 1,
+        superseded_lineage: 1,
+      },
+      prLineageWarnings: {
+        multi_active_lineage: 1,
+        terminal_reuse_blocked: 1,
+        superseded_lineage: 1,
+        missing_metadata: 0,
+        lineage_mismatch_blocked: 0,
+      },
       recoveryActions: {
         'issue-process-idle-timeout': {
           recoverable: 2,
@@ -410,6 +453,25 @@ describe('status helpers', () => {
       leaseConflicts: 1,
       rateLimitHits: 0,
     })
+  })
+
+  test('surfaces multi-lineage and terminal reuse warnings explicitly', () => {
+    const warnings = summarizePrLineageWarnings([
+      {
+        issueNumber: 37,
+        branch: 'agent/37-rebuild/codex-dev',
+        activePrNumbers: [78, 91],
+        supersededPrNumbers: [45],
+        terminalReuseBlockedPrNumbers: [45],
+        missingMetadataPrNumbers: [],
+        lineageMismatchBlockedPrNumbers: [],
+        updatedAt: '2026-04-05T08:09:50.000Z',
+      },
+    ])
+
+    expect(warnings).toContain('issue#37 has multiple active PR lineages: pr#78, pr#91')
+    expect(warnings).toContain('issue#37 blocked a terminal PR reuse attempt on pr#45')
+    expect(warnings).toContain('issue#37 has superseded PR lineages: pr#45')
   })
 
   test('formats a concise status report with concurrency caps and warnings', () => {
@@ -457,18 +519,23 @@ describe('status helpers', () => {
     expect(report).toContain('leases: active 2 | oldest heartbeat 75s | stalled 1 | last recovery issue-process-idle-timeout @ 2026-04-05T08:08:30.000Z')
     expect(report).toContain('lease detail: issue-process#77 implementation hb=75s progress=42s adoptable=yes')
     expect(report).toContain('state: startup pending yes | failed resumes 1 | cooldowns 1 | blocked resumes 1 | oldest blocked 45s | escalated 1 | oldest escalation 15s')
+    expect(report).toContain('pr lineage: warned issues 1 | multi-active 1 | terminal blocked 1 | superseded 1 | missing metadata 0 | mismatch blocked 0')
     expect(report).toContain('auto-upgrade: attempts 2 | success 1 | failed 0 | no-change 1 | failure streak 0 | last outcome no_change | last attempt 2026-04-05T08:09:55.000Z | last success 2026-04-05T07:55:00.000Z | paused until none | target v0.1.1@2222222')
     expect(report).toContain('poll: last 2026-04-05T08:10:00.000Z | last claim 2026-04-05T08:09:00.000Z | next 5s (deferred-transient) @ 2026-04-05T08:10:05.000Z')
     expect(report).toContain('recent recovery: issue-process-idle-timeout/recoverable issue-process#77')
     expect(report).toContain('blocked resumes: issue#91<-pr#110 45s esc=1/15s')
+    expect(report).toContain('pr lineage detail: issue#37 | active pr#78, pr#91 | superseded pr#45 | terminal pr#45')
     expect(report).toContain('launchd: loaded yes | state running | runs 2 | last signal Terminated: 15')
     expect(report).toContain('runtime files: record /Users/wujames/.agent-loop/runtime/jameswuhk-digital-employee__codex-dev__9310.json | log /Users/wujames/.agent-loop/runtime/jameswuhk-digital-employee__codex-dev__9310.log')
     expect(report).toContain('outcomes: polls success=12, skipped_concurrency=3, no_issues=4, error=1 | wake queued=2, started_work=1, no_match=1, allow_fallback=1')
     expect(report).toContain('github api: graphql/direct[success=8, error=0, timeout=0, rate_limited=1], rest/gh_cli[success=5, error=1, timeout=0, rate_limited=0]')
+    expect(report).toContain('pr-lineage metrics: events multi_active_lineage=1, terminal_reuse_blocked=1, superseded_lineage=1, missing_metadata=0, lineage_mismatch_blocked=0 | warnings multi_active_lineage=1, terminal_reuse_blocked=1, superseded_lineage=1, missing_metadata=0, lineage_mismatch_blocked=0')
     expect(report).toContain('auto-upgrade metrics: attempts 3 | success 1 | failed 1 | no-change 1 | last attempt age 300s | last success age 900s')
     expect(report).toContain('wake: pending 2 | now[queued=0, started_work=0, no_match=0, allow_fallback=1], issue[queued=2, started_work=1, no_match=0, allow_fallback=0], pr[queued=0, started_work=0, no_match=1, allow_fallback=0]')
     expect(report).toContain('pr blockers: pr#239<-issue#105 attempt 5 @ 2026-04-06T01:23:45.000Z: The PR breaks the existing approval-bar flow')
     expect(report).toContain('warnings: startup recovery is still pending')
+    expect(report).toContain('issue#37 has multiple active PR lineages: pr#78, pr#91')
+    expect(report).toContain('issue#37 blocked a terminal PR reuse attempt on pr#45')
     expect(report).toContain('github api rate limits observed: graphql/direct[success=0, error=0, timeout=0, rate_limited=1]')
   })
 

--- a/apps/agent-daemon/src/status.ts
+++ b/apps/agent-daemon/src/status.ts
@@ -47,6 +47,13 @@ const WAKE_KIND_ORDER = ['now', 'issue', 'pr'] as const
 const WAKE_OUTCOME_ORDER = ['queued', 'started_work', 'no_match', 'allow_fallback'] as const
 const GITHUB_API_REQUEST_KEY_ORDER = ['graphql/direct', 'graphql/gh_cli', 'rest/direct', 'rest/gh_cli'] as const
 const GITHUB_API_OUTCOME_ORDER = ['success', 'error', 'timeout', 'rate_limited'] as const
+const PR_LINEAGE_KIND_ORDER = [
+  'multi_active_lineage',
+  'terminal_reuse_blocked',
+  'superseded_lineage',
+  'missing_metadata',
+  'lineage_mismatch_blocked',
+] as const
 const GITHUB_AUDIT_MAX_AUTOMATED_PR_REVIEW_ATTEMPTS = 3
 const RECENT_TRANSIENT_LOOP_ERROR_WARNING_AGE_SECONDS = 5 * 60
 export interface DaemonHealthPayload extends DaemonStatus {
@@ -62,6 +69,8 @@ export interface DaemonMetricSummary {
   prReviews: Record<string, Record<string, number>>
   autoFixes: Record<string, number>
   mergeRecovery: Record<string, number>
+  prLineageEvents: Record<string, number>
+  prLineageWarnings: Record<string, number>
   recoveryActions: Record<string, Record<string, number>>
   transientLoopErrors: Record<string, number>
   workerIdleTimeouts: Record<string, number>
@@ -147,6 +156,8 @@ interface LocalEndpointResponse {
   statusText: string
   body: string
 }
+
+type PrLineageWarningList = NonNullable<DaemonHealthPayload['prLineage']>['warnings']
 
 export interface GitHubLeaseAuditCheck {
   scope: ManagedLeaseScope
@@ -424,6 +435,7 @@ export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): strin
   const oldestBlockedIssueResumeEscalationAgeSeconds = health.runtime.oldestBlockedIssueResumeEscalationAgeSeconds ?? 0
   const transientLoopErrorCount = health.runtime.transientLoopErrorCount ?? 0
   const startupRecoveryDeferredCount = health.runtime.startupRecoveryDeferredCount ?? 0
+  const prLineage = health.prLineage ?? null
   const lines = [
     `daemon: ${health.status} v${health.version} (${health.mode})`,
     `agent-loop: repo ${health.agentLoop?.repo ?? 'unknown'} | revision ${formatRevision(health.agentLoop?.revision ?? null)} | upgrade ${formatUpgradeSummary(health.upgrade)}`,
@@ -438,6 +450,7 @@ export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): strin
     `connectivity: transient ${transientLoopErrorCount} | startup deferred ${startupRecoveryDeferredCount} | last transient ${formatTransientLoopError(health.runtime.lastTransientLoopErrorKind, health.runtime.lastTransientLoopErrorAgeSeconds)}`,
     `leases: active ${health.runtime.activeLeaseCount} | oldest heartbeat ${formatNullableSeconds(health.runtime.oldestLeaseHeartbeatAgeSeconds)} | stalled ${health.runtime.stalledWorkerCount} | last recovery ${formatLastRecovery(health.runtime.lastRecoveryActionKind, health.runtime.lastRecoveryActionAt)}`,
     `state: startup pending ${formatBoolean(health.runtime.startupRecoveryPending)} | failed resumes ${health.runtime.failedIssueResumeAttemptsTracked} | cooldowns ${health.runtime.failedIssueResumeCooldownsTracked} | blocked resumes ${blockedIssueResumeCount} | oldest blocked ${formatNullableSeconds(oldestBlockedIssueResumeAgeSeconds)} | escalated ${blockedIssueResumeEscalationCount} | oldest escalation ${formatNullableSeconds(oldestBlockedIssueResumeEscalationAgeSeconds)}`,
+    `pr lineage: warned issues ${prLineage?.warningCount ?? 0} | multi-active ${prLineage?.warningCounts.multiActiveLineage ?? 0} | terminal blocked ${prLineage?.warningCounts.terminalReuseBlocked ?? 0} | superseded ${prLineage?.warningCounts.supersededLineage ?? 0} | missing metadata ${prLineage?.warningCounts.missingMetadata ?? 0} | mismatch blocked ${prLineage?.warningCounts.lineageMismatchBlocked ?? 0}`,
     `auto-upgrade: ${formatAutoUpgradeRuntimeSummary(health.runtime.autoUpgrade ?? null)}`,
     `poll: last ${health.lastPollAt ?? 'never'} | last claim ${health.lastClaimedAt ?? 'never'} | next ${formatNextPollSummary(health.nextPollAt, health.nextPollReason, health.nextPollDelayMs)}`,
   ]
@@ -450,6 +463,9 @@ export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): strin
   }
   if (blockedIssueResumeDetails.length > 0) {
     lines.push(`blocked resumes: ${formatBlockedIssueResumeInlineSummary(blockedIssueResumeDetails)}`)
+  }
+  if ((prLineage?.warnings.length ?? 0) > 0) {
+    lines.push(`pr lineage detail: ${formatPrLineageInlineSummary(prLineage?.warnings ?? [])}`)
   }
   if (snapshot.localRuntime?.launchd) {
     lines.push(`launchd: ${formatLaunchdInlineSummary(snapshot.localRuntime.launchd)}`)
@@ -466,6 +482,7 @@ export function formatStatusReport(snapshot: DaemonObservabilitySnapshot): strin
       `outcomes: polls ${formatOrderedMap(snapshot.metrics.polls, POLL_OUTCOME_ORDER)} | wake ${formatOrderedMap(summarizeWakeOutcomes(snapshot.metrics.wakeRequests), WAKE_OUTCOME_ORDER)} | reviews ${formatOrderedMap(reviewTotals, REVIEW_OUTCOME_ORDER)} | auto-fix ${formatOrderedMap(snapshot.metrics.autoFixes, AUTO_FIX_OUTCOME_ORDER)} | merge ${formatOrderedMap(snapshot.metrics.mergeRecovery, MERGE_RECOVERY_OUTCOME_ORDER)}`,
     )
     lines.push(`github api: ${formatGitHubApiRequestSummary(snapshot.metrics.githubApiRequests)}`)
+    lines.push(`pr-lineage metrics: events ${formatPrLineageMetricSummary(snapshot.metrics.prLineageEvents)} | warnings ${formatPrLineageMetricSummary(snapshot.metrics.prLineageWarnings)}`)
     lines.push(`auto-upgrade metrics: ${formatAutoUpgradeMetricSummary(snapshot.metrics)}`)
     lines.push(
       `wake: pending ${snapshot.metrics.pendingWakeRequests ?? 0} | ${formatWakeRequestSummary(snapshot.metrics.wakeRequests)}`,
@@ -546,6 +563,7 @@ export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): strin
   const blockedIssueResumeDetails = health.runtime.blockedIssueResumeDetails ?? []
   const oldestBlockedIssueResumeAgeSeconds = health.runtime.oldestBlockedIssueResumeAgeSeconds ?? 0
   const oldestBlockedIssueResumeEscalationAgeSeconds = health.runtime.oldestBlockedIssueResumeEscalationAgeSeconds ?? 0
+  const prLineage = health.prLineage ?? null
   const worktreeLines = health.activeWorktrees.length === 0
     ? ['none']
     : health.activeWorktrees.map((worktree) => `#${worktree.issueNumber} ${worktree.branch} ${worktree.path}`)
@@ -577,6 +595,8 @@ export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): strin
         ...REVIEW_STAGE_ORDER.map((stage) => `reviews.${stage}: ${formatOrderedMap(snapshot.metrics?.prReviews[stage] ?? {}, REVIEW_OUTCOME_ORDER)}`),
         `auto-fix: ${formatOrderedMap(snapshot.metrics.autoFixes, AUTO_FIX_OUTCOME_ORDER)}`,
         `merge-recovery: ${formatOrderedMap(snapshot.metrics.mergeRecovery, MERGE_RECOVERY_OUTCOME_ORDER)}`,
+        `pr-lineage-events: ${formatPrLineageMetricSummary(snapshot.metrics.prLineageEvents)}`,
+        `pr-lineage-warnings: ${formatPrLineageMetricSummary(snapshot.metrics.prLineageWarnings)}`,
         `transient-loop-errors: ${formatInlineKeyValue(snapshot.metrics.transientLoopErrors) || 'none'}`,
         `last-transient-loop-error-age-seconds: ${snapshot.metrics.lastTransientLoopErrorAgeSeconds ?? 0}`,
         `next-poll-delay-seconds: ${snapshot.metrics.nextPollDelaySeconds ?? 0}`,
@@ -647,6 +667,8 @@ export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): strin
     `oldest blocked issue resume age: ${formatNullableSeconds(oldestBlockedIssueResumeAgeSeconds)}`,
     `blocked issue resume escalations: ${blockedIssueResumeEscalationCount}`,
     `oldest blocked issue resume escalation age: ${formatNullableSeconds(oldestBlockedIssueResumeEscalationAgeSeconds)}`,
+    `pr lineage warned issues: ${prLineage?.warningCount ?? 0}`,
+    `pr lineage warning counts: multi-active=${prLineage?.warningCounts.multiActiveLineage ?? 0}, terminal-blocked=${prLineage?.warningCounts.terminalReuseBlocked ?? 0}, superseded=${prLineage?.warningCounts.supersededLineage ?? 0}, missing-metadata=${prLineage?.warningCounts.missingMetadata ?? 0}, mismatch-blocked=${prLineage?.warningCounts.lineageMismatchBlocked ?? 0}`,
     `last recovery action: ${formatLastRecovery(health.runtime.lastRecoveryActionKind, health.runtime.lastRecoveryActionAt)}`,
     `failed issue resume attempts tracked: ${health.runtime.failedIssueResumeAttemptsTracked}`,
     `failed issue resume cooldowns tracked: ${health.runtime.failedIssueResumeCooldownsTracked}`,
@@ -668,6 +690,11 @@ export function formatDoctorReport(snapshot: DaemonObservabilitySnapshot): strin
     ...(blockedIssueResumeDetails.length === 0
       ? ['none']
       : blockedIssueResumeDetails.map((blocked) => formatBlockedIssueResumeDoctorLine(blocked))),
+    '',
+    'PR Lineage',
+    ...((prLineage?.warnings.length ?? 0) === 0
+      ? ['none']
+      : summarizePrLineageWarnings(prLineage?.warnings ?? [])),
     '',
     'Recent Recovery Actions',
     ...recoveryHistoryLines,
@@ -811,6 +838,8 @@ export function summarizeDaemonMetrics(metricsText: string): DaemonMetricSummary
     prReviews: {},
     autoFixes: {},
     mergeRecovery: {},
+    prLineageEvents: {},
+    prLineageWarnings: {},
     recoveryActions: {},
     transientLoopErrors: {},
     workerIdleTimeouts: {},
@@ -859,6 +888,12 @@ export function summarizeDaemonMetrics(metricsText: string): DaemonMetricSummary
         break
       case 'agent_loop_pr_merge_recovery_total':
         if (sample.labels.outcome) summary.mergeRecovery[sample.labels.outcome] = sample.value
+        break
+      case 'agent_loop_pr_lineage_events_total':
+        if (sample.labels.kind) summary.prLineageEvents[sample.labels.kind] = sample.value
+        break
+      case 'agent_loop_pr_lineage_warnings':
+        if (sample.labels.kind) summary.prLineageWarnings[sample.labels.kind] = sample.value
         break
       case 'agent_loop_recovery_actions_total':
         if (!sample.labels.kind || !sample.labels.outcome) break
@@ -1073,6 +1108,9 @@ function buildDoctorWarnings(snapshot: DaemonObservabilitySnapshot): string[] {
   if (longBlockedWithoutEscalation.length > 0) {
     warnings.push(`long blocked issue resumes without GitHub escalation: ${longBlockedWithoutEscalation.join(', ')}`)
   }
+  if ((snapshot.health.prLineage?.warningCount ?? 0) > 0) {
+    warnings.push(...summarizePrLineageWarnings(snapshot.health.prLineage?.warnings ?? []))
+  }
   const adoptableLeases = snapshot.health.runtime.activeLeaseDetails.filter((lease) => lease.adoptable)
   if (adoptableLeases.length > 0) {
     warnings.push(`adoptable leases detected: ${adoptableLeases.map((lease) => formatLeaseIdentity(lease.scope, lease.targetNumber)).join(', ')}`)
@@ -1111,6 +1149,9 @@ function buildDoctorWarnings(snapshot: DaemonObservabilitySnapshot): string[] {
   }
   if (((snapshot.metrics?.mergeRecovery.refresh_push_failed ?? 0) + (snapshot.metrics?.mergeRecovery.retry_merge_failed ?? 0)) > 0) {
     warnings.push('merge recovery has recent push/merge retry failures; inspect the latest PR recovery comments')
+  }
+  if (Object.values(snapshot.metrics?.prLineageEvents ?? {}).reduce((sum, value) => sum + value, 0) > 0) {
+    warnings.push(`pr lineage events observed: ${formatPrLineageMetricSummary(snapshot.metrics?.prLineageEvents ?? {})}`)
   }
   if ((snapshot.githubAudit?.prBlockers.length ?? 0) > 0) {
     warnings.push(`open PR review blockers: ${snapshot.githubAudit?.prBlockers.map((blocker) => `pr#${blocker.prNumber}`).join(', ')}`)
@@ -1223,6 +1264,42 @@ function summarizeWakeOutcomes(
   return totals
 }
 
+export function summarizePrLineageWarnings(
+  warnings: PrLineageWarningList | null | undefined,
+): string[] {
+  const messages: string[] = []
+
+  for (const warning of warnings ?? []) {
+    if (warning.activePrNumbers.length > 1) {
+      messages.push(
+        `issue#${warning.issueNumber} has multiple active PR lineages: ${formatPrNumberList(warning.activePrNumbers)}`,
+      )
+    }
+    if (warning.terminalReuseBlockedPrNumbers.length > 0) {
+      messages.push(
+        `issue#${warning.issueNumber} blocked a terminal PR reuse attempt on ${formatPrNumberList(warning.terminalReuseBlockedPrNumbers)}`,
+      )
+    }
+    if (warning.supersededPrNumbers.length > 0) {
+      messages.push(
+        `issue#${warning.issueNumber} has superseded PR lineages: ${formatPrNumberList(warning.supersededPrNumbers)}`,
+      )
+    }
+    if (warning.missingMetadataPrNumbers.length > 0) {
+      messages.push(
+        `issue#${warning.issueNumber} has PR lineage metadata missing or invalid on ${formatPrNumberList(warning.missingMetadataPrNumbers)}`,
+      )
+    }
+    if (warning.lineageMismatchBlockedPrNumbers.length > 0) {
+      messages.push(
+        `issue#${warning.issueNumber} blocked PR lineage mismatch on ${formatPrNumberList(warning.lineageMismatchBlockedPrNumbers)}`,
+      )
+    }
+  }
+
+  return messages
+}
+
 function formatGitHubApiRequestKey(transport: string, mode: string): string {
   return `${transport}/${mode}`
 }
@@ -1240,6 +1317,10 @@ function formatOrderedMap(
   order: readonly string[],
 ): string {
   return order.map((key) => `${key}=${values[key] ?? 0}`).join(', ')
+}
+
+function formatPrNumberList(prNumbers: number[]): string {
+  return prNumbers.map((prNumber) => `pr#${prNumber}`).join(', ')
 }
 
 function formatBoolean(value: boolean): string {
@@ -1318,6 +1399,40 @@ function formatGitHubApiRequestSummary(values: Record<string, Record<string, num
     .map((key) => `${key}[${formatOrderedMap(values[key] ?? {}, GITHUB_API_OUTCOME_ORDER)}]`)
 
   return parts.join(', ') || 'none'
+}
+
+function formatPrLineageMetricSummary(values: Record<string, number>): string {
+  return formatOrderedMap(values, PR_LINEAGE_KIND_ORDER)
+}
+
+function formatPrLineageInlineSummary(
+  warnings: NonNullable<DaemonHealthPayload['prLineage']>['warnings'],
+): string {
+  const rendered = warnings.slice(0, 3).map((warning) => {
+    const parts = [`issue#${warning.issueNumber}`]
+    if (warning.activePrNumbers.length > 0) {
+      parts.push(`active ${formatPrNumberList(warning.activePrNumbers)}`)
+    }
+    if (warning.supersededPrNumbers.length > 0) {
+      parts.push(`superseded ${formatPrNumberList(warning.supersededPrNumbers)}`)
+    }
+    if (warning.terminalReuseBlockedPrNumbers.length > 0) {
+      parts.push(`terminal ${formatPrNumberList(warning.terminalReuseBlockedPrNumbers)}`)
+    }
+    if (warning.missingMetadataPrNumbers.length > 0) {
+      parts.push(`missing-metadata ${formatPrNumberList(warning.missingMetadataPrNumbers)}`)
+    }
+    if (warning.lineageMismatchBlockedPrNumbers.length > 0) {
+      parts.push(`mismatch ${formatPrNumberList(warning.lineageMismatchBlockedPrNumbers)}`)
+    }
+    return parts.join(' | ')
+  })
+
+  if (warnings.length > 3) {
+    rendered.push(`+${warnings.length - 3} more`)
+  }
+
+  return rendered.join(' | ')
 }
 
 function countGitHubApiOutcomes(

--- a/apps/agent-daemon/src/subtask-executor.test.ts
+++ b/apps/agent-daemon/src/subtask-executor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'bun:test'
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { AgentConfig } from '@agent/shared'
@@ -58,12 +58,29 @@ const TEST_CONFIG: AgentConfig = {
 }
 
 const tempDirs: string[] = []
+const spawnedPids: number[] = []
 
 afterEach(() => {
+  for (const pid of spawnedPids.splice(0)) {
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch {
+      // Process already exited.
+    }
+  }
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true })
   }
 })
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
 
 async function createGitRepo(): Promise<string> {
   const dir = mkdtempSync(join(tmpdir(), 'subtask-executor-test-'))
@@ -429,5 +446,69 @@ describe('runIssueBranchPreflight', () => {
         process.env.HOME = previousHome
       }
     }
+  })
+
+  it('kills timed out validation command process trees so preflight returns cleanly', async () => {
+    const dir = await createGitRepo()
+    await Bun.$`git -C ${dir} checkout -b agent/test`.quiet()
+    writeFileSync(join(dir, 'demo.txt'), 'after\n', 'utf-8')
+    await Bun.$`git -C ${dir} add demo.txt`.quiet()
+    await Bun.$`git -C ${dir} commit -m "feat: demo"`.quiet()
+
+    const scriptDir = mkdtempSync(join(tmpdir(), 'subtask-executor-timeout-'))
+    tempDirs.push(scriptDir)
+    const scriptPath = join(scriptDir, 'hang-validation.js')
+    const pidPath = join(scriptDir, 'validation.pid')
+
+    writeFileSync(
+      scriptPath,
+      `const fs = require('node:fs')
+fs.writeFileSync(process.argv[2], String(process.pid))
+setInterval(() => {}, 1000)
+`,
+      'utf-8',
+    )
+
+    const config: AgentConfig = {
+      ...TEST_CONFIG,
+      recovery: {
+        ...TEST_CONFIG.recovery,
+        workerIdleTimeoutMs: 200,
+      },
+    }
+
+    const preflightPromise = runIssueBranchPreflight(
+      dir,
+      `## Context
+### AllowedFiles
+- demo.txt
+### Validation
+- \`node ${JSON.stringify(scriptPath)} ${JSON.stringify(pidPath)}\``,
+      config,
+    )
+    const outcome = await Promise.race([
+      preflightPromise,
+      Bun.sleep(4_000).then(() => 'timeout' as const),
+    ])
+
+    if (outcome === 'timeout') {
+      if (existsSync(pidPath)) {
+        const pid = Number(readFileSync(pidPath, 'utf-8').trim())
+        if (Number.isInteger(pid) && pid > 0) {
+          spawnedPids.push(pid)
+        }
+      }
+      throw new Error('runIssueBranchPreflight did not return after timing out the validation command')
+    }
+
+    expect(outcome.valid).toBe(false)
+    expect(outcome.validationFailures).toHaveLength(1)
+    expect(outcome.validationFailures[0]?.timedOut).toBe(true)
+
+    const pid = Number(readFileSync(pidPath, 'utf-8').trim())
+    expect(pid).toBeGreaterThan(0)
+    spawnedPids.push(pid)
+    await Bun.sleep(100)
+    expect(isProcessAlive(pid)).toBe(false)
   })
 })

--- a/apps/agent-daemon/src/subtask-executor.ts
+++ b/apps/agent-daemon/src/subtask-executor.ts
@@ -13,6 +13,7 @@ import {
   type Subtask,
 } from '@agent/shared'
 import { runConfiguredAgent, type AgentFailureKind, type TaskExecutionMonitor } from './cli-agent'
+import { DETACH_PROCESS_GROUP, killProcessTree } from './process-tree'
 
 const PLANNING_TIMEOUT_MS = 2 * 60 * 1000 // 2 minutes for planning
 
@@ -605,8 +606,10 @@ export async function runIssueBranchPreflight(
 
   for (const command of executableValidationCommands) {
     monitor?.setPhase?.(`preflight:${command.slice(0, 48)}`)
-    const result = await runValidationCommand(worktreePath, command, config)
-    await monitor?.agentMonitor?.onActivity?.(result.stderr ? 'stderr' : 'stdout')
+    const result = await runValidationCommand(worktreePath, command, config, monitor)
+    if (!result.timedOut) {
+      await monitor?.agentMonitor?.onActivity?.(result.stderr ? 'stderr' : 'stdout')
+    }
 
     if (result.exitCode !== 0) {
       validationFailures.push(result)
@@ -689,6 +692,7 @@ async function runValidationCommand(
   worktreePath: string,
   command: string,
   config: AgentConfig,
+  monitor?: TaskExecutionMonitor,
 ): Promise<IssueBranchValidationCommandResult> {
   const env: Record<string, string> = {
     ...process.env,
@@ -709,6 +713,7 @@ async function runValidationCommand(
 
   const proc = Bun.spawn(['/bin/sh', '-c', command], {
     cwd: worktreePath,
+    detached: DETACH_PROCESS_GROUP,
     env,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -717,12 +722,16 @@ async function runValidationCommand(
   let timedOut = false
   const timeout = setTimeout(() => {
     timedOut = true
-    proc.kill()
+    killProcessTree(proc)
   }, config.recovery.workerIdleTimeoutMs)
 
   const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
+    readValidationStream(proc.stdout, () => {
+      void monitor?.agentMonitor?.onActivity?.('stdout')
+    }),
+    readValidationStream(proc.stderr, () => {
+      void monitor?.agentMonitor?.onActivity?.('stderr')
+    }),
   ])
   const exitCode = await proc.exited
   clearTimeout(timeout)
@@ -734,6 +743,32 @@ async function runValidationCommand(
     stderr,
     timedOut,
   }
+}
+
+async function readValidationStream(
+  stream: ReadableStream<Uint8Array>,
+  onChunk: () => void,
+): Promise<string> {
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (!value) continue
+    chunks.push(value)
+    onChunk()
+  }
+
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0)
+  const merged = new Uint8Array(totalLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return new TextDecoder().decode(merged)
 }
 
 function summarizeValidationFailureOutput(stdout: string, stderr: string): string {

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -18,6 +18,8 @@ import {
   fetchIssueBodySnapshot,
   getLatestManagedLease,
   getManagedPullRequestByNumber,
+  getPullRequestChecksStatus,
+  interpretPullRequestChecksResult,
   isGraphQlRateLimitErrorMessage,
   isManagedLeaseExpired,
   isManagedLeaseProgressStale,
@@ -431,6 +433,76 @@ describe('parseMergePrResponse', () => {
       message: 'Pull Request is not mergeable',
       sha: undefined,
     })
+  })
+})
+
+describe('interpretPullRequestChecksResult', () => {
+  test('treats failing checks as a merge blocker', () => {
+    expect(interpretPullRequestChecksResult({
+      stdout: 'build-and-test\tfail\t2m46s\thttps://example.test/run/1',
+      stderr: '',
+      exitCode: 1,
+      timedOut: false,
+    })).toEqual({
+      state: 'fail',
+      summary: 'build-and-test is fail',
+    })
+  })
+
+  test('treats pending checks as not ready yet', () => {
+    expect(interpretPullRequestChecksResult({
+      stdout: 'build-and-test\tpending\t0\thttps://example.test/run/1',
+      stderr: '',
+      exitCode: 8,
+      timedOut: false,
+    })).toEqual({
+      state: 'pending',
+      summary: 'build-and-test is pending',
+    })
+  })
+
+  test('allows merge when GitHub reports that no checks exist', () => {
+    expect(interpretPullRequestChecksResult({
+      stdout: "no checks reported on the 'agent/350/codex-dev-r1' branch",
+      stderr: '',
+      exitCode: 1,
+      timedOut: false,
+    })).toEqual({
+      state: 'pass',
+      summary: 'No checks reported',
+    })
+  })
+})
+
+describe('getPullRequestChecksStatus', () => {
+  test('runs gh pr checks against the configured repository', async () => {
+    const calls: Array<{ args: string[]; pat: string }> = []
+
+    const status = await getPullRequestChecksStatus(
+      390,
+      {
+        repo: 'JamesWuHK/agent-loop',
+        pat: 'test-token',
+      } as never,
+      async (args, config) => {
+        calls.push({ args, pat: config.pat })
+        return {
+          stdout: 'build-and-test\tpass\t2m43s\thttps://example.test/run/1',
+          stderr: '',
+          exitCode: 0,
+          timedOut: false,
+        }
+      },
+    )
+
+    expect(status).toEqual({
+      state: 'pass',
+      summary: '1 check(s) passed',
+    })
+    expect(calls).toEqual([{
+      args: ['pr', 'checks', '390', '-R', 'JamesWuHK/agent-loop'],
+      pat: 'test-token',
+    }])
   })
 })
 

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -15,6 +15,7 @@ import {
   extractOpenIssueConnectionPage,
   extractManagedLeaseComment,
   getActiveManagedLease,
+  fetchIssueBodySnapshot,
   getLatestManagedLease,
   isGraphQlRateLimitErrorMessage,
   isManagedLeaseExpired,
@@ -29,6 +30,7 @@ import {
   selectActivePullRequestForBranch,
   sortClaimableIssuesForScheduling,
   shouldClearIssueAssigneesForStateLabel,
+  updateIssueBody,
 } from './github-api'
 import { ISSUE_LABELS, ISSUE_PRIORITY_LABELS, type AgentConfig, type AgentIssue } from './types'
 
@@ -220,6 +222,90 @@ describe('ghApiRaw', () => {
       expect((observations[0]?.durationMs ?? 0) >= 0).toBe(true)
     } finally {
       setGitHubApiRequestObserver(null)
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+describe('issue body helpers', () => {
+  test('fetches an issue body snapshot through the shared GitHub API helper', async () => {
+    const originalFetch = globalThis.fetch
+    const config = {
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+    } as AgentConfig
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+
+      expect(url).toBe('https://api.github.com/repos/JamesWuHK/agent-loop/issues/54')
+
+      return new Response(JSON.stringify({
+        number: 54,
+        title: '[AL-14] apply',
+        body: 'remote markdown',
+        html_url: 'https://github.com/JamesWuHK/agent-loop/issues/54',
+        updated_at: '2026-04-12T08:00:00.000Z',
+      }), { status: 200 })
+    }) as typeof fetch
+
+    try {
+      await expect(fetchIssueBodySnapshot(54, config)).resolves.toEqual({
+        number: 54,
+        title: '[AL-14] apply',
+        body: 'remote markdown',
+        url: 'https://github.com/JamesWuHK/agent-loop/issues/54',
+        updatedAt: '2026-04-12T08:00:00.000Z',
+      })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test('updates an issue body through the shared GitHub API helper', async () => {
+    const originalFetch = globalThis.fetch
+    const config = {
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+    } as AgentConfig
+
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+
+      expect(url).toBe('https://api.github.com/repos/JamesWuHK/agent-loop/issues/54')
+      expect(init?.method).toBe('PATCH')
+      expect(JSON.parse(String(init?.body))).toEqual({
+        body: '## 用户故事\npatched markdown',
+      })
+
+      return new Response(JSON.stringify({
+        number: 54,
+        title: '[AL-14] apply',
+        body: '## 用户故事\npatched markdown',
+        html_url: 'https://github.com/JamesWuHK/agent-loop/issues/54',
+        updated_at: '2026-04-12T08:06:00.000Z',
+      }), { status: 200 })
+    }) as typeof fetch
+
+    try {
+      await expect(updateIssueBody(
+        54,
+        '## 用户故事\npatched markdown',
+        config,
+      )).resolves.toEqual({
+        number: 54,
+        url: 'https://github.com/JamesWuHK/agent-loop/issues/54',
+        updatedAt: '2026-04-12T08:06:00.000Z',
+      })
+    } finally {
       globalThis.fetch = originalFetch
     }
   })

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -26,6 +26,7 @@ import {
   qualifyGhApiArgs,
   ghApiRaw,
   setGitHubApiRequestObserver,
+  selectActivePullRequestForBranch,
   sortClaimableIssuesForScheduling,
   shouldClearIssueAssigneesForStateLabel,
 } from './github-api'
@@ -435,6 +436,54 @@ describe('derivePullRequestStateFromRaw', () => {
 
   test('returns closed when a closed pull request has not merged', () => {
     expect(derivePullRequestStateFromRaw('closed', null)).toBe('closed')
+  })
+})
+
+describe('selectActivePullRequestForBranch', () => {
+  test('prefers an open PR over historical terminal matches for the same branch', () => {
+    expect(selectActivePullRequestForBranch('agent/37/codex-dev', [
+      {
+        number: 45,
+        state: 'closed',
+        merged_at: null,
+        html_url: 'https://example.test/pr/45',
+        head: { ref: 'agent/37/codex-dev' },
+      },
+      {
+        number: 78,
+        state: 'open',
+        merged_at: null,
+        html_url: 'https://example.test/pr/78',
+        head: { ref: 'agent/37/codex-dev' },
+      },
+    ])).toEqual({
+      prNumber: 78,
+      prUrl: 'https://example.test/pr/78',
+      prState: 'open',
+    })
+  })
+
+  test('falls back to the latest terminal PR when no open PR exists', () => {
+    expect(selectActivePullRequestForBranch('agent/37/codex-dev', [
+      {
+        number: 45,
+        state: 'closed',
+        merged_at: null,
+        html_url: 'https://example.test/pr/45',
+        head: { ref: 'agent/37/codex-dev' },
+      },
+      {
+        number: 49,
+        state: 'closed',
+        merged_at: '2026-04-12T01:00:00Z',
+        html_url: 'https://example.test/pr/49',
+        head: { ref: 'agent/37/codex-dev' },
+      },
+    ])).toEqual({
+      prNumber: 49,
+      prUrl: 'https://example.test/pr/49',
+      prState: 'merged',
+    })
   })
 })
 

--- a/packages/agent-shared/src/github-api.test.ts
+++ b/packages/agent-shared/src/github-api.test.ts
@@ -17,6 +17,7 @@ import {
   getActiveManagedLease,
   fetchIssueBodySnapshot,
   getLatestManagedLease,
+  getManagedPullRequestByNumber,
   isGraphQlRateLimitErrorMessage,
   isManagedLeaseExpired,
   isManagedLeaseProgressStale,
@@ -305,6 +306,88 @@ describe('issue body helpers', () => {
         url: 'https://github.com/JamesWuHK/agent-loop/issues/54',
         updatedAt: '2026-04-12T08:06:00.000Z',
       })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+describe('getManagedPullRequestByNumber', () => {
+  test('returns null for closed managed PRs so automation does not target terminal lineage', async () => {
+    const originalFetch = globalThis.fetch
+    const config = {
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+    } as AgentConfig
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+
+      expect(url).toBe('https://api.github.com/repos/JamesWuHK/agent-loop/pulls/386')
+
+      return new Response(JSON.stringify({
+        number: 386,
+        title: '[AL-24] stale closed PR',
+        html_url: 'https://github.com/JamesWuHK/agent-loop/pull/386',
+        state: 'closed',
+        merged_at: null,
+        draft: false,
+        head: {
+          ref: 'agent/83/codex-dev',
+          sha: 'abc123',
+        },
+        labels: [
+          { name: 'agent:retry' },
+        ],
+      }), { status: 200 })
+    }) as typeof fetch
+
+    try {
+      await expect(getManagedPullRequestByNumber(386, config)).resolves.toBeNull()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test('returns null for merged managed PRs so automation does not target terminal lineage', async () => {
+    const originalFetch = globalThis.fetch
+    const config = {
+      repo: 'JamesWuHK/agent-loop',
+      pat: 'ghp_test',
+    } as AgentConfig
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+
+      expect(url).toBe('https://api.github.com/repos/JamesWuHK/agent-loop/pulls/387')
+
+      return new Response(JSON.stringify({
+        number: 387,
+        title: '[AL-24] merged PR',
+        html_url: 'https://github.com/JamesWuHK/agent-loop/pull/387',
+        state: 'closed',
+        merged_at: '2026-04-12T09:00:00.000Z',
+        draft: false,
+        head: {
+          ref: 'agent/83/codex-dev',
+          sha: 'def456',
+        },
+        labels: [
+          { name: 'agent:approved' },
+        ],
+      }), { status: 200 })
+    }) as typeof fetch
+
+    try {
+      await expect(getManagedPullRequestByNumber(387, config)).resolves.toBeNull()
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -1337,6 +1337,15 @@ export interface SelectedPullRequestForBranch {
   prState: 'open' | 'merged' | 'closed'
 }
 
+export interface BranchPullRequestRecord {
+  number: number
+  prUrl: string | null
+  prState: 'open' | 'merged' | 'closed'
+  headRefName: string
+  baseRefName: string | null
+  body: string | null
+}
+
 export interface MergePrResult {
   merged: boolean
   message: string
@@ -1357,12 +1366,16 @@ interface RawRestPullRequest {
   number?: number
   title?: string
   html_url?: string
+  body?: string | null
   state?: string
   merged_at?: string | null
   draft?: boolean
   head?: {
     ref?: string
     sha?: string
+  }
+  base?: {
+    ref?: string
   }
   labels?: Array<{ name?: string }>
 }
@@ -1453,6 +1466,23 @@ export function selectActivePullRequestForBranch(
     })
 
   return matchingPullRequests[0] ?? null
+}
+
+function mapRawBranchPullRequestRecord(pr: RawRestPullRequest): BranchPullRequestRecord | null {
+  if (typeof pr.number !== 'number') return null
+  if (typeof pr.head?.ref !== 'string') return null
+
+  const prState = derivePullRequestStateFromRaw(pr.state, pr.merged_at ?? null)
+  if (prState === null) return null
+
+  return {
+    number: pr.number,
+    prUrl: typeof pr.html_url === 'string' ? pr.html_url : null,
+    prState,
+    headRefName: pr.head.ref,
+    baseRefName: typeof pr.base?.ref === 'string' ? pr.base.ref : null,
+    body: typeof pr.body === 'string' ? pr.body : null,
+  }
 }
 
 function mapRawRestPullRequest(pr: RawRestPullRequest): ManagedPullRequest | null {
@@ -1730,6 +1760,27 @@ export async function checkPrExists(
   return checkPrExistsRest(branch, config)
 }
 
+export async function listBranchPullRequests(
+  branch: string,
+  config: AgentConfig,
+): Promise<BranchPullRequestRecord[]> {
+  const [owner] = config.repo.split('/')
+  const endpoint = `repos/${config.repo}/pulls?state=all&head=${encodeURIComponent(`${owner}:${branch}`)}&per_page=100`
+  const { stdout, exitCode, stderr } = await ghApiRaw([endpoint], config)
+
+  if (exitCode !== 0) {
+    throw new GhError(
+      `api pulls?state=all&head=${branch}`,
+      exitCode,
+      parseGhApiErrorMessage(stdout, stderr),
+    )
+  }
+
+  return extractRestPullRequestListPage(JSON.parse(stdout))
+    .map(mapRawBranchPullRequestRecord)
+    .filter((pullRequest): pullRequest is BranchPullRequestRecord => pullRequest !== null)
+}
+
 export async function listOpenAgentPullRequests(
   config: AgentConfig,
 ): Promise<ManagedPullRequest[]> {
@@ -1820,6 +1871,27 @@ export async function commentOnPr(
 
   if (exitCode !== 0) {
     throw new GhError(`pr comment ${prNumber}`, exitCode, stderr)
+  }
+}
+
+export async function closePullRequest(
+  prNumber: number,
+  config: AgentConfig,
+): Promise<void> {
+  const response = await withTempJsonFile(
+    'agent-loop-pr-close',
+    { state: 'closed' },
+    async (path) => ghApiRaw([
+      `repos/${config.repo}/issues/${prNumber}`,
+      '-X',
+      'PATCH',
+      '--input',
+      path,
+    ], config),
+  )
+
+  if (response.exitCode !== 0) {
+    throw new GhError(`api issues/${prNumber} close`, response.exitCode, parseGhApiErrorMessage(response.stdout, response.stderr))
   }
 }
 

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -798,9 +798,24 @@ interface RawRestGitHubIssue {
   body?: string | null
   state?: string
   updated_at?: string
+  html_url?: string
   labels?: Array<{ name?: string }>
   assignees?: Array<{ login?: string }>
   pull_request?: unknown
+}
+
+export interface IssueBodySnapshot {
+  number: number
+  title: string
+  body: string
+  url: string
+  updatedAt: string
+}
+
+export interface IssueBodyUpdateResult {
+  number: number
+  url: string
+  updatedAt: string
 }
 
 export function deriveIssueStateFromRaw(
@@ -869,6 +884,19 @@ function mapRawRestIssue(issue: RawRestGitHubIssue): AgentIssue | null {
     claimBlockedBy: [],
     hasExecutableContract: contractValidation.valid,
     contractValidationErrors: contractValidation.errors,
+  }
+}
+
+function mapRawIssueBodySnapshot(
+  issue: RawRestGitHubIssue,
+  fallbackIssueNumber: number,
+): IssueBodySnapshot {
+  return {
+    number: typeof issue.number === 'number' ? issue.number : fallbackIssueNumber,
+    title: typeof issue.title === 'string' ? issue.title : '',
+    body: typeof issue.body === 'string' ? issue.body : '',
+    url: typeof issue.html_url === 'string' ? issue.html_url : '',
+    updatedAt: typeof issue.updated_at === 'string' ? issue.updated_at : '',
   }
 }
 
@@ -1032,6 +1060,58 @@ export async function getAgentIssueByNumber(
   config: AgentConfig,
 ): Promise<AgentIssue | null> {
   return fetchIssuesByNumbers([issueNumber], config).then((issues) => issues.get(issueNumber) ?? null)
+}
+
+export async function fetchIssueBodySnapshot(
+  issueNumber: number,
+  config: AgentConfig,
+): Promise<IssueBodySnapshot> {
+  const { stdout, exitCode, stderr } = await ghApiRaw([
+    `repos/${config.repo}/issues/${issueNumber}`,
+  ], config)
+
+  if (exitCode !== 0) {
+    throw new GhError(
+      `api issues/${issueNumber}`,
+      exitCode,
+      parseGhApiErrorMessage(stdout, stderr),
+    )
+  }
+
+  return mapRawIssueBodySnapshot(JSON.parse(stdout) as RawRestGitHubIssue, issueNumber)
+}
+
+export async function updateIssueBody(
+  issueNumber: number,
+  body: string,
+  config: AgentConfig,
+): Promise<IssueBodyUpdateResult> {
+  const response = await withTempJsonFile(
+    'agent-loop-issue-body-update',
+    { body },
+    async (path) => ghApiRaw([
+      `repos/${config.repo}/issues/${issueNumber}`,
+      '-X',
+      'PATCH',
+      '--input',
+      path,
+    ], config),
+  )
+
+  if (response.exitCode !== 0) {
+    throw new GhError(
+      `api issues/${issueNumber} update body`,
+      response.exitCode,
+      parseGhApiErrorMessage(response.stdout, response.stderr),
+    )
+  }
+
+  const updated = mapRawIssueBodySnapshot(JSON.parse(response.stdout) as RawRestGitHubIssue, issueNumber)
+  return {
+    number: updated.number,
+    url: updated.url,
+    updatedAt: updated.updatedAt,
+  }
 }
 
 async function enrichClaimability(

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -1321,6 +1321,22 @@ export interface PrCheckResult {
   prState: 'open' | 'merged' | 'closed' | null
 }
 
+export interface PullRequestBranchLookupCandidate {
+  number?: number
+  html_url?: string
+  state?: string
+  merged_at?: string | null
+  head?: {
+    ref?: string
+  }
+}
+
+export interface SelectedPullRequestForBranch {
+  prNumber: number
+  prUrl: string | null
+  prState: 'open' | 'merged' | 'closed'
+}
+
 export interface MergePrResult {
   merged: boolean
   message: string
@@ -1411,6 +1427,34 @@ export function extractRestPullRequest(data: unknown): RawRestPullRequest | null
     : null
 }
 
+export function selectActivePullRequestForBranch(
+  branch: string,
+  pullRequests: PullRequestBranchLookupCandidate[],
+): SelectedPullRequestForBranch | null {
+  const matchingPullRequests = pullRequests
+    .map((pullRequest) => {
+      if (typeof pullRequest.number !== 'number') return null
+      if (typeof pullRequest.head?.ref !== 'string' || pullRequest.head.ref !== branch) return null
+
+      const prState = derivePullRequestStateFromRaw(pullRequest.state, pullRequest.merged_at ?? null)
+      if (prState === null) return null
+
+      return {
+        prNumber: pullRequest.number,
+        prUrl: typeof pullRequest.html_url === 'string' ? pullRequest.html_url : null,
+        prState,
+      } satisfies SelectedPullRequestForBranch
+    })
+    .filter((pullRequest): pullRequest is SelectedPullRequestForBranch => pullRequest !== null)
+    .sort((left, right) => {
+      const stateDelta = Number(left.prState !== 'open') - Number(right.prState !== 'open')
+      if (stateDelta !== 0) return stateDelta
+      return right.prNumber - left.prNumber
+    })
+
+  return matchingPullRequests[0] ?? null
+}
+
 function mapRawRestPullRequest(pr: RawRestPullRequest): ManagedPullRequest | null {
   if (typeof pr.number !== 'number') return null
   if (typeof pr.title !== 'string') return null
@@ -1445,15 +1489,15 @@ async function checkPrExistsRest(
   }
 
   const data = extractRestPullRequestListPage(JSON.parse(stdout))
-  if (data.length === 0) {
+  const selected = selectActivePullRequestForBranch(branch, data)
+  if (selected === null) {
     return { prNumber: null, prUrl: null, prState: null }
   }
 
-  const pr = data[0]!
   return {
-    prNumber: typeof pr.number === 'number' ? pr.number : null,
-    prUrl: typeof pr.html_url === 'string' ? pr.html_url : null,
-    prState: derivePullRequestStateFromRaw(pr.state, pr.merged_at ?? null),
+    prNumber: selected.prNumber,
+    prUrl: selected.prUrl,
+    prState: selected.prState,
   }
 }
 

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -1666,7 +1666,11 @@ async function getManagedPullRequestByNumberRest(
     )
   }
 
-  const mapped = mapRawRestPullRequest(extractRestPullRequest(JSON.parse(stdout)) ?? {})
+  const rawPullRequest = extractRestPullRequest(JSON.parse(stdout)) ?? {}
+  const prState = derivePullRequestStateFromRaw(rawPullRequest.state, rawPullRequest.merged_at ?? null)
+  if (prState !== 'open') return null
+
+  const mapped = mapRawRestPullRequest(rawPullRequest)
   if (!mapped) return null
   if (!mapped.headRefName.startsWith('agent/')) return null
   return mapped

--- a/packages/agent-shared/src/github-api.ts
+++ b/packages/agent-shared/src/github-api.ts
@@ -1426,10 +1426,110 @@ export interface BranchPullRequestRecord {
   body: string | null
 }
 
+export interface PullRequestChecksStatus {
+  state: 'pass' | 'pending' | 'fail' | 'error'
+  summary: string
+}
+
 export interface MergePrResult {
   merged: boolean
   message: string
   sha?: string
+}
+
+const PASSING_PR_CHECK_STATES = new Set(['pass', 'success', 'neutral', 'skipping', 'skipped'])
+const PENDING_PR_CHECK_STATES = new Set(['pending', 'queued', 'waiting', 'in_progress'])
+const FAILING_PR_CHECK_STATES = new Set([
+  'fail',
+  'failure',
+  'failing',
+  'cancel',
+  'cancelled',
+  'timed_out',
+  'startup_failure',
+  'action_required',
+  'error',
+])
+
+function parsePullRequestChecksRows(stdout: string): Array<{ name: string; state: string }> {
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split('\t'))
+    .filter((parts) => parts.length >= 2)
+    .map((parts) => ({
+      name: parts[0]?.trim() ?? '',
+      state: parts[1]?.trim().toLowerCase() ?? '',
+    }))
+    .filter((row) => row.name.length > 0 && row.state.length > 0)
+}
+
+function formatPullRequestChecksError(result: Pick<GhCommandResult, 'stdout' | 'stderr' | 'exitCode' | 'timedOut'>): string {
+  const stdout = result.stdout.trim()
+  const stderr = result.stderr.trim()
+
+  if (result.timedOut) {
+    return stderr || stdout || 'gh pr checks timed out'
+  }
+
+  return stderr || stdout || `gh pr checks exited with code ${result.exitCode}`
+}
+
+export function interpretPullRequestChecksResult(
+  result: Pick<GhCommandResult, 'stdout' | 'stderr' | 'exitCode' | 'timedOut'>,
+): PullRequestChecksStatus {
+  const stdout = result.stdout.trim()
+
+  if (/no checks reported/i.test(stdout)) {
+    return {
+      state: 'pass',
+      summary: 'No checks reported',
+    }
+  }
+
+  const rows = parsePullRequestChecksRows(stdout)
+  const firstFailing = rows.find((row) => FAILING_PR_CHECK_STATES.has(row.state))
+  if (firstFailing) {
+    return {
+      state: 'fail',
+      summary: `${firstFailing.name} is ${firstFailing.state}`,
+    }
+  }
+
+  const firstPending = rows.find((row) => PENDING_PR_CHECK_STATES.has(row.state))
+  if (firstPending) {
+    return {
+      state: 'pending',
+      summary: `${firstPending.name} is ${firstPending.state}`,
+    }
+  }
+
+  if (rows.length > 0 && rows.every((row) => PASSING_PR_CHECK_STATES.has(row.state))) {
+    return {
+      state: 'pass',
+      summary: `${rows.length} check(s) passed`,
+    }
+  }
+
+  if (result.exitCode !== 0 || result.timedOut) {
+    return {
+      state: 'error',
+      summary: formatPullRequestChecksError(result),
+    }
+  }
+
+  if (rows.length > 0) {
+    return {
+      state: 'pass',
+      summary: `${rows.length} check(s) passed`,
+    }
+  }
+
+  return {
+    state: 'error',
+    summary: formatPullRequestChecksError(result),
+  }
 }
 
 interface RawPullRequestListItem {
@@ -2053,6 +2153,18 @@ export async function mergePullRequest(
   }
 
   return parseMergePrResponse(stdout)
+}
+
+export async function getPullRequestChecksStatus(
+  prNumber: number,
+  config: Pick<AgentConfig, 'repo' | 'pat'>,
+  runner: (
+    args: string[],
+    config: Pick<AgentConfig, 'repo' | 'pat'>,
+  ) => Promise<Pick<GhCommandResult, 'stdout' | 'stderr' | 'exitCode' | 'timedOut'>> = runBoundedGhCommand,
+): Promise<PullRequestChecksStatus> {
+  const result = await runner(['pr', 'checks', String(prNumber), '-R', config.repo], config)
+  return interpretPullRequestChecksResult(result)
 }
 
 export async function addPrLabels(

--- a/packages/agent-shared/src/index.ts
+++ b/packages/agent-shared/src/index.ts
@@ -1,6 +1,12 @@
 export * from './types'
 export * from './state-machine'
 export * from './github-api'
+export {
+  getPullRequestChecksStatus,
+  interpretPullRequestChecksResult,
+  parseMergePrResponse,
+  type PullRequestChecksStatus,
+} from './github-api'
 export * from './subtask-parser'
 export * from './issue-contract'
 export * from './issue-contract-validator'

--- a/packages/agent-shared/src/project-profile.test.ts
+++ b/packages/agent-shared/src/project-profile.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test'
-import { getProjectPromptGuidance } from './project-profile'
+import {
+  getProjectIssueAuthoringRules,
+  getProjectPromptGuidance,
+} from './project-profile'
 
 describe('getProjectPromptGuidance', () => {
   it('defaults to generic guidance when no project profile is configured', () => {
@@ -25,5 +28,45 @@ describe('getProjectPromptGuidance', () => {
     }, 'implementation')
 
     expect(guidance.at(-1)).toBe('Run `pytest` instead of inventing a JS harness.')
+  })
+
+  it('normalizes project issue authoring rules while preserving deterministic order', () => {
+    const rules = getProjectIssueAuthoringRules({
+      profile: 'generic',
+      issueAuthoring: {
+        preferredValidationCommands: [
+          'bun test apps/agent-daemon/src/issue-repair.test.ts',
+          'bun test apps/agent-daemon/src/issue-repair.test.ts',
+          '  ',
+        ],
+        preferredAllowedFiles: [
+          'apps/agent-daemon/src/issue-repair.ts',
+          'apps/agent-daemon/src/issue-repair.test.ts',
+        ],
+        forbiddenPaths: [
+          'apps/agent-daemon/src/dashboard.ts',
+          'apps/agent-daemon/src/dashboard.ts',
+        ],
+        reviewHints: [
+          '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+        ],
+      },
+    })
+
+    expect(rules).toEqual({
+      preferredValidationCommands: [
+        'bun test apps/agent-daemon/src/issue-repair.test.ts',
+      ],
+      preferredAllowedFiles: [
+        'apps/agent-daemon/src/issue-repair.ts',
+        'apps/agent-daemon/src/issue-repair.test.ts',
+      ],
+      forbiddenPaths: [
+        'apps/agent-daemon/src/dashboard.ts',
+      ],
+      reviewHints: [
+        '优先检查 repair 流程是否保留合法的 Dependencies JSON',
+      ],
+    })
   })
 })

--- a/packages/agent-shared/src/project-profile.ts
+++ b/packages/agent-shared/src/project-profile.ts
@@ -1,4 +1,5 @@
 import type {
+  ProjectIssueAuthoringRules,
   ProjectProfileConfig,
   ProjectProfileName,
   ProjectPromptContext,
@@ -45,3 +46,27 @@ export function getProjectPromptGuidance(
   return [...builtin, ...overrides]
 }
 
+export function getProjectIssueAuthoringRules(
+  project: ProjectProfileConfig | undefined,
+): Required<ProjectIssueAuthoringRules> {
+  return {
+    preferredValidationCommands: uniqueStrings(project?.issueAuthoring?.preferredValidationCommands ?? []),
+    preferredAllowedFiles: uniqueStrings(project?.issueAuthoring?.preferredAllowedFiles ?? []),
+    forbiddenPaths: uniqueStrings(project?.issueAuthoring?.forbiddenPaths ?? []),
+    reviewHints: uniqueStrings(project?.issueAuthoring?.reviewHints ?? []),
+  }
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>()
+  const normalized: string[] = []
+
+  for (const value of values) {
+    const trimmed = value.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    normalized.push(trimmed)
+  }
+
+  return normalized
+}

--- a/packages/agent-shared/src/state-machine.test.ts
+++ b/packages/agent-shared/src/state-machine.test.ts
@@ -87,7 +87,7 @@ describe('parseClaimEventComment', () => {
 })
 
 describe('resolveActiveClaimMachine', () => {
-  it('keeps the earliest claimant as active owner until a reset event occurs', () => {
+  it('treats the newest claim in the current epoch as the active owner', () => {
     const comments = [
       {
         body: buildEventComment({
@@ -119,6 +119,31 @@ describe('resolveActiveClaimMachine', () => {
     ]
 
     expect(resolveActiveClaimMachine(comments)).toBe('codex-a')
+  })
+
+  it('does not let a stale historical claimant block a fresh claim in the same ready epoch', () => {
+    const comments = [
+      {
+        body: buildEventComment({
+          event: 'claimed',
+          machine: 'e6f5b0a1-a129-492d-b208-8e1da8e49ef4',
+          ts: '2026-04-07T15:23:32.305Z',
+          reason: 'resume-existing-worktree',
+        }),
+        createdAt: '2026-04-07T15:23:41Z',
+      },
+      {
+        body: buildEventComment({
+          event: 'claimed',
+          machine: 'codex-dev',
+          ts: '2026-04-11T14:55:32.138Z',
+          worktreeId: 'issue-171-codex-dev',
+        }),
+        createdAt: '2026-04-11T14:55:33Z',
+      },
+    ]
+
+    expect(resolveActiveClaimMachine(comments)).toBe('codex-dev')
   })
 
   it('hands ownership to a later claimant after stale-requeue resets the epoch', () => {

--- a/packages/agent-shared/src/state-machine.ts
+++ b/packages/agent-shared/src/state-machine.ts
@@ -91,7 +91,7 @@ export function resolveActiveClaimMachine(
       continue
     }
 
-    if (entry.event.event === 'claimed' && activeMachine === null) {
+    if (entry.event.event === 'claimed') {
       activeMachine = entry.event.machine
     }
   }

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -287,6 +287,29 @@ export interface RecoveryActionRuntimeDetail {
   reason: string | null
 }
 
+export interface PrLineageWarningRuntimeDetail {
+  issueNumber: number
+  branch: string
+  activePrNumbers: number[]
+  supersededPrNumbers: number[]
+  terminalReuseBlockedPrNumbers: number[]
+  missingMetadataPrNumbers: number[]
+  lineageMismatchBlockedPrNumbers: number[]
+  updatedAt: string
+}
+
+export interface PrLineageRuntimeStatus {
+  warningCount: number
+  warningCounts: {
+    multiActiveLineage: number
+    terminalReuseBlocked: number
+    supersededLineage: number
+    missingMetadata: number
+    lineageMismatchBlocked: number
+  }
+  warnings: PrLineageWarningRuntimeDetail[]
+}
+
 // ─── Claim Event (JSON in issue comment) ────────────────────────────────────
 
 export interface ClaimEvent {
@@ -392,6 +415,7 @@ export interface DaemonStatus {
   }
   agentLoop?: AgentLoopBuildMetadata
   upgrade?: AgentLoopUpgradeMetadata
+  prLineage?: PrLineageRuntimeStatus
   endpoints: {
     health: {
       host: string

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -120,15 +120,25 @@ export interface ProjectPromptGuidanceOverrides {
   recovery?: string[]
 }
 
+export interface ProjectIssueAuthoringRules {
+  preferredValidationCommands?: string[]
+  preferredAllowedFiles?: string[]
+  forbiddenPaths?: string[]
+  reviewHints?: string[]
+}
+
 export interface ProjectProfileConfig {
   profile: ProjectProfileName
   promptGuidance?: ProjectPromptGuidanceOverrides
+  issueAuthoring?: ProjectIssueAuthoringRules
   maxConcurrency?: number
 }
 
 export interface BuildRepoAuthoringContextInput {
   repoRoot: string
   issueText: string
+  repoRelativeFilePaths?: string[]
+  project?: ProjectProfileConfig
   maxValidationCommands?: number
   maxAllowedFiles?: number
   maxForbiddenFiles?: number
@@ -138,6 +148,13 @@ export interface RepoAuthoringContext {
   candidateValidationCommands: string[]
   candidateAllowedFiles: string[]
   candidateForbiddenFiles: string[]
+  candidateReviewHints?: string[]
+  projectIssueRules?: {
+    preferredValidationCommands: string[]
+    preferredAllowedFiles: string[]
+    forbiddenPaths: string[]
+    reviewHints: string[]
+  }
 }
 
 export interface AgentSchedulingConfig {

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -78,6 +78,8 @@ export interface PrLineageMetadata {
   fingerprint: string
 }
 
+export type CodexReasoningEffort = 'low' | 'medium' | 'high'
+
 // ─── Internal Issue (derived) ───────────────────────────────────────────────
 
 export interface AgentIssue {
@@ -375,6 +377,7 @@ export interface AgentConfig {
     claudePath: string
     codexPath: string
     codexBaseUrl?: string
+    codexReasoningEffort?: CodexReasoningEffort
     // Agent 执行超时（毫秒）
     timeoutMs: number
   }

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -68,6 +68,16 @@ export interface ManagedPullRequest {
   labels: string[]
 }
 
+export interface PrLineageMetadata {
+  version: 1
+  issue: number
+  headBranch: string
+  baseBranch: string
+  baseSha: string
+  attempt: number
+  fingerprint: string
+}
+
 // ─── Internal Issue (derived) ───────────────────────────────────────────────
 
 export interface AgentIssue {

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -126,6 +126,20 @@ export interface ProjectProfileConfig {
   maxConcurrency?: number
 }
 
+export interface BuildRepoAuthoringContextInput {
+  repoRoot: string
+  issueText: string
+  maxValidationCommands?: number
+  maxAllowedFiles?: number
+  maxForbiddenFiles?: number
+}
+
+export interface RepoAuthoringContext {
+  candidateValidationCommands: string[]
+  candidateAllowedFiles: string[]
+  candidateForbiddenFiles: string[]
+}
+
 export interface AgentSchedulingConfig {
   concurrencyByRepo: Record<string, number>
   concurrencyByProfile: Partial<Record<ProjectProfileName, number>>


### PR DESCRIPTION
## Summary
- kill detached process groups instead of only the top-level shell when agent or preflight commands time out
- stream validation command output activity into lease monitoring and pass finalize preflight through the issue monitor
- add a regression test proving timed out validation commands return cleanly without leaving orphaned processes behind

## Testing
- bun test src/cli-agent.test.ts
- bun test src/subtask-executor.test.ts
- bun test src/daemon.test.ts
- bun run typecheck