### PR TITLE
fix(recovery): block out-of-scope salvage commits

### DIFF
--- a/apps/agent-daemon/src/subtask-executor.test.ts
+++ b/apps/agent-daemon/src/subtask-executor.test.ts
@@ -121,10 +121,69 @@ describe('salvageDirtyWorktree', () => {
     const status = (await Bun.$`git -C ${dir} status --short`.quiet().text()).trim()
     const subject = (await Bun.$`git -C ${dir} log -1 --pretty=%s`.quiet().text()).trim()
 
-    expect(result).toBeString()
-    expect(result?.length).toBeGreaterThan(0)
+    expect(result).toMatchObject({
+      kind: 'committed',
+      commitSha: expect.any(String),
+    })
     expect(status).toBe('')
     expect(subject).toBe('fix: salvage dirty repo')
+  })
+
+  it('refuses to salvage dirty files outside the allowed scope', async () => {
+    const dir = await createGitRepo()
+
+    await Bun.$`mkdir -p ${join(dir, 'apps', 'desktop', 'src', 'pages')}`.quiet()
+    writeFileSync(join(dir, 'apps', 'desktop', 'src', 'pages', 'MainPage.tsx'), 'base\n', 'utf-8')
+    writeFileSync(join(dir, 'apps', 'desktop', 'src', 'pages', 'MainPage.sprint-p.smoke.test.tsx'), 'base\n', 'utf-8')
+    await Bun.$`git -C ${dir} add .`.quiet()
+    await Bun.$`git -C ${dir} commit -m "chore: add page fixtures"`.quiet()
+
+    writeFileSync(join(dir, 'apps', 'desktop', 'src', 'pages', 'MainPage.tsx'), 'allowed change\n', 'utf-8')
+    writeFileSync(join(dir, 'apps', 'desktop', 'src', 'pages', 'MainPage.sprint-p.smoke.test.tsx'), 'out-of-scope change\n', 'utf-8')
+
+    const result = await salvageDirtyWorktree(
+      dir,
+      'fix: salvage dirty repo',
+      TEST_CONFIG,
+      console,
+      ['apps/desktop/src/pages/MainPage.tsx'],
+    )
+
+    expect(result).toEqual({
+      kind: 'blocked',
+      outOfScopeFiles: ['apps/desktop/src/pages/MainPage.sprint-p.smoke.test.tsx'],
+    })
+
+    const status = (await Bun.$`git -C ${dir} status --short`.quiet().text()).trim()
+    const subject = (await Bun.$`git -C ${dir} log -1 --pretty=%s`.quiet().text()).trim()
+
+    expect(status).toContain('apps/desktop/src/pages/MainPage.tsx')
+    expect(status).toContain('apps/desktop/src/pages/MainPage.sprint-p.smoke.test.tsx')
+    expect(subject).toBe('chore: add page fixtures')
+  })
+
+  it('still salvages dirty files when every change is inside scope', async () => {
+    const dir = await createGitRepo()
+
+    await Bun.$`mkdir -p ${join(dir, 'apps', 'desktop', 'src', 'pages')}`.quiet()
+    writeFileSync(join(dir, 'apps', 'desktop', 'src', 'pages', 'MainPage.tsx'), 'base\n', 'utf-8')
+    await Bun.$`git -C ${dir} add .`.quiet()
+    await Bun.$`git -C ${dir} commit -m "chore: add page fixture"`.quiet()
+
+    writeFileSync(join(dir, 'apps', 'desktop', 'src', 'pages', 'MainPage.tsx'), 'allowed change\n', 'utf-8')
+
+    const result = await salvageDirtyWorktree(
+      dir,
+      'fix: salvage dirty repo',
+      TEST_CONFIG,
+      console,
+      ['apps/desktop/src/pages/MainPage.tsx'],
+    )
+
+    expect(result).toMatchObject({
+      kind: 'committed',
+      commitSha: expect.any(String),
+    })
   })
 })
 
