### PR TITLE
Fix #65: [AL-21] retryable finalize 错误后不要把 terminal human-needed PR 在 unchanged head 上恢复成 auto-fix

### DIFF
--- a/apps/agent-daemon/src/pr-reviewer.test.ts
+++ b/apps/agent-daemon/src/pr-reviewer.test.ts
@@ -370,6 +370,7 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
           },
         ],
       },
+      action: 'retrying',
       commentCreatedAt: '2026-04-05T08:00:00.000Z',
       commentUpdatedAt: '2026-04-05T08:10:00.000Z',
     })
@@ -393,7 +394,7 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
     })
   })
 
-  test('allows standalone review to resume from a valid structured human-needed comment', () => {
+  test('allows standalone review to resume from a valid structured retrying comment', () => {
     const comments = [
       {
         body: `<!-- agent-loop:pr-review {"pr":84,"attempt":1,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
@@ -404,6 +405,37 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
 
     expect(canResumeAutomatedPrReview(comments, 3)).toBe(true)
     expect(getNextAutomatedPrReviewAttempt(comments)).toBe(2)
+  })
+
+  test('allows standalone review to resume from a legacy retrying comment without explicit action metadata', () => {
+    const comments = [
+      {
+        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":1,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
+<!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":"First blocker","findings":[{"severity":"high","file":"apps/desktop/src/pages/MainPage.tsx","summary":"retry success regressed","mustFix":["restore success-list semantics"],"mustNotDo":["do not add selection state"],"validation":["bun --cwd apps/desktop test src/pages/MainPage.test.tsx"],"scopeRationale":"issue #76 requires preserving success semantics"}]} -->
+## Automated review found blocking issues — starting one auto-fix retry`,
+      },
+    ]
+
+    expect(canResumeAutomatedPrReview(comments, 3)).toBe(true)
+    expect(getReusableAutomatedPrReviewFeedback(comments, 'abc123', 3)).toEqual({
+      attempt: 1,
+      feedback: {
+        approved: false,
+        canMerge: false,
+        reason: 'First blocker',
+        findings: [
+          {
+            severity: 'high',
+            file: 'apps/desktop/src/pages/MainPage.tsx',
+            summary: 'retry success regressed',
+            mustFix: ['restore success-list semantics'],
+            mustNotDo: ['do not add selection state'],
+            validation: ['bun --cwd apps/desktop test src/pages/MainPage.test.tsx'],
+            scopeRationale: 'issue #76 requires preserving success semantics',
+          },
+        ],
+      },
+    })
   })
 
   test('does not resume standalone review when the latest automated comment lacks valid structured feedback', () => {
@@ -504,6 +536,40 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
     expect(canResumeHumanNeededPrReview(comments, 3, 'abc123', updatedIssueBody)).toBe(true)
   })
 
+  test('does not resume or reuse terminal human-needed feedback on an unchanged head', () => {
+    const comments = [
+      {
+        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":2,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
+<!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":"Second blocker","findings":[{"severity":"high","file":"apps/desktop/src/pages/MainPage.tsx","summary":"retry success regressed","mustFix":["restore success-list semantics"],"mustNotDo":["do not add selection state"],"validation":["bun --cwd apps/desktop test src/pages/MainPage.test.tsx"],"scopeRationale":"issue #76 requires preserving success semantics"}]} -->
+## Automated review still failing — human intervention required`,
+      },
+    ]
+
+    expect(canResumeAutomatedPrReview(comments, 3)).toBe(false)
+    expect(canResumeHumanNeededPrReview(comments, 3, 'abc123', null)).toBe(false)
+    expect(getReusableAutomatedPrReviewFeedback(comments, 'abc123', 3)).toBeNull()
+  })
+
+  test('does not resume or reuse legacy terminal human-needed feedback on an unchanged head', () => {
+    const comments = [
+      {
+        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":2,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
+<!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":"Second blocker","findings":[{"severity":"high","file":"apps/desktop/src/pages/MainPage.tsx","summary":"retry success regressed","mustFix":["restore success-list semantics"],"mustNotDo":["do not add selection state"],"validation":["bun --cwd apps/desktop test src/pages/MainPage.test.tsx"],"scopeRationale":"issue #76 requires preserving success semantics"}]} -->
+## Automated review still failing — human intervention required
+
+- Attempt: 2
+- Merge ready: no
+- Reason: Second blocker
+
+Next step: stopping automation and leaving the worktree/branch for a human.`,
+      },
+    ]
+
+    expect(canResumeAutomatedPrReview(comments, 3)).toBe(false)
+    expect(canResumeHumanNeededPrReview(comments, 3, 'abc123', null)).toBe(false)
+    expect(getReusableAutomatedPrReviewFeedback(comments, 'abc123', 3)).toBeNull()
+  })
+
   test('does not restart standalone review from legacy comments that only differ by issue timestamp', () => {
     const comments = [
       {
@@ -518,12 +584,12 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
     expect(shouldRestartAutomatedPrReviewOnIssueUpdate(comments, '2026-04-05T08:10:01.000Z')).toBe(false)
   })
 
-  test('reuses the latest structured review feedback when the PR head sha is unchanged', () => {
+  test('reuses the latest structured retrying feedback when the PR head sha is unchanged', () => {
     const comments = [
       {
-        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":2,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
+        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":2,"approved":false,"canMerge":false,"headRefOid":"abc123","action":"retrying"} -->
 <!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":"Second blocker","findings":[{"severity":"high","file":"apps/desktop/src/pages/MainPage.tsx","summary":"retry success regressed","mustFix":["restore success-list semantics"],"mustNotDo":["do not add selection state"],"validation":["bun --cwd apps/desktop test src/pages/MainPage.test.tsx"],"scopeRationale":"issue #76 requires preserving success semantics"}]} -->
-## Automated review still failing — human intervention required`,
+## Automated review found blocking issues — starting one auto-fix retry`,
       },
     ]
 

--- a/apps/agent-daemon/src/pr-reviewer.test.ts
+++ b/apps/agent-daemon/src/pr-reviewer.test.ts
@@ -376,6 +376,38 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
     })
   })
 
