### PR TITLE
fix(daemon): wait for default branch after merge

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -51,6 +51,7 @@ import {
   shouldCompleteIssueRecoveryOnRemoteClose,
   shouldRequeueFailedIssue,
   shouldResumeManagedIssue,
+  waitForDefaultBranchToContainCommit,
 } from './daemon'
 import { ISSUE_LABELS, PR_REVIEW_LABELS } from '@agent/shared'
 import {
@@ -2586,6 +2587,64 @@ describe('daemon merge recovery helpers', () => {
       expect(
         Number.parseInt((await Bun.$`git -C ${repoDir} rev-list --count HEAD..origin/main`.quiet().text()).trim(), 10),
       ).toBe(0)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('waits for the default branch to catch up to a freshly merged commit before continuing', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'daemon-default-branch-catchup-'))
+    const remoteDir = join(tempDir, 'remote.git')
+    const repoDir = join(tempDir, 'repo')
+    const peerDir = join(tempDir, 'peer')
+
+    try {
+      mkdirSync(remoteDir, { recursive: true })
+      mkdirSync(repoDir, { recursive: true })
+
+      await Bun.$`git -C ${remoteDir} init --bare`.quiet()
+      await Bun.$`git -C ${repoDir} init -b main`.quiet()
+      await Bun.$`git -C ${repoDir} config user.name test`.quiet()
+      await Bun.$`git -C ${repoDir} config user.email test@example.com`.quiet()
+      await Bun.$`git -C ${repoDir} remote add origin ${remoteDir}`.quiet()
+
+      writeFileSync(join(repoDir, 'base.txt'), 'base\n', 'utf-8')
+      await Bun.$`git -C ${repoDir} add base.txt`.quiet()
+      await Bun.$`git -C ${repoDir} commit -m "base"`.quiet()
+      await Bun.$`git -C ${repoDir} push -u origin main`.quiet()
+
+      await Bun.$`git clone ${remoteDir} ${peerDir}`.quiet()
+      await Bun.$`git -C ${peerDir} config user.name test`.quiet()
+      await Bun.$`git -C ${peerDir} config user.email test@example.com`.quiet()
+      await Bun.$`git -C ${peerDir} checkout main`.quiet()
+
+      writeFileSync(join(peerDir, 'base.txt'), 'base\nmerged-update\n', 'utf-8')
+      await Bun.$`git -C ${peerDir} add base.txt`.quiet()
+      await Bun.$`git -C ${peerDir} commit -m "merged update"`.quiet()
+      const mergedSha = (await Bun.$`git -C ${peerDir} rev-parse HEAD`.quiet().text()).trim()
+
+      const delayedPush = (async () => {
+        await Bun.sleep(150)
+        await Bun.$`git -C ${peerDir} push origin main`.quiet()
+      })()
+
+      const result = await waitForDefaultBranchToContainCommit(
+        repoDir,
+        'main',
+        mergedSha,
+        console,
+        {
+          maxAttempts: 20,
+          delayMs: 50,
+        },
+      )
+      await delayedPush
+
+      expect(result).toEqual({
+        success: true,
+        observedSha: mergedSha,
+      })
+      expect((await Bun.$`git -C ${repoDir} rev-parse origin/main`.quiet().text()).trim()).toBe(mergedSha)
     } finally {
       rmSync(tempDir, { recursive: true, force: true })
     }

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -3388,6 +3388,20 @@ export class AgentDaemon {
         this.config,
       )
 
+      if (mergeResult.sha) {
+        const defaultSync = await waitForDefaultBranchToContainCommit(
+          worktreePath,
+          this.config.git.defaultBranch,
+          mergeResult.sha,
+          this.logger,
+        )
+        if (!defaultSync.success) {
+          this.logger.warn(
+            `[daemon] merged PR #${pr.prNumber} but origin/${this.config.git.defaultBranch} did not converge locally before continuing: ${defaultSync.message}`,
+          )
+        }
+      }
+
       this.logger.log(`[daemon] issue #${issue.number} done! PR: #${pr.prNumber}`)
       recordIssueProcessed('done')
       recordPrCreated()
@@ -5541,6 +5555,69 @@ async function restoreManagedWorktreeState(
     if (!benign) {
       logger.warn(`[worktree] could not abort ${command.label} in ${worktreePath}: ${(stderr || stdout).trim()}`)
     }
+  }
+}
+
+const DEFAULT_BRANCH_MERGE_SYNC_RETRY_ATTEMPTS = 10
+const DEFAULT_BRANCH_MERGE_SYNC_RETRY_DELAY_MS = 2_000
+
+export async function waitForDefaultBranchToContainCommit(
+  worktreePath: string,
+  defaultBranch: string,
+  requiredCommitSha: string,
+  logger = console,
+  options: {
+    maxAttempts?: number
+    delayMs?: number
+  } = {},
+): Promise<
+  | { success: true; observedSha: string }
+  | { success: false; message: string }
+> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_BRANCH_MERGE_SYNC_RETRY_ATTEMPTS)
+  const delayMs = Math.max(0, options.delayMs ?? DEFAULT_BRANCH_MERGE_SYNC_RETRY_DELAY_MS)
+  let lastObservedSha = ''
+  let lastError = ''
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const fetchResult = await runGitInWorktree(worktreePath, ['fetch', 'origin', defaultBranch])
+    if (fetchResult.exitCode !== 0) {
+      lastError = fetchResult.stderr || fetchResult.stdout || `git fetch origin ${defaultBranch} failed`
+    } else {
+      const baseResult = await runGitInWorktree(worktreePath, ['rev-parse', `origin/${defaultBranch}`])
+      if (baseResult.exitCode === 0) {
+        lastObservedSha = baseResult.stdout.trim()
+        const containsRequiredCommit =
+          lastObservedSha === requiredCommitSha
+          || (await runGitInWorktree(
+            worktreePath,
+            ['merge-base', '--is-ancestor', requiredCommitSha, `origin/${defaultBranch}`],
+          )).exitCode === 0
+        if (containsRequiredCommit) {
+          if (attempt > 1) {
+            logger.log(
+              `[worktree] observed origin/${defaultBranch} catch up to ${lastObservedSha.slice(0, 7)} after merge ${requiredCommitSha.slice(0, 7)} in ${worktreePath} on attempt ${attempt}`,
+            )
+          }
+          return {
+            success: true,
+            observedSha: lastObservedSha,
+          }
+        }
+      } else {
+        lastError = baseResult.stderr || baseResult.stdout || `git rev-parse origin/${defaultBranch} failed`
+      }
+    }
+
+    if (attempt < maxAttempts) {
+      await Bun.sleep(delayMs)
+    }
+  }
+
+  return {
+    success: false,
+    message: lastError
+      || `origin/${defaultBranch} did not reach merged commit ${requiredCommitSha.slice(0, 7)} after ${maxAttempts} attempts (last observed ${lastObservedSha.slice(0, 7) || 'unknown'})`,
   }
 }
 


### PR DESCRIPTION
## Summary
- wait for `origin/<default>` to catch up to the merged commit before the daemon continues after a managed PR merge
- reduce the race where the next failed-issue recovery can rebuild on a stale default branch tip immediately after the previous PR merged
- add a regression test that simulates delayed default-branch visibility and verifies the retry loop

## Testing
- bun --cwd apps/agent-daemon test src/daemon.test.ts
