### PR TITLE
Fix #106: [AL-34] 引入 Sprint Contract 与 issue attempt artifact schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ This blocked failed issue has a matching manual resolution signal and may be ret
 ## Self-Hosting（用 Agent Loop 开发 Agent Loop）
 
 Issue body format is defined in [docs/issue-writing.md](docs/issue-writing.md).
+Issue harness roadmap notes live under [docs/roadmaps/README.md](docs/roadmaps/README.md).
+
+`Sprint Contract` 是 issue harness 在本地 worktree 里落下的派生 snapshot，默认路径是 `.agent-loop/sprint-contract.json`。它只复制这一轮 attempt 需要共享的最小执行 contract，用来让 planner / executor / recovery 对齐目标和验收；GitHub issue body 仍然是任务语义的权威来源，这份 artifact 不会写回远端，也不是新的远端 issue schema。
 
 Agent Loop 用自己的 Issues 管理自己的开发任务：
 

--- a/apps/agent-daemon/src/sprint-contract.test.ts
+++ b/apps/agent-daemon/src/sprint-contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { SprintContract } from '../../../packages/agent-shared/src/types'
+import {
+  buildSprintContract,
+  readSprintContract,
+  resolveSprintContractPath,
+  serializeSprintContract,
+  writeSprintContract,
+} from './sprint-contract'
+
+describe('SprintContract artifacts', () => {
+  test('round-trips a sprint contract through worktree-local artifact storage', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'agent-loop-sprint-contract-'))
+
+    try {
+      const contract = buildSprintContract({
+        issueNumber: 34,
+        issueTitle: '[AL-34] sprint contract',
+        attemptKind: 'fresh-claim',
+        objective: 'Introduce a durable attempt contract before the first writable run',
+        allowedFiles: ['apps/agent-daemon/src/sprint-contract.ts'],
+        requiredSemantics: ['issue body remains the source of truth'],
+        validationCommands: ['bun test apps/agent-daemon/src/sprint-contract.test.ts'],
+        plannedSteps: ['add artifact helpers', 'add round-trip coverage'],
+      })
+
+      await writeSprintContract(worktreePath, contract)
+
+      expect(await readSprintContract(worktreePath)).toEqual(contract)
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true })
+    }
+  })
+
+  test('returns null when the worktree-local sprint contract artifact is missing', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'agent-loop-sprint-contract-missing-'))
+
+    try {
+      expect(await readSprintContract(worktreePath)).toBeNull()
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true })
+    }
+  })
+
+  test('serializes sprint contracts deterministically with fixed key order and empty lists', () => {
+    const contract = buildSprintContract({
+      issueNumber: 106,
+      issueTitle: '[AL-34] 引入 Sprint Contract',
+      attemptKind: 'issue-recovery',
+      objective: 'Recover the smallest in-scope changes for the sprint contract artifact',
+      allowedFiles: [],
+      requiredSemantics: [],
+      validationCommands: [],
+      plannedSteps: [],
+      createdAt: '2026-04-15T00:00:00.000Z',
+    })
+
+    const reordered: SprintContract = {
+      plannedSteps: [],
+      validationCommands: [],
+      requiredSemantics: [],
+      allowedFiles: [],
+      objective: 'Recover the smallest in-scope changes for the sprint contract artifact',
+      attemptKind: 'issue-recovery',
+      issueTitle: '[AL-34] 引入 Sprint Contract',
+      issueNumber: 106,
+      artifactVersion: 1,
+      createdAt: '2026-04-15T00:00:00.000Z',
+    }
+
+    expect(serializeSprintContract(reordered)).toBe(serializeSprintContract(contract))
+    expect(serializeSprintContract(contract)).toBe(`{
+  "artifactVersion": 1,
+  "issueNumber": 106,
+  "issueTitle": "[AL-34] 引入 Sprint Contract",
+  "attemptKind": "issue-recovery",
+  "objective": "Recover the smallest in-scope changes for the sprint contract artifact",
+  "allowedFiles": [],
+  "requiredSemantics": [],
+  "validationCommands": [],
+  "plannedSteps": [],
+  "createdAt": "2026-04-15T00:00:00.000Z"
+}
+`)
+  })
+
+  test('returns null for malformed sprint contract artifacts instead of crashing recovery', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'agent-loop-sprint-contract-malformed-'))
+
+    try {
+      mkdirSync(join(worktreePath, '.agent-loop'), { recursive: true })
+      writeFileSync(resolveSprintContractPath(worktreePath), '{"artifactVersion":999}', 'utf-8')
+
+      expect(await readSprintContract(worktreePath)).toBeNull()
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/agent-daemon/src/sprint-contract.test.ts
+++ b/apps/agent-daemon/src/sprint-contract.test.ts
@@ -99,4 +99,63 @@ describe('SprintContract artifacts', () => {
       rmSync(worktreePath, { recursive: true, force: true })
     }
   })