@@ -245,6 +304,64 @@ describe('resolveAgentExecutionTimeoutMs', () => {
 })
 
 describe('runIssueRecovery', () => {
+  it('fails recoverably instead of creating a salvage commit when pre-run dirty files are outside AllowedFiles', async () => {
+    const dir = await createGitRepo()
+
+    await Bun.$`mkdir -p ${join(dir, 'apps', 'desktop', 'src', 'pages')}`.quiet()
+    writeFileSync(join(dir, 'apps', 'desktop', 'src', 'pages', 'MainPage.tsx'), 'base\n', 'utf-8')
+    writeFileSync(join(dir, 'apps', 'desktop', 'src', 'pages', 'MainPage.followup-decision-restore.test.tsx'), 'base\n', 'utf-8')
+    await Bun.$`git -C ${dir} add .`.quiet()
+    await Bun.$`git -C ${dir} commit -m "chore: add issue fixtures"`.quiet()
+
+    writeFileSync(join(dir, 'apps', 'desktop', 'src', 'pages', 'MainPage.tsx'), 'allowed change\n', 'utf-8')
+    writeFileSync(join(dir, 'apps', 'desktop', 'src', 'pages', 'MainPage.followup-decision-restore.test.tsx'), 'out-of-scope change\n', 'utf-8')
+
+    const result = await runIssueRecovery(
+      dir,
+      193,
+      '[US18-4] scope hygiene',
+      [
+        '## 用户故事',
+        '',
+        '作为维护者，我希望恢复流程遵守 AllowedFiles。',
+        '',
+        '## Context',
+        '',
+        '### Dependencies',
+        '```json',
+        '{"dependsOn":[]}',
+        '```',
+        '',
+        '### AllowedFiles',
+        '- apps/desktop/src/pages/MainPage.tsx',
+        '',
+        '### Validation',
+        '- `cd apps/desktop && bun run --bun test src/pages/MainPage.checkpoint-brief-card.test.tsx`',
+        '',
+        '## RED 测试',
+        '```ts',
+        'throw new Error("red")',
+        '```',
+        '',
+        '## 实现步骤',
+        '1. restore scope hygiene',
+        '',
+        '## 验收',
+        '- [ ] done',
+      ].join('\n'),
+      TEST_CONFIG,
+    )
+
+    expect(result).toMatchObject({
+      success: false,
+      commitCreated: false,
+      error: 'dirty worktree contains files outside AllowedFiles: apps/desktop/src/pages/MainPage.followup-decision-restore.test.tsx',
+    })
+
+    const subject = (await Bun.$`git -C ${dir} log -1 --pretty=%s`.quiet().text()).trim()
+    expect(subject).toBe('chore: add issue fixtures')
+  })
+
   it('returns remote_closed without salvaging when the linked issue is already done elsewhere', async () => {
     const dir = await createGitRepo()
     const scriptDir = mkdtempSync(join(tmpdir(), 'subtask-executor-agent-'))

--- a/apps/agent-daemon/src/subtask-executor.ts
+++ b/apps/agent-daemon/src/subtask-executor.ts
@@ -220,6 +220,16 @@ export interface IssueRecoveryResult {
   failureKind?: AgentFailureKind
 }
 
+export type SalvageDirtyWorktreeResult =
+  | {
+      kind: 'committed'
+      commitSha: string
+    }
+  | {
+      kind: 'blocked'
+      outOfScopeFiles: string[]
+    }
+
 export async function shouldTreatCleanNoCommitSubtaskAsSuccess(
   worktreePath: string,
   defaultBranch: string,
@@ -247,9 +257,25 @@ export async function salvageDirtyWorktree(
   commitMessage: string,
   config: AgentConfig,
   logger = console,
-): Promise<string | null> {
-  const status = (await $`git -C ${worktreePath} status --short`.quiet().text()).trim()
-  if (!status) return null
+  allowedFiles: string[] = [],
+): Promise<SalvageDirtyWorktreeResult | null> {
+  const dirtyFiles = await readDirtyWorktreeFiles(worktreePath)
+  if (dirtyFiles.length === 0) return null
+
+  if (allowedFiles.length > 0) {
+    const outOfScopeFiles = dirtyFiles.filter(
+      (file) => !allowedFiles.some((pattern) => matchesContractFilePattern(file, pattern)),
+    )
+    if (outOfScopeFiles.length > 0) {
+      logger.warn(
+        `[salvage] blocked dirty worktree in ${worktreePath}; files outside AllowedFiles: ${outOfScopeFiles.join(', ')}`,
+      )
+      return {
+        kind: 'blocked',
+        outOfScopeFiles,
+      }
+    }
+  }
 
   logger.warn(`[salvage] found uncommitted changes in ${worktreePath}; creating recovery commit`)
 
@@ -258,7 +284,10 @@ export async function salvageDirtyWorktree(
 
   const commitSha = (await $`git -C ${worktreePath} rev-parse HEAD`.quiet().text()).trim()
   logger.log(`[salvage] created commit ${commitSha.slice(0, 7)} from pending worktree changes`)
-  return commitSha
+  return {
+    kind: 'committed',
+    commitSha,
+  }
 }
 
 export async function runIssueRecovery(
@@ -272,17 +301,28 @@ export async function runIssueRecovery(
   recentBlockingReasons: string[] = [],
   monitor?: TaskExecutionMonitor,
 ): Promise<IssueRecoveryResult> {
+  const issueContract = parseIssueContract(issueBody)
   const salvagedBeforeRun = await salvageDirtyWorktree(
     worktreePath,
     `fix(issue-recovery): salvage pending changes for issue #${issueNumber}`,
     config,
     logger,
+    issueContract.allowedFiles,
   )
-  if (salvagedBeforeRun) {
+  if (salvagedBeforeRun?.kind === 'blocked') {
+    return {
+      success: false,
+      exitCode: 1,
+      error: formatBlockedSalvageError(salvagedBeforeRun.outOfScopeFiles),
+      commitCreated: false,
+    }
+  }
+
+  if (salvagedBeforeRun?.kind === 'committed') {
     return {
       success: true,
       exitCode: 0,
-      commitSha: salvagedBeforeRun,
+      commitSha: salvagedBeforeRun.commitSha,
       commitCreated: true,
     }
   }
@@ -338,13 +378,24 @@ export async function runIssueRecovery(
       `fix(issue-recovery): salvage pending changes for issue #${issueNumber}`,
       config,
       logger,
+      issueContract.allowedFiles,
     )
-    if (salvagedCommit) {
-      logger.warn(`[issue-recovery] agent exited ${result.exitCode} but left recoverable changes — continuing with salvaged commit ${salvagedCommit.slice(0, 7)}`)
+    if (salvagedCommit?.kind === 'blocked') {
+      return {
+        success: false,
+        exitCode: result.exitCode,
+        error: formatBlockedSalvageError(salvagedCommit.outOfScopeFiles),
+        commitCreated: false,
+        failureKind: result.failureKind,
+      }
+    }
+
+    if (salvagedCommit?.kind === 'committed') {
+      logger.warn(`[issue-recovery] agent exited ${result.exitCode} but left recoverable changes — continuing with salvaged commit ${salvagedCommit.commitSha.slice(0, 7)}`)
       return {
         success: true,
         exitCode: 0,
-        commitSha: salvagedCommit,
+        commitSha: salvagedCommit.commitSha,
         commitCreated: true,
       }
     }
@@ -369,12 +420,22 @@ export async function runIssueRecovery(
       `fix(issue-recovery): salvage pending changes for issue #${issueNumber}`,
       config,
       logger,
+      issueContract.allowedFiles,
     )
-    if (salvagedCommit) {
+    if (salvagedCommit?.kind === 'blocked') {
+      return {
+        success: false,
+        exitCode: 1,
+        error: formatBlockedSalvageError(salvagedCommit.outOfScopeFiles),
+        commitCreated: false,
+      }
+    }
+
+    if (salvagedCommit?.kind === 'committed') {
       return {
         success: true,
         exitCode: 0,
-        commitSha: salvagedCommit,
+        commitSha: salvagedCommit.commitSha,
         commitCreated: true,
       }
     }
@@ -414,6 +475,7 @@ export async function runReviewAutoFix(
   const beforeHead = (await $`git -C ${worktreePath} rev-parse HEAD`.quiet().text()).trim()
   const linkedIssue = await getAgentIssueByNumber(issueNumber, config)
   const issueBody = linkedIssue?.body ?? ''
+  const issueContract = parseIssueContract(issueBody)
   const prompt = buildReviewAutoFixPrompt(
     issueNumber,
     prNumber,
@@ -440,16 +502,27 @@ export async function runReviewAutoFix(
       `fix(review-auto-fix): salvage pending changes for PR #${prNumber}`,
       config,
       logger,
+      issueContract.allowedFiles,
     )
-    if (salvagedCommit) {
-      logger.warn(`[review-fix] agent exited ${result.exitCode} but left recoverable changes — continuing with salvaged commit ${salvagedCommit.slice(0, 7)}`)
+    if (salvagedCommit?.kind === 'blocked') {
+      return {
+        success: false,
+        exitCode: result.exitCode,
+        outcome: 'agent_failed',
+        error: formatBlockedSalvageError(salvagedCommit.outOfScopeFiles),
+        failureKind: result.failureKind,
+      }
+    }
+
+    if (salvagedCommit?.kind === 'committed') {
+      logger.warn(`[review-fix] agent exited ${result.exitCode} but left recoverable changes — continuing with salvaged commit ${salvagedCommit.commitSha.slice(0, 7)}`)
       return finalizeReviewAutoFixResult(
         worktreePath,
         issueBody,
         config,
         logger,
         prNumber,
-        salvagedCommit,
+        salvagedCommit.commitSha,
         'salvaged',
       )
     }
@@ -470,16 +543,26 @@ export async function runReviewAutoFix(
       `fix(review-auto-fix): salvage pending changes for PR #${prNumber}`,
       config,
       logger,
+      issueContract.allowedFiles,
     )
-    if (salvagedCommit) {
-      logger.log(`[review-fix] salvaged commit ${salvagedCommit.slice(0, 7)} for PR #${prNumber}`)
+    if (salvagedCommit?.kind === 'blocked') {
+      return {
+        success: false,
+        exitCode: 1,
+        outcome: 'agent_failed',
+        error: formatBlockedSalvageError(salvagedCommit.outOfScopeFiles),
+      }
+    }
+
+    if (salvagedCommit?.kind === 'committed') {
+      logger.log(`[review-fix] salvaged commit ${salvagedCommit.commitSha.slice(0, 7)} for PR #${prNumber}`)
       return finalizeReviewAutoFixResult(
         worktreePath,
         issueBody,
         config,
         logger,
         prNumber,
-        salvagedCommit,
+        salvagedCommit.commitSha,
         'salvaged',
       )
     }
@@ -686,6 +769,26 @@ async function readChangedFilesAgainstDefaultBranch(
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
+}
+
+async function readDirtyWorktreeFiles(worktreePath: string): Promise<string[]> {
+  const raw = await $`git -C ${worktreePath} status --porcelain`.quiet().text()
+
+  return raw
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => line.slice(3).trim())
+    .map((path) => {
+      const renameSeparator = path.indexOf(' -> ')
+      return renameSeparator >= 0 ? path.slice(renameSeparator + 4) : path
+    })
+    .map((path) => path.replace(/^"(.*)"$/, '$1'))
+    .filter(Boolean)
+}
+
+function formatBlockedSalvageError(outOfScopeFiles: string[]): string {
+  return `dirty worktree contains files outside AllowedFiles: ${outOfScopeFiles.join(', ')}`
 }
 
 async function runValidationCommand(


### PR DESCRIPTION
## Summary
- make `salvageDirtyWorktree` scope-aware so dirty files outside `AllowedFiles` cannot be auto-committed
- return recoverable blocked failures during issue recovery and review auto-fix instead of creating contaminated salvage commits
- keep clean worktrees and in-scope salvage behavior unchanged

## Testing
- `bun --cwd apps/agent-daemon test src/subtask-executor.test.ts`
- `bun run --cwd apps/agent-daemon typecheck`

Closes #121.