+  test('infers retrying action from legacy automated review wording without explicit action metadata', () => {
+    expect(extractLatestAutomatedPrReviewState([
+      {
+        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":1,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
+<!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":"First blocker","findings":[{"severity":"high","file":"apps/desktop/src/pages/MainPage.tsx","summary":"retry success regressed","mustFix":["restore success-list semantics"],"mustNotDo":["do not add selection state"],"validation":["bun --cwd apps/desktop test src/pages/MainPage.test.tsx"],"scopeRationale":"issue #76 requires preserving success semantics"}]} -->
+Automated review found blocking issues
+
+- Attempt: 1
+- Merge ready: no
+- Reason: First blocker
+
+Next step: daemon will attempt one automatic fix on the same branch.`,
+      },
+    ])?.action).toBe('retrying')
+  })
+
+  test('infers human-needed action from legacy automated review wording without explicit action metadata', () => {
+    expect(extractLatestAutomatedPrReviewState([
+      {
+        body: `<!-- agent-loop:pr-review {"pr":84,"attempt":2,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
+<!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":"Second blocker","findings":[{"severity":"high","file":"apps/desktop/src/pages/MainPage.tsx","summary":"retry success regressed","mustFix":["restore success-list semantics"],"mustNotDo":["do not add selection state"],"validation":["bun --cwd apps/desktop test src/pages/MainPage.test.tsx"],"scopeRationale":"issue #76 requires preserving success semantics"}]} -->
+Automated review still failing - human intervention required
+
+- Attempt: 2
+- Merge ready: no
+- Reason: Second blocker
+
+Next step: stopping automation and leaving the worktree/branch for a human.`,
+      },
+    ])?.action).toBe('human-needed')
+  })
+
   test('extracts the latest automated PR review blocker summary', () => {
     expect(extractLatestAutomatedPrReviewBlockerSummary([
       {
@@ -555,7 +587,7 @@ Next step: stopping automation and leaving the worktree/branch for a human.`,
       {
         body: `<!-- agent-loop:pr-review {"pr":84,"attempt":2,"approved":false,"canMerge":false,"headRefOid":"abc123"} -->
 <!-- agent-loop:review-feedback {"approved":false,"canMerge":false,"reason":"Second blocker","findings":[{"severity":"high","file":"apps/desktop/src/pages/MainPage.tsx","summary":"retry success regressed","mustFix":["restore success-list semantics"],"mustNotDo":["do not add selection state"],"validation":["bun --cwd apps/desktop test src/pages/MainPage.test.tsx"],"scopeRationale":"issue #76 requires preserving success semantics"}]} -->
-## Automated review still failing — human intervention required
+Automated review still failing - human intervention required
 
 - Attempt: 2
 - Merge ready: no

--- a/apps/agent-daemon/src/pr-reviewer.ts
+++ b/apps/agent-daemon/src/pr-reviewer.ts
@@ -112,6 +112,11 @@ const REVIEW_DEPENDENCY_DIRNAME = 'node_modules'
 const REVIEW_DEPENDENCY_SCAN_DEPTH = 3
 const MAX_REVIEW_OUTPUT_ATTEMPTS = 2
 const DETACHED_REVIEW_EXCLUDE_MARKER = '# agent-loop detached review dependency symlinks'
+const AUTOMATED_PR_REVIEW_RETRYING_TITLE = 'automated review found blocking issues'
+const AUTOMATED_PR_REVIEW_RETRYING_TITLE_WITH_RETRY = 'automated review found blocking issues - starting one auto-fix retry'
+const AUTOMATED_PR_REVIEW_HUMAN_NEEDED_TITLE = 'automated review still failing - human intervention required'
+const AUTOMATED_PR_REVIEW_RETRYING_NEXT_STEP = 'next step: daemon will attempt one automatic fix on the same branch.'
+const AUTOMATED_PR_REVIEW_HUMAN_NEEDED_NEXT_STEP = 'next step: stopping automation and leaving the worktree/branch for a human.'
 
 /**
  * Review a PR using the configured CLI agent to determine if it can be merged.
@@ -873,20 +878,29 @@ function extractAutomatedPrReviewAction(
 ): 'approved' | 'retrying' | 'human-needed' | null {
   if (metadata.action) return metadata.action
   if (metadata.approved || metadata.canMerge) return 'approved'
-  if (body.includes('## Automated review found blocking issues — starting one auto-fix retry')) {
-    return 'retrying'
-  }
-  if (body.includes('## Automated review still failing — human intervention required')) {
+  const normalizedBody = normalizeAutomatedPrReviewCommentBody(body)
+  if (
+    normalizedBody.includes(AUTOMATED_PR_REVIEW_HUMAN_NEEDED_TITLE)
+    || normalizedBody.includes(AUTOMATED_PR_REVIEW_HUMAN_NEEDED_NEXT_STEP)
+  ) {
     return 'human-needed'
   }
-  if (body.includes('Next step: daemon will attempt one automatic fix on the same branch.')) {
+  if (
+    normalizedBody.includes(AUTOMATED_PR_REVIEW_RETRYING_TITLE_WITH_RETRY)
+    || normalizedBody.includes(AUTOMATED_PR_REVIEW_RETRYING_TITLE)
+    || normalizedBody.includes(AUTOMATED_PR_REVIEW_RETRYING_NEXT_STEP)
+  ) {
     return 'retrying'
-  }
-  if (body.includes('Next step: stopping automation and leaving the worktree/branch for a human.')) {
-    return 'human-needed'
   }
 
   return null
+}
+
+function normalizeAutomatedPrReviewCommentBody(body: string): string {
+  return body
+    .replace(/[—–]/g, '-')
+    .replace(/\r\n/g, '\n')
+    .toLowerCase()
 }
 
 function buildIssueContractFingerprint(body: string | null | undefined): string | null {

--- a/apps/agent-daemon/src/pr-reviewer.ts
+++ b/apps/agent-daemon/src/pr-reviewer.ts
@@ -59,6 +59,7 @@ interface AutomatedPrReviewMetadata {
   attempt: number
   approved: boolean
   canMerge: boolean
+  action?: 'approved' | 'retrying' | 'human-needed'
   headRefOid?: string
   issueContractFingerprint?: string
 }
@@ -72,6 +73,7 @@ export interface AutomatedPrReviewCommentLike {
 export interface LatestAutomatedPrReviewState {
   metadata: AutomatedPrReviewMetadata
   feedback: StructuredReviewFeedbackPayload | null
+  action: 'approved' | 'retrying' | 'human-needed' | null
   commentCreatedAt: string | null
   commentUpdatedAt: string | null
 }
@@ -437,6 +439,7 @@ export function buildPrReviewComment(
     attempt,
     approved: review.approved,
     canMerge: review.canMerge,
+    action,
     ...(headRefOid ? { headRefOid } : {}),
     ...(issueContractFingerprint ? { issueContractFingerprint } : {}),
   }
@@ -504,12 +507,14 @@ export function extractLatestAutomatedPrReviewState(
   comments: AutomatedPrReviewCommentLike[],
 ): LatestAutomatedPrReviewState | null {
   for (let index = comments.length - 1; index >= 0; index--) {
-    const metadata = extractAutomatedPrReviewMetadata(comments[index]?.body ?? '')
+    const body = comments[index]?.body ?? ''
+    const metadata = extractAutomatedPrReviewMetadata(body)
     if (!metadata) continue
 
     return {
       metadata,
-      feedback: extractStructuredReviewFeedback(comments[index]?.body ?? ''),
+      feedback: extractStructuredReviewFeedback(body),
+      action: extractAutomatedPrReviewAction(body, metadata),
       commentCreatedAt: comments[index]?.createdAt ?? null,
       commentUpdatedAt: comments[index]?.updatedAt ?? comments[index]?.createdAt ?? null,
     }
@@ -559,6 +564,8 @@ export function canResumeAutomatedPrReview(
   if (!latest) return false
 
   return (
+    latest.action === 'retrying'
+    &&
     latest.metadata.approved === false
     && latest.metadata.canMerge === false
     && latest.feedback !== null
@@ -603,11 +610,21 @@ export function canResumeHumanNeededPrReview(
   currentHeadRefOid: string | null | undefined,
   issueBody: string | null | undefined,
 ): boolean {
-  return (
+  const latest = extractLatestAutomatedPrReviewState(comments)
+  if (!latest) return false
+
+  const canResumeFromTerminalState = (
     didLatestAutomatedPrReviewExecutionFail(comments)
-    || canResumeAutomatedPrReview(comments, maxAttempt)
     || shouldRestartAutomatedPrReviewOnNewHead(comments, currentHeadRefOid)
     || shouldRestartAutomatedPrReviewOnIssueUpdate(comments, issueBody)
+  )
+  if (latest.action === 'human-needed') {
+    return canResumeFromTerminalState
+  }
+
+  return (
+    canResumeFromTerminalState
+    || canResumeAutomatedPrReview(comments, maxAttempt)
   )
 }
 
@@ -636,6 +653,7 @@ export function getReusableAutomatedPrReviewFeedback(
   const latest = extractLatestAutomatedPrReviewState(comments)
   if (!latest) return null
   if (latest.feedback === null) return null
+  if (latest.action !== 'retrying') return null
   if (latest.metadata.approved || latest.metadata.canMerge) return null
   if (latest.metadata.attempt >= maxAttempt) return null
   if (!latest.metadata.headRefOid || latest.metadata.headRefOid !== currentHeadRefOid) return null
@@ -824,22 +842,51 @@ function extractAutomatedPrReviewMetadata(body: string): AutomatedPrReviewMetada
       return null
     }
 
+    const action = parsed.action === 'approved' || parsed.action === 'retrying' || parsed.action === 'human-needed'
+      ? parsed.action
+      : undefined
+    const headRefOid = typeof parsed.headRefOid === 'string' && parsed.headRefOid.trim().length > 0
+      ? parsed.headRefOid.trim()
+      : undefined
+    const issueContractFingerprint = typeof parsed.issueContractFingerprint === 'string'
+      && parsed.issueContractFingerprint.trim().length > 0
+      ? parsed.issueContractFingerprint.trim()
+      : undefined
+
     return {
       pr,
       attempt,
       approved: parsed.approved === true,
       canMerge: parsed.canMerge === true,
-      headRefOid: typeof parsed.headRefOid === 'string' && parsed.headRefOid.trim().length > 0
-        ? parsed.headRefOid.trim()
-        : undefined,
-      issueContractFingerprint: typeof parsed.issueContractFingerprint === 'string'
-        && parsed.issueContractFingerprint.trim().length > 0
-        ? parsed.issueContractFingerprint.trim()
-        : undefined,
+      ...(action ? { action } : {}),
+      ...(headRefOid ? { headRefOid } : {}),
+      ...(issueContractFingerprint ? { issueContractFingerprint } : {}),
     }
   } catch {
     return null
   }
+}
+
+function extractAutomatedPrReviewAction(
+  body: string,
+  metadata: AutomatedPrReviewMetadata,
+): 'approved' | 'retrying' | 'human-needed' | null {
+  if (metadata.action) return metadata.action
+  if (metadata.approved || metadata.canMerge) return 'approved'
+  if (body.includes('## Automated review found blocking issues — starting one auto-fix retry')) {
+    return 'retrying'
+  }
+  if (body.includes('## Automated review still failing — human intervention required')) {
+    return 'human-needed'
+  }
+  if (body.includes('Next step: daemon will attempt one automatic fix on the same branch.')) {
+    return 'retrying'
+  }
+  if (body.includes('Next step: stopping automation and leaving the worktree/branch for a human.')) {
+    return 'human-needed'
+  }
+
+  return null
 }
 
 function buildIssueContractFingerprint(body: string | null | undefined): string | null {


### PR DESCRIPTION
## Summary

Fixes #65

## Metadata

```json
{
  "issue": 65,
  "machine": "codex-dev",
  "generated_by": "agent-loop"
}
```

## Test Plan

- [ ] tested locally
- [ ] CI passes