### PR TITLE
Fix #67: [AL-22] 启动阶段的 remote upgrade announcement 失败不应打挂 daemon 进程

### DIFF
--- a/apps/agent-daemon/src/daemon.test.ts
+++ b/apps/agent-daemon/src/daemon.test.ts
@@ -42,6 +42,7 @@ import {
   isMergeabilityFailure,
   refreshResumableIssueBranchOntoDefault,
   rebaseManagedBranchOntoDefault,
+  runRemoteUpgradeAnnouncementSafely,
   shouldApplyStandaloneIssueTransition,
   shouldResetLinkedPrToRetryOnIssueResume,
   shouldCompleteIssueRecoveryOnRemoteClose,
@@ -460,6 +461,44 @@ describe('wake queue integration', () => {
 })
 
 describe('agent-loop upgrade coordination', () => {
+  test('downgrades startup remote upgrade announcement failures into warnings', async () => {
+    const warnings: string[] = []
+
+    await runRemoteUpgradeAnnouncementSafely(
+      async () => {
+        throw new Error('The socket connection was closed unexpectedly.')
+      },
+      {
+        warn(message: string) {
+          warnings.push(message)
+        },
+      },
+    )
+
+    expect(warnings).toEqual([
+      expect.stringContaining('failed to process remote upgrade announcement'),
+    ])
+  })
+
+  test('keeps successful remote upgrade announcement checks silent', async () => {
+    let called = false
+    const warnings: string[] = []
+
+    await runRemoteUpgradeAnnouncementSafely(
+      async () => {
+        called = true
+      },
+      {
+        warn(message: string) {
+          warnings.push(message)
+        },
+      },
+    )
+
+    expect(called).toBe(true)
+    expect(warnings).toEqual([])
+  })
+
   test('refreshes upgrade status and wakes the scheduler when a newer remote upgrade announcement appears', async () => {
     const daemon = createTestDaemon({
       upgrade: {

--- a/apps/agent-daemon/src/daemon.ts
+++ b/apps/agent-daemon/src/daemon.ts
@@ -121,6 +121,17 @@ export interface StopDaemonOptions {
   reason?: string
 }
 
+export async function runRemoteUpgradeAnnouncementSafely(
+  check: () => Promise<void>,
+  logger: { warn(message: string): void },
+): Promise<void> {
+  try {
+    await check()
+  } catch (error) {
+    logger.warn(`[daemon] failed to process remote upgrade announcement: ${formatDaemonError(error)}`)
+  }
+}
+
 export const HEALTH_PATH = '/health'
 export const WAKE_PATH = '/wake'
 export const DEFAULT_HEALTH_SERVER_PORT = 9310
@@ -775,9 +786,10 @@ export class AgentDaemon {
         return
       }
 
-      void this.maybeProcessRemoteUpgradeAnnouncement().catch((error) => {
-        this.logger.warn(`[daemon] failed to process remote upgrade announcement: ${formatDaemonError(error)}`)
-      })
+      void runRemoteUpgradeAnnouncementSafely(
+        () => this.maybeProcessRemoteUpgradeAnnouncement(),
+        this.logger,
+      )
     }, intervalMs)
   }
 
@@ -868,7 +880,10 @@ export class AgentDaemon {
     })
 
     void this.maybeRefreshAgentLoopUpgradeStatus(true)
-    void this.maybeProcessRemoteUpgradeAnnouncement()
+    void runRemoteUpgradeAnnouncementSafely(
+      () => this.maybeProcessRemoteUpgradeAnnouncement(),
+      this.logger,
+    )
 
     // Run first recovery + poll immediately; subsequent polls are self-scheduled
     await this.runPollCycleSafely()


### PR DESCRIPTION
## Summary

Fixes #67

<!-- agent-loop:pr-lineage {"version":1,"issue":67,"headBranch":"agent/67-rebuild-20260412213747/codex-dev","baseBranch":"master","baseSha":"2224a50449934e5bdf0a24e6c50673c3d098e5d1","attempt":2,"fingerprint":"5c9a6efb73187207518c78399722bb43d28838ea19907e87a50428c97ab9ce5a"} -->

## Metadata

```json
{
  "issue": 67,
  "machine": "codex-dev",
  "generated_by": "agent-loop"
}
```

## Test Plan

- [ ] tested locally
- [ ] CI passes