+
+  test('returns null when required list fields are not arrays of non-empty strings', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'agent-loop-sprint-contract-invalid-lists-'))
+
+    const invalidArtifacts = [
+      {
+        artifactVersion: 1,
+        issueNumber: 106,
+        issueTitle: '[AL-34] 引入 Sprint Contract',
+        attemptKind: 'review-auto-fix',
+        objective: 'Reject corrupted allowedFiles data',
+        allowedFiles: 'README.md',
+        requiredSemantics: ['issue body remains the source of truth'],
+        validationCommands: ['bun test apps/agent-daemon/src/sprint-contract.test.ts'],
+        plannedSteps: ['repair artifact parsing'],
+        createdAt: '2026-04-15T00:00:00.000Z',
+      },
+      {
+        artifactVersion: 1,
+        issueNumber: 106,
+        issueTitle: '[AL-34] 引入 Sprint Contract',
+        attemptKind: 'review-auto-fix',
+        objective: 'Reject corrupted validationCommands data',
+        allowedFiles: ['apps/agent-daemon/src/sprint-contract.ts'],
+        requiredSemantics: ['issue body remains the source of truth'],
+        validationCommands: null,
+        plannedSteps: ['repair artifact parsing'],
+        createdAt: '2026-04-15T00:00:00.000Z',
+      },
+      {
+        artifactVersion: 1,
+        issueNumber: 106,
+        issueTitle: '[AL-34] 引入 Sprint Contract',
+        attemptKind: 'review-auto-fix',
+        objective: 'Reject mixed-type list entries',
+        allowedFiles: ['apps/agent-daemon/src/sprint-contract.ts', 42],
+        requiredSemantics: ['issue body remains the source of truth'],
+        validationCommands: ['bun test apps/agent-daemon/src/sprint-contract.test.ts'],
+        plannedSteps: ['repair artifact parsing'],
+        createdAt: '2026-04-15T00:00:00.000Z',
+      },
+    ]
+
+    try {
+      mkdirSync(join(worktreePath, '.agent-loop'), { recursive: true })
+
+      for (const artifact of invalidArtifacts) {
+        writeFileSync(
+          resolveSprintContractPath(worktreePath),
+          `${JSON.stringify(artifact, null, 2)}\n`,
+          'utf-8',
+        )
+
+        expect(await readSprintContract(worktreePath)).toBeNull()
+      }
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true })
+    }
+  })
 })

