### PR TITLE
fix(daemon): upgrade before claiming new work

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -579,6 +579,60 @@ describe('agent-loop upgrade coordination', () => {
     })
   })
 
+  test('attempts automatic self-upgrade before claiming new work when idle', async () => {
+    await withRuntimeSupervisor('detached', async () => {
+      const daemon = createTestDaemon({
+        upgrade: {
+          enabled: true,
+          repo: 'JamesWuHK/agent-loop',
+          channel: 'master',
+          checkIntervalMs: 60_000,
+          reminderIntervalMs: 3_600_000,
+          autoApply: true,
+        },
+      }) as any
+
+      let autoUpgradeAttempts = 0
+      let claimAttempts = 0
+
+      daemon.running = true
+      daemon.startupRecoveryPending = false
+      daemon.maybeStartResumableIssue = async () => false
+      daemon.maybeStartStandaloneApprovedPrMerge = async () => false
+      daemon.maybeRequeueFailedIssue = async () => false
+      daemon.maybeStartClaimedIssue = async () => {
+        claimAttempts += 1
+        return true
+      }
+      daemon.maybeStartStandalonePrReview = async () => false
+      daemon.maybeRefreshAgentLoopUpgradeStatus = async () => {}
+      daemon.performAutomaticAgentLoopUpgrade = async () => {
+        autoUpgradeAttempts += 1
+        return true
+      }
+      daemon.scheduleNextPoll = () => {
+        throw new Error('pollCycle should not schedule another poll after auto-upgrade starts')
+      }
+      daemon.agentLoopUpgrade = {
+        enabled: true,
+        repo: 'JamesWuHK/agent-loop',
+        channel: 'master',
+        checkedAt: '2026-04-11T11:00:00.000Z',
+        status: 'upgrade-available',
+        latestVersion: '0.1.2',
+        latestRevision: '2222222222222222222222222222222222222222',
+        latestCommitAt: '2026-04-11T10:59:30.000Z',
+        safeToUpgradeNow: true,
+        message: 'channel master is newer: local v0.1.0, latest v0.1.2',
+      }
+
+      await daemon.pollCycle()
+
+      expect(autoUpgradeAttempts).toBe(1)
+      expect(claimAttempts).toBe(0)
+    })
+  })
+
   test('keeps direct-mode upgrades in reminder-only mode', async () => {
     await withRuntimeSupervisor('direct', async () => {
       const daemon = createTestDaemon({

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -1261,6 +1261,12 @@ export class AgentDaemon {
         return
       }
 
+      if (!startedWork && await this.maybeAutoApplyAgentLoopUpgrade()) {
+        recordPoll('no_issues')
+        recordPollDuration(Date.now() - pollStartTime)
+        return
+      }
+
       const wakeAttempt = await this.maybeStartQueuedWakeRequest()
       if (wakeAttempt.handled) {
         allowUntargetedFallback = allowUntargetedFallback || wakeAttempt.allowUntargetedFallback


### PR DESCRIPTION
## Summary
- run automatic self-upgrade before starting new work when the daemon is idle
- keep the idle no-work upgrade path as a fallback
- add a regression test for the case where claimable issues exist but an upgrade is pending

## Why
On codex-dev, the daemon released issue #188 cleanly after the timed-out preflight fix, but then immediately claimed #180 instead of restarting into the newer build. The poll loop only attempted auto-apply inside finalizePollCycle(), which runs after all claim/start paths. When the ready queue is non-empty, the old daemon can starve auto-upgrade indefinitely.

## Testing
- bun test apps/agent-daemon/src/daemon.test.ts
- bun run typecheck