--- a/apps/agent-daemon/src/sprint-contract.ts
+++ b/apps/agent-daemon/src/sprint-contract.ts
@@ -1,0 +1,165 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  SPRINT_ATTEMPT_KINDS,
+  SPRINT_CONTRACT_ARTIFACT_VERSION,
+  type SprintAttemptKind,
+  type SprintContract,
+} from '../../../packages/agent-shared/src/types'
+
+const SPRINT_CONTRACT_DIRECTORY = '.agent-loop'
+const SPRINT_CONTRACT_FILENAME = 'sprint-contract.json'
+const SPRINT_ATTEMPT_KIND_SET = new Set<SprintAttemptKind>(SPRINT_ATTEMPT_KINDS)
+
+export interface BuildSprintContractInput {
+  issueNumber: number
+  issueTitle: string
+  attemptKind: SprintAttemptKind
+  objective: string
+  allowedFiles: string[]
+  requiredSemantics: string[]
+  validationCommands: string[]
+  plannedSteps: string[]
+  createdAt?: string
+}
+
+export function resolveSprintContractPath(worktreePath: string): string {
+  return join(worktreePath, SPRINT_CONTRACT_DIRECTORY, SPRINT_CONTRACT_FILENAME)
+}
+
+export function buildSprintContract(input: BuildSprintContractInput): SprintContract {
+  return normalizeSprintContractRecord({
+    artifactVersion: SPRINT_CONTRACT_ARTIFACT_VERSION,
+    issueNumber: input.issueNumber,
+    issueTitle: input.issueTitle,
+    attemptKind: input.attemptKind,
+    objective: input.objective,
+    allowedFiles: input.allowedFiles,
+    requiredSemantics: input.requiredSemantics,
+    validationCommands: input.validationCommands,
+    plannedSteps: input.plannedSteps,
+    createdAt: input.createdAt ?? new Date().toISOString(),
+  })
+}
+
+export function serializeSprintContract(contract: SprintContract): string {
+  return `${JSON.stringify(normalizeSprintContractRecord(contract), null, 2)}\n`
+}
+
+export async function writeSprintContract(
+  worktreePath: string,
+  contract: SprintContract,
+): Promise<SprintContract> {
+  const normalized = normalizeSprintContractRecord(contract)
+  const artifactPath = resolveSprintContractPath(worktreePath)
+
+  await mkdir(join(worktreePath, SPRINT_CONTRACT_DIRECTORY), { recursive: true })
+  await writeFile(artifactPath, serializeSprintContract(normalized), 'utf-8')
+
+  return normalized
+}
+
+export async function readSprintContract(worktreePath: string): Promise<SprintContract | null> {
+  try {
+    const artifact = await readFile(resolveSprintContractPath(worktreePath), 'utf-8')
+    return parseSprintContract(artifact)
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return null
+    }
+
+    throw error
+  }
+}
+
+function parseSprintContract(content: string): SprintContract | null {
+  try {
+    return normalizeSprintContractRecord(JSON.parse(content))
+  } catch {
+    return null
+  }
+}
+
+function normalizeSprintContractRecord(value: unknown): SprintContract {
+  const record = value as Partial<Record<keyof SprintContract, unknown>>
+  const attemptKind = normalizeAttemptKind(record.attemptKind)
+
+  if (!attemptKind) {
+    throw new Error('Invalid sprint contract attempt kind')
+  }
+
+  const createdAt = normalizeTimestamp(record.createdAt)
+  if (!createdAt) {
+    throw new Error('Invalid sprint contract createdAt timestamp')
+  }
+
+  return {
+    artifactVersion: normalizeArtifactVersion(record.artifactVersion),
+    issueNumber: normalizeIssueNumber(record.issueNumber),
+    issueTitle: normalizeRequiredString(record.issueTitle, 'issueTitle'),
+    attemptKind,
+    objective: normalizeRequiredString(record.objective, 'objective'),
+    allowedFiles: normalizeStringList(record.allowedFiles),
+    requiredSemantics: normalizeStringList(record.requiredSemantics),
+    validationCommands: normalizeStringList(record.validationCommands),
+    plannedSteps: normalizeStringList(record.plannedSteps),
+    createdAt,
+  }
+}
+
+function normalizeArtifactVersion(value: unknown): typeof SPRINT_CONTRACT_ARTIFACT_VERSION {
+  if (value !== SPRINT_CONTRACT_ARTIFACT_VERSION) {
+    throw new Error('Unsupported sprint contract artifactVersion')
+  }
+
+  return SPRINT_CONTRACT_ARTIFACT_VERSION
+}
+
+function normalizeIssueNumber(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new Error('Invalid sprint contract issueNumber')
+  }
+
+  return value
+}
+
+function normalizeAttemptKind(value: unknown): SprintAttemptKind | null {
+  return typeof value === 'string' && SPRINT_ATTEMPT_KIND_SET.has(value as SprintAttemptKind)
+    ? value as SprintAttemptKind
+    : null
+}
+
+function normalizeRequiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Invalid sprint contract ${field}`)
+  }
+
+  return value.trim()
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0)
+}
+
+function normalizeTimestamp(value: unknown): string | null {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return null
+  }
+
+  const timestamp = value.trim()
+  return Number.isFinite(Date.parse(timestamp)) ? timestamp : null
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && error.code === 'ENOENT'
+}

--- a/apps/agent-daemon/src/sprint-contract.ts
+++ b/apps/agent-daemon/src/sprint-contract.ts
@@ -99,10 +99,10 @@ function normalizeSprintContractRecord(value: unknown): SprintContract {
     issueTitle: normalizeRequiredString(record.issueTitle, 'issueTitle'),
     attemptKind,
     objective: normalizeRequiredString(record.objective, 'objective'),
-    allowedFiles: normalizeStringList(record.allowedFiles),
-    requiredSemantics: normalizeStringList(record.requiredSemantics),
-    validationCommands: normalizeStringList(record.validationCommands),
-    plannedSteps: normalizeStringList(record.plannedSteps),
+    allowedFiles: normalizeStringList(record.allowedFiles, 'allowedFiles'),
+    requiredSemantics: normalizeStringList(record.requiredSemantics, 'requiredSemantics'),
+    validationCommands: normalizeStringList(record.validationCommands, 'validationCommands'),
+    plannedSteps: normalizeStringList(record.plannedSteps, 'plannedSteps'),
     createdAt,
   }
 }
@@ -137,15 +137,23 @@ function normalizeRequiredString(value: unknown, field: string): string {
   return value.trim()
 }
 
-function normalizeStringList(value: unknown): string[] {
+function normalizeStringList(value: unknown, field: string): string[] {
   if (!Array.isArray(value)) {
-    return []
+    throw new Error(`Invalid sprint contract ${field}`)
   }
 
-  return value
-    .filter((entry): entry is string => typeof entry === 'string')
-    .map(entry => entry.trim())
-    .filter(entry => entry.length > 0)
+  return value.map((entry) => {
+    if (typeof entry !== 'string') {
+      throw new Error(`Invalid sprint contract ${field}`)
+    }
+
+    const normalized = entry.trim()
+    if (normalized.length === 0) {
+      throw new Error(`Invalid sprint contract ${field}`)
+    }
+
+    return normalized
+  })
 }
 
 function normalizeTimestamp(value: unknown): string | null {

--- a/docs/roadmaps/README.md
+++ b/docs/roadmaps/README.md
@@ -1,0 +1,9 @@
+# Roadmaps
+
+这些 roadmap 记录 issue harness 的本地演进切片，不重新定义 GitHub 上的 issue schema。
+
+## Issue Harness
+
+- [Issue Harness Phase 1](./issue-harness-phase-1/README.md)
+
+`Sprint Contract` 属于 issue harness 的本地 durable artifact：它从 issue body 派生，服务于单次 attempt 的 planner / executor / evaluator / recovery 协作，不替代远端 issue body，也不会把本地 contract 回写到 GitHub。

--- a/docs/roadmaps/issue-harness-phase-1/README.md
+++ b/docs/roadmaps/issue-harness-phase-1/README.md
@@ -1,0 +1,30 @@
+# Issue Harness Phase 1
+
+Phase 1 先建立 issue attempt 的本地 durable contract，不在这一阶段接入 planner、executor 或 daemon 主流程。
+
+## Sprint Contract
+
+`Sprint Contract` 是 worktree 内 `.agent-loop/sprint-contract.json` 的本地 artifact。它由当前 issue body 派生，保存这一轮 attempt 最小但可执行的 contract：
+
+- `artifactVersion`
+- `issueNumber`
+- `issueTitle`
+- `attemptKind`
+- `objective`
+- `allowedFiles`
+- `requiredSemantics`
+- `validationCommands`
+- `plannedSteps`
+- `createdAt`
+
+首批 `attemptKind` vocabulary 固定为：
+
+- `fresh-claim`
+- `issue-recovery`
+- `review-auto-fix`
+
+## Scope Boundary
+
+- GitHub issue body 仍然是任务语义的权威来源
+- `Sprint Contract` 只是在本地落盘的派生 snapshot，不是新的远端 issue schema
+- 缺少本地 artifact 时，后续流程应该返回 `null` 或 empty state，而不是把 daemon 直接打崩

--- a/packages/agent-shared/src/types.ts
+++ b/packages/agent-shared/src/types.ts
@@ -93,6 +93,29 @@ export interface IssueDependencyMetadata {
   dependencyParseError: boolean
 }
 
+export const SPRINT_CONTRACT_ARTIFACT_VERSION = 1 as const
+
+export const SPRINT_ATTEMPT_KINDS = [
+  'fresh-claim',
+  'issue-recovery',
+  'review-auto-fix',
+] as const
+
+export type SprintAttemptKind = (typeof SPRINT_ATTEMPT_KINDS)[number]
+
+export interface SprintContract {
+  artifactVersion: typeof SPRINT_CONTRACT_ARTIFACT_VERSION
+  issueNumber: number
+  issueTitle: string
+  attemptKind: SprintAttemptKind
+  objective: string
+  allowedFiles: string[]
+  requiredSemantics: string[]
+  validationCommands: string[]
+  plannedSteps: string[]
+  createdAt: string
+}
+
 export type ProjectProfileName =
   | 'generic'
   | 'desktop-vite'


### PR DESCRIPTION
## Summary

Fixes #106

<!-- agent-loop:pr-lineage {"version":1,"issue":106,"headBranch":"agent/106/codex-dev","baseBranch":"master","baseSha":"c81980f0aad38a9c7cc689e3ec990f7369892a18","attempt":1,"fingerprint":"74fc12fad672d9ad321e0aa73d37bee647c2904c78a60d9f9137f395c51e70c4"} -->

## Metadata

```json
{
  "issue": 106,
  "machine": "codex-dev",
  "generated_by": "agent-loop"
}
```

## Test Plan

- [ ] tested locally
- [ ] CI passes